### PR TITLE
push $SCRIPTPATH before building runtime

### DIFF
--- a/Bld/build.sh
+++ b/Bld/build.sh
@@ -75,6 +75,8 @@ xbuild PLinux.sln /p:Platform=$Platform /p:Configuration=$Configuration
 
 popd
 
+pushd $SCRIPTPATH
 mkdir -p build; cd build; cmake ../../Src; make
+popd
 
 


### PR DESCRIPTION
This makes the build script executable from outside the Bld dir. It was
the only part of the build that didn't have this property and there is
no real reason not to have it.