### PR TITLE
Fix a couple of issues with PingPong sample.

### DIFF
--- a/Src/PrtDist/Samples/PingPong/MainFunction.c
+++ b/Src/PrtDist/Samples/PingPong/MainFunction.c
@@ -25,11 +25,19 @@ char* GetApplicationName()
 {
     char* last = strrchr(FirstArgument, '/');
     char* last2 = strrchr(FirstArgument, '\\');
-    if (last2 > last)
+
+    if (last != NULL)
     {
-        last = last2;
+        return last + 1;
     }
-    return last + 1;
+    else if (last2 != NULL)
+    {
+        return last2 + 1;
+    }
+    else
+    {
+        return FirstArgument;
+    }
 }
 
 void PrintUsage() {

--- a/Src/PrtDist/Samples/PingPong/PingPong.vcxproj
+++ b/Src/PrtDist/Samples/PingPong/PingPong.vcxproj
@@ -78,12 +78,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(PSdkFolder)\Samples\PingPongFast\</OutDir>
+    <OutDir>$(PSdkFolder)\Samples\PingPong\</OutDir>
     <IntDir>$(ProjectDir)$(Configuration)\obj\$(Platform)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(PSdkFolder)\Samples\PingPongFast\</OutDir>
+    <OutDir>$(PSdkFolder)\Samples\PingPong\</OutDir>
     <IntDir>$(ProjectDir)$(Configuration)\obj\$(Platform)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
- PingPong.exe crashes when run as "PingPong.exe" without a / or \ in the
path.
- PingPong.exe was getting copied to PingPongFast instead of PingPong
directory.