### PR TITLE
Update PLogFormatter to new IActorRuntimeLog.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,7 +233,7 @@ stubs.c
 
 Src/PrtDist/Binaries/clusterconfiguration.xml
 *.idb
-/Ext/PsTools
+/Ext
 /Src/Prt/Samples/ForeignTypes/Tester.ipdb
 /Src/Prt/Samples/ForeignTypes/Tester.iobj
 /Src/Prt/Samples/ForeignTypes/Tester.exe

--- a/Src/CoyoteRuntime/CoyoteRuntime.csproj
+++ b/Src/CoyoteRuntime/CoyoteRuntime.csproj
@@ -5,7 +5,7 @@
     <OutputPath>D:\Workspace\P\Bld\Drops\Debug\Binaries</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc7" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/Src/CoyoteRuntime/PLogFormatter.cs
+++ b/Src/CoyoteRuntime/PLogFormatter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Coyote.Actors;
+﻿using Microsoft.Coyote;
+using Microsoft.Coyote.Actors;
 using Microsoft.Coyote.Runtime;
 using Microsoft.Coyote.Runtime.Logging;
 using Plang.PrtSharp.Exceptions;
@@ -23,37 +24,37 @@ namespace Plang.PrtSharp
                 return;
             }
 
-            base.OnStateTransition(id, stateName.Split('.').Last(), isEntry);
+            base.OnStateTransition(id, stateName, isEntry);
         }
 
         public override void OnDefaultEventHandler(ActorId id, string stateName)
         {
-            base.OnDefaultEventHandler(id, stateName.Split('.').Last());
+            base.OnDefaultEventHandler(id, stateName);
         }
 
         public override void OnPopState(ActorId id, string currStateName, string restoredStateName)
         {
-            base.OnPopState(id, currStateName.Split('.').Last(), restoredStateName.Split('.').Last());
+            base.OnPopState(id, currStateName, restoredStateName);
         }
 
-        public override void OnPopUnhandledEvent(ActorId id, string stateName, string eventName)
+        public override void OnPopUnhandledEvent(ActorId id, string stateName, Event e)
         {
-            base.OnPopUnhandledEvent(id, stateName.Split('.').Last(), eventName);
+            base.OnPopUnhandledEvent(id, stateName, e);
         }
 
         public override void OnPushState(ActorId id, string currStateName, string newStateName)
         {
-            base.OnPushState(id, currStateName.Split('.').Last(), newStateName.Split('.').Last());
+            base.OnPushState(id, currStateName, newStateName);
         }
 
         public override void OnWaitEvent(ActorId id, string stateName, params Type[] eventTypes)
         {
-            base.OnWaitEvent(id, stateName.Split('.').Last(), eventTypes);
+            base.OnWaitEvent(id, stateName, eventTypes);
         }
 
         public override void OnWaitEvent(ActorId id, string stateName, Type eventType)
         {
-            base.OnWaitEvent(id, stateName.Split('.').Last(), eventType);
+            base.OnWaitEvent(id, stateName, eventType);
         }
 
         public override void OnMonitorStateTransition(string monitorTypeName, ActorId id, string stateName, bool isEntry, bool? isInHotState)
@@ -63,7 +64,7 @@ namespace Plang.PrtSharp
                 return;
             }
 
-            base.OnMonitorStateTransition(monitorTypeName, id, stateName.Split('.').Last(), isEntry, isInHotState);
+            base.OnMonitorStateTransition(monitorTypeName, id, stateName, isEntry, isInHotState);
         }
 
         public override void OnCreateActor(ActorId id, ActorId creator)
@@ -76,44 +77,46 @@ namespace Plang.PrtSharp
             base.OnCreateActor(id, creator);
         }
 
-        public override void OnDequeueEvent(ActorId id, string stateName, string eventName)
+        public override void OnDequeueEvent(ActorId id, string stateName, Event e)
         {
+
             if (stateName.Contains("__InitState__") || id.Name.Contains("GodMachine"))
             {
                 return;
             }
 
-            base.OnDequeueEvent(id, stateName.Split('.').Last(), eventName.Split('.').Last());
+            base.OnDequeueEvent(id, stateName, e);
         }
 
-        public override void OnRaiseEvent(ActorId id, string stateName, string eventName)
+        public override void OnRaiseEvent(ActorId id, string stateName, Event e)
         {
+            string eventName = e.GetType().FullName;
             if (stateName.Contains("__InitState__") || id.Name.Contains("GodMachine") || eventName.Contains("GotoStateEvent"))
             {
                 return;
             }
 
-            base.OnRaiseEvent(id, stateName.Split('.').Last(), eventName.Split('.').Last());
+            base.OnRaiseEvent(id, stateName, e);
         }
 
-        public override void OnEnqueueEvent(ActorId id, string eventName)
+        public override void OnEnqueueEvent(ActorId id, Event e)
         {
-            base.OnEnqueueEvent(id, eventName.Split('.').Last());
+            base.OnEnqueueEvent(id, e);
         }
 
-        public override void OnReceiveEvent(ActorId id, string stateName, string eventName, bool wasBlocked)
+        public override void OnReceiveEvent(ActorId id, string stateName, Event e, bool wasBlocked)
         {
-            base.OnReceiveEvent(id, stateName.Split('.').Last(), eventName.Split('.').Last(), wasBlocked);
+            base.OnReceiveEvent(id, stateName, e, wasBlocked);
         }
 
-        public override void OnMonitorRaiseEvent(string monitorTypeName, ActorId id, string stateName, string eventName)
+        public override void OnMonitorRaiseEvent(string monitorTypeName, ActorId id, string stateName, Event e)
         {
-            base.OnMonitorRaiseEvent(monitorTypeName, id, stateName.Split('.').Last(), eventName.Split('.').Last());
+            base.OnMonitorRaiseEvent(monitorTypeName, id, stateName, e);
         }
 
-        public override void OnSendEvent(ActorId targetActorId, ActorId senderId, string senderStateName, string eventName, Guid opGroupId, bool isTargetHalted)
+        public override void OnSendEvent(ActorId targetActorId, ActorId senderId, string senderStateName, Event e, Guid opGroupId, bool isTargetHalted)
         {
-            base.OnSendEvent(targetActorId, senderId, senderStateName.Split('.').Last(), eventName.Split('.').Last(), opGroupId, isTargetHalted);
+            base.OnSendEvent(targetActorId, senderId, senderStateName, e, opGroupId, isTargetHalted);
         }
 
         public override void OnGotoState(ActorId id, string currStateName, string newStateName)
@@ -123,7 +126,7 @@ namespace Plang.PrtSharp
                 return;
             }
 
-            base.OnGotoState(id, currStateName.Split('.').Last(), newStateName.Split('.').Last());
+            base.OnGotoState(id, currStateName, newStateName);
         }
 
         public override void OnExecuteAction(ActorId id, string stateName, string actionName)
@@ -136,12 +139,12 @@ namespace Plang.PrtSharp
 
         public override void OnExceptionHandled(ActorId id, string stateName, string actionName, Exception ex)
         {
-            base.OnExceptionHandled(id, stateName.Split('.').Last(), actionName, ex);
+            base.OnExceptionHandled(id, stateName, actionName, ex);
         }
 
         public override void OnExceptionThrown(ActorId id, string stateName, string actionName, Exception ex)
         {
-            base.OnExceptionThrown(id, stateName.Split('.').Last(), actionName, ex);
+            base.OnExceptionThrown(id, stateName, actionName, ex);
         }
     }
 }

--- a/Src/CoyoteRuntime/PLogFormatter.cs
+++ b/Src/CoyoteRuntime/PLogFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Coyote.Actors;
 using Microsoft.Coyote.Runtime;
+using Microsoft.Coyote.Runtime.Logging;
 using Plang.PrtSharp.Exceptions;
 using System;
 using System.Linq;
@@ -9,151 +10,138 @@ namespace Plang.PrtSharp
     /// <summary>
     ///     Formatter for the Coyote runtime log.
     /// </summary>
-    public class PLogFormatter : ActorRuntimeLogFormatter
+    public class PLogFormatter : ActorRuntimeLogTextFormatter
     {
         public PLogFormatter() : base()
         {
         }
 
-        public override bool GetStateTransitionLog(ActorId id, string stateName, bool isEntry, out string text)
+        public override void OnStateTransition(ActorId id, string stateName, bool isEntry)
         {
             if (stateName.Contains("__InitState__") || id.Name.Contains("GodMachine"))
             {
-                text = string.Empty;
-                return false;
+                return;
             }
 
-            return base.GetStateTransitionLog(id, stateName.Split('.').Last(), isEntry, out text);
+            base.OnStateTransition(id, stateName.Split('.').Last(), isEntry);
         }
 
-        public override bool GetDefaultEventHandlerLog(ActorId id, string stateName, out string text)
+        public override void OnDefaultEventHandler(ActorId id, string stateName)
         {
-            return base.GetDefaultEventHandlerLog(id, stateName.Split('.').Last(), out text);
+            base.OnDefaultEventHandler(id, stateName.Split('.').Last());
         }
 
-        public override bool GetPopStateLog(ActorId id, string currStateName, string restoredStateName, out string text)
+        public override void OnPopState(ActorId id, string currStateName, string restoredStateName)
         {
-            return base.GetPopStateLog(id, currStateName.Split('.').Last(), restoredStateName.Split('.').Last(), out text);
+            base.OnPopState(id, currStateName.Split('.').Last(), restoredStateName.Split('.').Last());
         }
 
-        public override bool GetPopUnhandledEventLog(ActorId id, string stateName, string eventName, out string text)
+        public override void OnPopUnhandledEvent(ActorId id, string stateName, string eventName)
         {
-            return base.GetPopUnhandledEventLog(id, stateName.Split('.').Last(), eventName, out text);
+            base.OnPopUnhandledEvent(id, stateName.Split('.').Last(), eventName);
         }
 
-        public override bool GetPushStateLog(ActorId id, string currStateName, string newStateName, out string text)
+        public override void OnPushState(ActorId id, string currStateName, string newStateName)
         {
-            return base.GetPushStateLog(id, currStateName.Split('.').Last(), newStateName.Split('.').Last(), out text);
+            base.OnPushState(id, currStateName.Split('.').Last(), newStateName.Split('.').Last());
         }
 
-        public override bool GetWaitEventLog(ActorId id, string stateName, Type[] eventTypes, out string text)
+        public override void OnWaitEvent(ActorId id, string stateName, params Type[] eventTypes)
         {
-            return base.GetWaitEventLog(id, stateName.Split('.').Last(), eventTypes, out text);
+            base.OnWaitEvent(id, stateName.Split('.').Last(), eventTypes);
         }
 
-        public override bool GetWaitEventLog(ActorId id, string stateName, Type eventType, out string text)
+        public override void OnWaitEvent(ActorId id, string stateName, Type eventType)
         {
-            return base.GetWaitEventLog(id, stateName.Split('.').Last(), eventType, out text);
+            base.OnWaitEvent(id, stateName.Split('.').Last(), eventType);
         }
 
-        public override bool GetMonitorStateTransitionLog(string monitorTypeName, ActorId id, string stateName,
-            bool isEntry, bool? isInHotState, out string text)
+        public override void OnMonitorStateTransition(string monitorTypeName, ActorId id, string stateName, bool isEntry, bool? isInHotState)
         {
             if (stateName.Contains("__InitState__"))
             {
-                text = string.Empty;
-                return false;
+                return;
             }
 
-            return base.GetMonitorStateTransitionLog(monitorTypeName, id, stateName.Split('.').Last(), isEntry, isInHotState, out text);
+            base.OnMonitorStateTransition(monitorTypeName, id, stateName.Split('.').Last(), isEntry, isInHotState);
         }
 
-        public override bool GetCreateActorLog(ActorId id, ActorId creator, out string text)
+        public override void OnCreateActor(ActorId id, ActorId creator)
         {
             if (id.Name.Contains("GodMachine"))
             {
-                text = string.Empty;
-                return false;
+                return;
             }
 
-            return base.GetCreateActorLog(id, creator, out text);
+            base.OnCreateActor(id, creator);
         }
 
-        public override bool GetDequeueEventLog(ActorId id, string stateName, string eventName, out string text)
+        public override void OnDequeueEvent(ActorId id, string stateName, string eventName)
         {
             if (stateName.Contains("__InitState__") || id.Name.Contains("GodMachine"))
             {
-                text = string.Empty;
-                return false;
+                return;
             }
 
-            return base.GetDequeueEventLog(id, stateName.Split('.').Last(), eventName.Split('.').Last(), out text);
+            base.OnDequeueEvent(id, stateName.Split('.').Last(), eventName.Split('.').Last());
         }
 
-        public override bool GetRaiseEventLog(ActorId id, string stateName, string eventName, out string text)
+        public override void OnRaiseEvent(ActorId id, string stateName, string eventName)
         {
             if (stateName.Contains("__InitState__") || id.Name.Contains("GodMachine") || eventName.Contains("GotoStateEvent"))
             {
-                text = string.Empty;
-                return false;
+                return;
             }
 
-            return base.GetRaiseEventLog(id, stateName.Split('.').Last(), eventName.Split('.').Last(), out text);
+            base.OnRaiseEvent(id, stateName.Split('.').Last(), eventName.Split('.').Last());
         }
 
-        public override bool GetEnqueueEventLog(ActorId id, string eventName, out string text)
+        public override void OnEnqueueEvent(ActorId id, string eventName)
         {
-            return base.GetEnqueueEventLog(id, eventName.Split('.').Last(), out text);
+            base.OnEnqueueEvent(id, eventName.Split('.').Last());
         }
 
-        public override bool GetReceiveEventLog(ActorId id, string stateName, string eventName, bool wasBlocked, out string text)
+        public override void OnReceiveEvent(ActorId id, string stateName, string eventName, bool wasBlocked)
         {
-            return base.GetReceiveEventLog(id, stateName.Split('.').Last(), eventName.Split('.').Last(), wasBlocked, out text);
+            base.OnReceiveEvent(id, stateName.Split('.').Last(), eventName.Split('.').Last(), wasBlocked);
         }
 
-        public override bool GetMonitorRaiseEventLog(string monitorTypeName, ActorId id, string stateName, string eventName, out string text)
+        public override void OnMonitorRaiseEvent(string monitorTypeName, ActorId id, string stateName, string eventName)
         {
-            return base.GetMonitorRaiseEventLog(monitorTypeName, id, stateName.Split('.').Last(), eventName.Split('.').Last(), out text);
+            base.OnMonitorRaiseEvent(monitorTypeName, id, stateName.Split('.').Last(), eventName.Split('.').Last());
         }
 
-        public override bool GetSendEventLog(ActorId targetActorId, ActorId senderId, string senderStateName,
-            string eventName, Guid opGroupId, bool isTargetHalted, out string text)
+        public override void OnSendEvent(ActorId targetActorId, ActorId senderId, string senderStateName, string eventName, Guid opGroupId, bool isTargetHalted)
         {
-            return base.GetSendEventLog(targetActorId, senderId, senderStateName.Split('.').Last(), eventName.Split('.').Last(), opGroupId, isTargetHalted, out text);
+            base.OnSendEvent(targetActorId, senderId, senderStateName.Split('.').Last(), eventName.Split('.').Last(), opGroupId, isTargetHalted);
         }
 
-        public override bool GetGotoStateLog(ActorId id, string currStateName, string newStateName, out string text)
+        public override void OnGotoState(ActorId id, string currStateName, string newStateName)
         {
             if (currStateName.Contains("__InitState__") || id.Name.Contains("GodMachine"))
             {
-                text = string.Empty;
-                return false;
+                return;
             }
 
-            return base.GetGotoStateLog(id, currStateName.Split('.').Last(), newStateName.Split('.').Last(), out text);
+            base.OnGotoState(id, currStateName.Split('.').Last(), newStateName.Split('.').Last());
         }
 
-        public override bool GetExecuteActionLog(ActorId id, string stateName, string actionName, out string text)
+        public override void OnExecuteAction(ActorId id, string stateName, string actionName)
         {
-            text = string.Empty;
-            return false;
         }
 
-        public override bool GetMonitorExecuteActionLog(string monitorTypeName, ActorId id,
-            string stateName, string actionName, out string text)
+        public override void OnMonitorExecuteAction(string monitorTypeName, ActorId id, string stateName, string actionName)
         {
-            text = string.Empty;
-            return false;
         }
 
-        public override bool GetExceptionHandledLog(ActorId id, string stateName, string actionName, Exception ex, out string text)
+        public override void OnExceptionHandled(ActorId id, string stateName, string actionName, Exception ex)
         {
-            return base.GetExceptionHandledLog(id, stateName.Split('.').Last(), actionName, ex, out text);
+            base.OnExceptionHandled(id, stateName.Split('.').Last(), actionName, ex);
         }
 
-        public override bool GetExceptionThrownLog(ActorId id, string stateName, string actionName, Exception ex, out string text)
+        public override void OnExceptionThrown(ActorId id, string stateName, string actionName, Exception ex)
         {
-            return base.GetExceptionThrownLog(id, stateName.Split('.').Last(), actionName, ex, out text);
+            base.OnExceptionThrown(id, stateName.Split('.').Last(), actionName, ex);
         }
     }
 }

--- a/Src/CoyoteRuntime/PLogFormatter.cs
+++ b/Src/CoyoteRuntime/PLogFormatter.cs
@@ -217,5 +217,18 @@ namespace Plang.PrtSharp
         {
             base.OnExceptionThrown(id: id, stateName: this.GetShortName(stateName), actionName: actionName, ex: ex);
         }
+
+        public override void OnCreateMonitor(string monitorTypeName, ActorId id)
+        {
+            base.OnCreateMonitor(this.GetShortName(monitorTypeName), id);
+        }
+
+        public override void OnHandleRaisedEvent(ActorId id, string stateName, Event e)
+        {
+        }
+
+        public override void OnMonitorProcessEvent(ActorId senderId, string senderStateName, string monitorTypeName, ActorId id, string stateName, Event e)
+        {
+        }
     }
 }

--- a/Src/CoyoteRuntime/PMachine.cs
+++ b/Src/CoyoteRuntime/PMachine.cs
@@ -83,7 +83,6 @@ namespace Plang.PrtSharp
 
             AnnounceInternal(ev);
             base.SendEvent(target.Id, ev);
-            Logger.WriteLine($"<SendPayloadLog> Event {ev.GetType().Name} with payload {((PEvent)ev).Payload}");
         }
 
         public Transition TryRaiseEvent(Event ev, object payload = null)

--- a/Src/Pc/CompilerCore/Backend/Coyote/CoyoteCodeGenerator.cs
+++ b/Src/Pc/CompilerCore/Backend/Coyote/CoyoteCodeGenerator.cs
@@ -291,7 +291,7 @@ namespace Plang.Compiler.Backend.Coyote
             context.WriteLine(output);
             context.WriteLine(output, "[Microsoft.Coyote.TestingServices.Test]");
             context.WriteLine(output, "public static void Execute(IActorRuntime runtime) {");
-            context.WriteLine(output, "runtime.SetLogFormatter(new PLogFormatter());");
+            context.WriteLine(output, "runtime.RegisterLog(new PLogFormatter());");
             context.WriteLine(output, "PModule.runtime = runtime;");
             context.WriteLine(output, "PHelper.InitializeInterfaces();");
             context.WriteLine(output, "PHelper.InitializeEnums();");

--- a/Src/Samples/PingPongCoyote/Main.cs
+++ b/Src/Samples/PingPongCoyote/Main.cs
@@ -237,7 +237,7 @@ namespace pingpong
         [Microsoft.Coyote.TestingServices.Test]
         public static void Execute(IActorRuntime runtime)
         {
-            runtime.SetLogFormatter(new PLogFormatter());
+            runtime.RegisterLog(new PLogFormatter());
             PModule.runtime = runtime;
             PHelper.InitializeInterfaces();
             PHelper.InitializeEnums();

--- a/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
+++ b/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc7" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Samples/TwoPhaseCommit/TwoPhaseCommit.csproj
+++ b/Src/Samples/TwoPhaseCommit/TwoPhaseCommit.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc7" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Main.cs" />

--- a/Tst/UnitTests/Runners/CoyoteRunner.cs
+++ b/Tst/UnitTests/Runners/CoyoteRunner.cs
@@ -113,7 +113,7 @@ namespace Main
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.Coyote"" Version=""1.0.0-rc7""/>
+    <PackageReference Include=""Microsoft.Coyote"" Version=""1.0.0-rc9""/>
     <Reference Include = ""CoyoteRuntime.dll""/>
   </ItemGroup>
 </Project>";

--- a/Tst/UnitTests/UnitTests.csproj
+++ b/Tst/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc7" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />


### PR DESCRIPTION
**Don't merge this until the next Coyote update...** I'm just giving folks a heads up... `IActorRuntimeLogFormatter` is going away.  You can still implement your own entirely custom `IActorRuntimeLog` like we did with the `ActorRuntimeLogGraphBuilder`, or you can subclass  a new "text logging" implementation of this interface called `ActorRuntimeLogTextFormatter`.  The next coyote update also provides a new "--xml-trace" option which uses a new `IActorRuntimeLog` implementation called `ActorRuntimeLogXmlFormatter`.  This replaces the old crufty *.pstrace files with a much more machine readable xml format which might also be handy for any tooling you build around these logs.