### PR TITLE
Add short-circuiting behavior for boolean operators `&&` and `||`

### DIFF
--- a/Src/Pc/CompilerCore/Backend/IRTransformer.cs
+++ b/Src/Pc/CompilerCore/Backend/IRTransformer.cs
@@ -93,6 +93,7 @@ namespace Plang.Compiler.Backend
                         // And is short-circuiting, so we need to treat it differently from other binary operators
                         deps.AddRange(lhsDeps);
                         var (andTemp, andInitialStore) = SaveInTemporary(lhsTemp);
+                        deps.Add(andInitialStore);
                         var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, andTemp, rhsTemp)));
                         deps.Add(new IfStmt(location, andTemp, reassignFromRhs, null));
                         return (andTemp, deps);
@@ -102,8 +103,9 @@ namespace Plang.Compiler.Backend
                         // Or is short-circuiting, so we need to treat it differently from other binary operators
                         deps.AddRange(lhsDeps);
                         var (orTemp, orInitialStore) = SaveInTemporary(lhsTemp);
+                        deps.Add(orInitialStore);
                         var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, orTemp, rhsTemp)));
-                        deps.Add(new IfStmt(location, orTemp, new NoStmt(), reassignFromRhs));
+                        deps.Add(new IfStmt(location, orTemp, new NoStmt(location), reassignFromRhs));
                         return (orTemp, deps);
                     }
                     else

--- a/Src/Pc/CompilerCore/Backend/IRTransformer.cs
+++ b/Src/Pc/CompilerCore/Backend/IRTransformer.cs
@@ -87,11 +87,34 @@ namespace Plang.Compiler.Backend
                 case BinOpExpr binOpExpr:
                     var (lhsTemp, lhsDeps) = SimplifyExpression(binOpExpr.Lhs);
                     var (rhsTemp, rhsDeps) = SimplifyExpression(binOpExpr.Rhs);
-                    var (binOpTemp, binOpStore) =
-                        SaveInTemporary(new BinOpExpr(location, binOpExpr.Operation, lhsTemp, rhsTemp));
-                    deps.AddRange(lhsDeps.Concat(rhsDeps));
-                    deps.Add(binOpStore);
-                    return (binOpTemp, deps);
+
+                    if (binOpExpr.Operation == BinOpType.And)
+                    {
+                        // And is short-circuiting, so we need to treat it differently from other binary operators
+                        deps.AddRange(lhsDeps);
+                        var (andTemp, andInitialStore) = SaveInTemporary(lhsTemp);
+                        var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, andTemp, rhsTemp)));
+                        deps.Add(new IfStmt(location, andTemp, reassignFromRhs, null));
+                        return (andTemp, deps);
+                    }
+                    else if (binOpExpr.Operation == BinOpType.Or)
+                    {
+                        // Or is short-circuiting, so we need to treat it differently from other binary operators
+                        deps.AddRange(lhsDeps);
+                        var (orTemp, orInitialStore) = SaveInTemporary(lhsTemp);
+                        var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, orTemp, rhsTemp)));
+                        deps.Add(new IfStmt(location, orTemp, new NoStmt(), reassignFromRhs));
+                        return (orTemp, deps);
+                    }
+                    else
+                    {
+                        var (binOpTemp, binOpStore) =
+                            SaveInTemporary(new BinOpExpr(location, binOpExpr.Operation, lhsTemp, rhsTemp));
+                        deps.AddRange(lhsDeps.Concat(rhsDeps));
+                        deps.Add(binOpStore);
+                        return (binOpTemp, deps);
+                    }
+
                 case CastExpr castExpr:
                     var (castSubExpr, castDeps) = SimplifyExpression(castExpr.SubExpr);
                     var (castTemp, castStore) = SaveInTemporary(new CastExpr(location, castSubExpr, castExpr.Type));

--- a/Src/Pc/CompilerCore/Backend/IRTransformer.cs
+++ b/Src/Pc/CompilerCore/Backend/IRTransformer.cs
@@ -92,9 +92,9 @@ namespace Plang.Compiler.Backend
                     {
                         // And is short-circuiting, so we need to treat it differently from other binary operators
                         deps.AddRange(lhsDeps);
-                        var (andTemp, andInitialStore) = SaveInTemporary(lhsTemp);
+                        var (andTemp, andInitialStore) = SaveInTemporary(new CloneExpr(lhsTemp));
                         deps.Add(andInitialStore);
-                        var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, andTemp, rhsTemp)));
+                        var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, andTemp, new CloneExpr(rhsTemp))));
                         deps.Add(new IfStmt(location, andTemp, reassignFromRhs, null));
                         return (andTemp, deps);
                     }
@@ -102,9 +102,9 @@ namespace Plang.Compiler.Backend
                     {
                         // Or is short-circuiting, so we need to treat it differently from other binary operators
                         deps.AddRange(lhsDeps);
-                        var (orTemp, orInitialStore) = SaveInTemporary(lhsTemp);
+                        var (orTemp, orInitialStore) = SaveInTemporary(new CloneExpr(lhsTemp));
                         deps.Add(orInitialStore);
-                        var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, orTemp, rhsTemp)));
+                        var reassignFromRhs = new CompoundStmt(location, rhsDeps.Append(new AssignStmt(location, orTemp, new CloneExpr(rhsTemp))));
                         deps.Add(new IfStmt(location, orTemp, new NoStmt(location), reassignFromRhs));
                         return (orTemp, deps);
                     }

--- a/Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval/ShortCircuitEval.p
+++ b/Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval/ShortCircuitEval.p
@@ -40,11 +40,8 @@ machine Main {
 		  s -= (1);                 
 		  assert (sizeof(s) == 1);   //holds
 		  
-                  // P does not support short-circuit evaulation in conditional expressions.
-                  // If we start supporting it later, we should uncomment the following two 
-                  // lines to create a suitable XYZ case for it.
-		  // if (false && (s[1] == 1)) {;};  
-		  // if (true || (s[1] == 1)) {;};   
+		  if (false && (s[1] == 1)) {;};  
+		  if (true || (s[1] == 1)) {;};   
 
 		  raise halt;
        }    


### PR DESCRIPTION
This change modifies the IR transformer to transform`&&` and `||` into code which uses `if` statements to implement short-circuiting behavior.  It turns out the test suite already contained a regression test to check the short-circuiting behavior of boolean operators, but the code to test it was intentionally commented out until the feature was implemented.  Rather than create a new regression test, I uncommented the code in this existing test.