### PR TITLE
Moved PRT_STEP_UNHANDLED logging code above error handler.

### DIFF
--- a/Src/Prt/Core/PrtExecution.c
+++ b/Src/Prt/Core/PrtExecution.c
@@ -590,6 +590,16 @@ _In_ PRT_BOOLEAN				isPopStatement
 	packSize = PrtGetPackSize(context);
 	length = context->callStack.length;
 
+	if (isPopStatement)
+	{
+		PrtLog(PRT_STEP_POP, context);
+	}
+	else
+	{
+		// unhandled event
+		PrtLog(PRT_STEP_UNHANDLED, context);
+	}
+
 	if (length == 0)
 	{
 		if (PrtPrimGetEvent(PrtGetCurrentTrigger(context)) == PRT_SPECIAL_EVENT_HALT)
@@ -617,16 +627,6 @@ _In_ PRT_BOOLEAN				isPopStatement
 
 	PrtUpdateCurrentActionsSet(context);
 	PrtUpdateCurrentDeferredSet(context);
-
-	if (isPopStatement)
-	{
-		PrtLog(PRT_STEP_POP, context);
-	}
-	else
-	{
-		// unhandled event
-		PrtLog(PRT_STEP_UNHANDLED, context);
-	}
 }
 
 FORCEINLINE


### PR DESCRIPTION
Is this OK? 

The log used to read:

```
<CreateLog> Machine ArtifactManagerMachine(1) is created
<StateLog> Machine ArtifactManagerMachine(1) entered state Init
<EnqueueLog> Enqueued event ArtifactManagerInit with payload (< (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>) on Machine ArtifactManagerMachine(1)
<DequeueLog> Dequeued event ArtifactManagerInit with payload (< (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>) by Machine ArtifactManagerMachine(1)
<ExitLog> Machine ArtifactManagerMachine(1) exiting state Init
<StateLog> Machine ArtifactManagerMachine(1) entered state Initialize
<EnqueueLog> Enqueued event UpdateArtifactManager with payload ((false, false, 0, 0, false, false, false, 0, 0, false, 0, 0, 0, 0, 0, false, false, 0, 0, false, 0, false, false, 0), < (0, 0, 0, 0), 0>, [], []) on Machine ArtifactManagerMachine(1)
<DequeueLog> Dequeued event UpdateArtifactManager with payload ((false, false, 0, 0, false, false, false, 0, 0, false, 0, 0, 0, 0, 0, false, false, 0, 0, false, 0, false, false, 0), < (0, 0, 0, 0), 0>, [], []) by Machine ArtifactManagerMachine(1)
<ExitLog> Machine ArtifactManagerMachine(1) exiting state Initialize
Assertion failed: false && "Exception handler.", file d:\temp\pcrash\pmaster\src\prtdist\samples\nodeservicetest\nodeservicetest.cpp, line 98
```

Now it reads:

```
<CreateLog> Machine ArtifactManagerMachine(1) is created
<StateLog> Machine ArtifactManagerMachine(1) entered state Init
<EnqueueLog> Enqueued event ArtifactManagerInit with payload (< (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>) on Machine ArtifactManagerMachine(1)
<DequeueLog> Dequeued event ArtifactManagerInit with payload (< (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>, < (0, 0, 0, 0), 0>) by Machine ArtifactManagerMachine(1)
<ExitLog> Machine ArtifactManagerMachine(1) exiting state Init
<StateLog> Machine ArtifactManagerMachine(1) entered state Initialize
<EnqueueLog> Enqueued event UpdateArtifactManager with payload ((false, false, 0, 0, false, false, false, 0, 0, false, 0, 0, 0, 0, 0, false, false, 0, 0, false, 0, false, false, 0), < (0, 0, 0, 0), 0>, [], []) on Machine ArtifactManagerMachine(1)
<DequeueLog> Dequeued event UpdateArtifactManager with payload ((false, false, 0, 0, false, false, false, 0, 0, false, 0, 0, 0, 0, 0, false, false, 0, 0, false, 0, false, false, 0), < (0, 0, 0, 0), 0>, [], []) by Machine ArtifactManagerMachine(1)
<ExitLog> Machine ArtifactManagerMachine(1) exiting state Initialize
<PopLog> Machine ArtifactManagerMachine(1) popped with unhandled event UpdateArtifactManager and reentered state Initialize
Assertion failed: false && "Exception handler.", file d:\temp\pcrash\pmaster\src\prtdist\samples\nodeservicetest\nodeservicetest.cpp, line 98
```