### PR TITLE
Upgrade to coyote rc6

### DIFF
--- a/Src/CoyoteRuntime/CoyoteRuntime.csproj
+++ b/Src/CoyoteRuntime/CoyoteRuntime.csproj
@@ -5,7 +5,7 @@
     <OutputPath>$(PSdkFolder)\$(TargetFramework)\Binaries</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc5" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc6" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/Src/CoyoteRuntime/GodMachine.cs
+++ b/Src/CoyoteRuntime/GodMachine.cs
@@ -6,9 +6,9 @@ namespace Plang.PrtSharp
 {
     public class _GodMachine : StateMachine
     {
-        private void InitOnEntry()
+        private void InitOnEntry(Event e)
         {
-            Type mainMachine = (ReceivedEvent as Config).MainMachine;
+            Type mainMachine = (e as Config).MainMachine;
             CreateActor(mainMachine,
                 new PMachine.InitializeParametersEvent(
                     new PMachine.InitializeParameters("I_" + mainMachine.Name, null)));

--- a/Src/CoyoteRuntime/PMonitor.cs
+++ b/Src/CoyoteRuntime/PMonitor.cs
@@ -25,7 +25,7 @@ namespace Plang.PrtSharp
         public void TryGotoState<T>(object payload = null) where T : State
         {
             gotoPayload = payload;
-            base.Goto<T>();
+            base.GotoState<T>();
             throw new PNonStandardReturnException { ReturnKind = NonStandardReturn.Goto };
         }
 

--- a/Src/Pc/CompilerCore/Backend/Coyote/CoyoteCodeGenerator.cs
+++ b/Src/Pc/CompilerCore/Backend/Coyote/CoyoteCodeGenerator.cs
@@ -572,7 +572,11 @@ namespace Plang.Compiler.Backend.Coyote
 
             string functionName = context.Names.GetNameForDecl(function);
             string functionParameters = "";
-            if (!function.IsAnon)
+            if (function.IsAnon)
+            {
+                functionParameters = "Event currentMachine_dequeuedEvent";
+            }
+            else
             {
                 functionParameters = string.Join(
                     ", ",
@@ -612,7 +616,7 @@ namespace Plang.Compiler.Backend.Coyote
                 {
                     Variable param = function.Signature.Parameters.First();
                     context.WriteLine(output,
-                        $"{GetCSharpType(param.Type)} {context.Names.GetNameForDecl(param)} = ({GetCSharpType(param.Type)})(gotoPayload ?? ((PEvent)currentMachine.ReceivedEvent).Payload);");
+                        $"{GetCSharpType(param.Type)} {context.Names.GetNameForDecl(param)} = ({GetCSharpType(param.Type)})(gotoPayload ?? ((PEvent)currentMachine_dequeuedEvent).Payload);");
                     context.WriteLine(output, "this.gotoPayload = null;");
                 }
             }
@@ -1220,7 +1224,7 @@ namespace Plang.Compiler.Backend.Coyote
                             break;
 
                         case "DefaultEvent":
-                            context.Write(output, "new DefaultEvent()");
+                            context.Write(output, "DefaultEvent.Instance");
                             break;
 
                         default:

--- a/Src/Samples/PingPongCoyote/Main.cs
+++ b/Src/Samples/PingPongCoyote/Main.cs
@@ -174,10 +174,10 @@ namespace pingpong
             PONG currentMachine = this;
         }
 
-        public void Anon_3()
+        public void Anon_3(Event currentMachine_dequeuedEvent)
         {
             PONG currentMachine = this;
-            PMachineValue payload = (PMachineValue)(gotoPayload ?? ((PEvent)currentMachine.ReceivedEvent).Payload);
+            PMachineValue payload = (PMachineValue)(gotoPayload ?? ((PEvent)currentMachine_dequeuedEvent).Payload);
             gotoPayload = null;
             PMachineValue TMP_tmp0_2 = null;
             PEvent TMP_tmp1_2 = null;

--- a/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
+++ b/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc5" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Samples/TwoPhaseCommit/TwoPhaseCommit.csproj
+++ b/Src/Samples/TwoPhaseCommit/TwoPhaseCommit.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc5" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc6" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Main.cs" />

--- a/Tst/UnitTests/Runners/CoyoteRunner.cs
+++ b/Tst/UnitTests/Runners/CoyoteRunner.cs
@@ -113,7 +113,7 @@ namespace Main
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.Coyote"" Version=""1.0.0-rc5""/>
+    <PackageReference Include=""Microsoft.Coyote"" Version=""1.0.0-rc6""/>
     <Reference Include = ""CoyoteRuntime.dll""/>
   </ItemGroup>
 </Project>";

--- a/Tst/UnitTests/UnitTests.csproj
+++ b/Tst/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc5" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc6" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Tutorial/Failover/FailOver.cs
+++ b/Tutorial/Failover/FailOver.cs
@@ -148,10 +148,10 @@ namespace FailOver
             this.receives.Add(nameof(PHalt));
         }
         
-        public async Task Anon_1()
+        public async Task Anon_1(Event currentMachine_dequeuedEvent)
         {
             FaultTolerantMachine currentMachine = this;
-            PrtTuple<PMachineValue, PMachineValue> arg = ((PEvent<PrtTuple<PMachineValue, PMachineValue>>)currentMachine.ReceivedEvent).PayloadT;
+            PrtTuple<PMachineValue, PMachineValue> arg = ((PEvent<PrtTuple<PMachineValue, PMachineValue>>)currentMachine_dequeuedEvent).PayloadT;
             PMachineValue TMP_tmp0_1 = null;
             PMachineValue TMP_tmp1_1 = null;
             PMachineValue TMP_tmp2_1 = null;
@@ -352,10 +352,10 @@ namespace FailOver
             ReliableStorageMachine currentMachine = this;
             s_1 = ((PrtInt)(long)MyState.State0);
         }
-        public void Anon_7()
+        public void Anon_7(Event currentMachine_dequeuedEvent)
         {
             ReliableStorageMachine currentMachine = this;
-            PMachineValue m_1 = ((PEvent<PMachineValue>)currentMachine.ReceivedEvent).PayloadT;
+            PMachineValue m_1 = ((PEvent<PMachineValue>)currentMachine_dequeuedEvent).PayloadT;
             PMachineValue TMP_tmp0_7 = null;
             IEventWithPayload TMP_tmp1_6 = null;
             MyState TMP_tmp2_6 = (MyState)(0);

--- a/Tutorial/Hello/Hello.cs
+++ b/Tutorial/Hello/Hello.cs
@@ -80,10 +80,10 @@ namespace Hello
             this.receives.Add(nameof(START));
         }
         
-        public void Anon()
+        public void Anon(Event currentMachine_dequeuedEvent)
         {
             Timer currentMachine = this;
-            PMachineValue payload = (PMachineValue)(gotoPayload ?? ((PEvent)currentMachine.ReceivedEvent).Payload);
+            PMachineValue payload = (PMachineValue)(gotoPayload ?? ((PEvent)currentMachine_dequeuedEvent).Payload);
             this.gotoPayload = null;
             client = (PMachineValue)(((PMachineValue)((IPrtValue)payload)?.Clone()));
             currentMachine.GotoState<Timer.WaitForReq>();


### PR DESCRIPTION
Hey @ankushdesai, this PR upgrades P to the latest Coyote (`rc6`), which includes passing events as the in-parameter to an event-handler to improve programmability (rather than using the `ReceivedEvent` property, which has now been removed).