### PR TITLE
set type followup fix

### DIFF
--- a/Src/Prt/Core/PrtValues.c
+++ b/Src/Prt/Core/PrtValues.c
@@ -1904,6 +1904,8 @@ PRT_BOOLEAN PRT_CALL_CONV PrtInhabitsType(_In_ PRT_VALUE* value, _In_ PRT_TYPE* 
 
 			next = next->insertNext;
 		}
+
+		return PRT_TRUE;
 	}
 
 	case PRT_KIND_SET:


### PR DESCRIPTION
The previous merge for set datatype broke some tests and was found to have clipped a return statement. This followup fixes the mistake.