### PR TITLE
Coyote is hiding the Transition type. 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <activePackageSource>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-  </activePackageSource>
   <packageSources>
+    <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="Coyote" value="../../foundry99/Coyote/bin"/>
   </packageSources>
   <config>
     <!-- Defend against repositoryPath being set somewhere else in the environment. -->
-    <add key="repositoryPath" value="packages" />
+    <add key="globalPackagesFolder" value="./packages" />
+    <add key="repositoryPath" value="./packages" />    
   </config>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,6 @@
     <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="Coyote" value="../../foundry99/Coyote/bin"/>
   </packageSources>
   <config>
     <!-- Defend against repositoryPath being set somewhere else in the environment. -->

--- a/P.sln
+++ b/P.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio 16
+VisualStudioVersion = 16.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Runtime", "Runtime", "{D641DC13-F2F0-4365-963A-DCFC80BABCAA}"
 EndProject

--- a/Src/CoyoteRuntime/CoyoteRuntime.csproj
+++ b/Src/CoyoteRuntime/CoyoteRuntime.csproj
@@ -5,7 +5,7 @@
     <OutputPath>D:\Workspace\P\Bld\Drops\Debug\Binaries</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/Src/CoyoteRuntime/CoyoteRuntime.csproj
+++ b/Src/CoyoteRuntime/CoyoteRuntime.csproj
@@ -5,7 +5,7 @@
     <OutputPath>D:\Workspace\P\Bld\Drops\Debug\Binaries</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/Src/CoyoteRuntime/CoyoteRuntime.csproj
+++ b/Src/CoyoteRuntime/CoyoteRuntime.csproj
@@ -5,7 +5,7 @@
     <OutputPath>D:\Workspace\P\Bld\Drops\Debug\Binaries</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/Src/CoyoteRuntime/Exceptions/PNonStandardReturnException.cs
+++ b/Src/CoyoteRuntime/Exceptions/PNonStandardReturnException.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Plang.PrtSharp.Exceptions
+{
+    public enum NonStandardReturn
+    {
+        Raise,
+        Goto,
+        Pop
+    }
+
+    public class PNonStandardReturnException : Exception
+    {
+        public PNonStandardReturnException()
+        {
+        }
+
+        public PNonStandardReturnException(string message) : base(message)
+        {
+        }
+
+        public PNonStandardReturnException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected PNonStandardReturnException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public NonStandardReturn ReturnKind { get; set; }
+    }
+}

--- a/Src/CoyoteRuntime/PLogFormatter.cs
+++ b/Src/CoyoteRuntime/PLogFormatter.cs
@@ -210,11 +210,19 @@ namespace Plang.PrtSharp
 
         public override void OnExceptionHandled(ActorId id, string stateName, string actionName, Exception ex)
         {
+            if (ex is PNonStandardReturnException)
+            {
+                return;
+            }
             base.OnExceptionHandled(id: id, stateName: this.GetShortName(stateName), actionName: actionName, ex: ex);
         }
 
         public override void OnExceptionThrown(ActorId id, string stateName, string actionName, Exception ex)
         {
+            if (ex is PNonStandardReturnException)
+            {
+                return;
+            }
             base.OnExceptionThrown(id: id, stateName: this.GetShortName(stateName), actionName: actionName, ex: ex);
         }
 

--- a/Src/CoyoteRuntime/PLogFormatter.cs
+++ b/Src/CoyoteRuntime/PLogFormatter.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Coyote;
 using Microsoft.Coyote.Actors;
 using Microsoft.Coyote.Runtime;
-using Microsoft.Coyote.Runtime.Logging;
 using Plang.PrtSharp.Exceptions;
 using System;
 using System.Linq;
@@ -54,7 +53,7 @@ namespace Plang.PrtSharp
             base.OnPopState(id, this.GetShortName(currStateName), this.GetShortName(restoredStateName));
         }
 
-        public override void OnPopUnhandledEvent(ActorId id, string stateName, Event e)
+        public override void OnPopStateUnhandledEvent(ActorId id, string stateName, Event e)
         {
             stateName = this.GetShortName(stateName);
             string eventName = this.GetEventNameWithPayload(e);
@@ -80,24 +79,25 @@ namespace Plang.PrtSharp
             base.OnWaitEvent(id, this.GetShortName(stateName), eventType);
         }
 
-        public override void OnMonitorStateTransition(string monitorTypeName, ActorId id, string stateName, bool isEntry, bool? isInHotState)
+
+        public override void OnMonitorStateTransition(string monitorType, string stateName, bool isEntry, bool? isInHotState)
         {
             if (stateName.Contains("__InitState__"))
             {
                 return;
             }
 
-            base.OnMonitorStateTransition(monitorTypeName: this.GetShortName(monitorTypeName), id: id, stateName: this.GetShortName(stateName), isEntry: isEntry, isInHotState: isInHotState);
+            base.OnMonitorStateTransition(monitorType: this.GetShortName(monitorType), stateName: this.GetShortName(stateName), isEntry: isEntry, isInHotState: isInHotState);
         }
 
-        public override void OnCreateActor(ActorId id, ActorId creator)
+        public override void OnCreateActor(ActorId id, string creatorName, string creatorType)
         {
             if (id.Name.Contains("GodMachine"))
             {
                 return;
             }
 
-            base.OnCreateActor(id, creator);
+            base.OnCreateActor(id, creatorName, creatorType);
         }
 
         public override void OnDequeueEvent(ActorId id, string stateName, Event e)
@@ -171,21 +171,21 @@ namespace Plang.PrtSharp
             this.Logger.WriteLine(text);
         }
 
-        public override void OnMonitorRaiseEvent(string monitorTypeName, ActorId id, string stateName, Event e)
+        public override void OnMonitorRaiseEvent(string monitorType, string stateName, Event e)
         {
             stateName = this.GetShortName(stateName);
             string eventName = this.GetEventNameWithPayload(e);
-            string text = $"<MonitorLog> Monitor '{GetShortName(monitorTypeName)}' with id '{id}' raised event '{eventName}' in state '{stateName}'.";
+            string text = $"<MonitorLog> Monitor '{GetShortName(monitorType)}' raised event '{eventName}' in state '{stateName}'.";
             this.Logger.WriteLine(text);
         }
 
-        public override void OnSendEvent(ActorId targetActorId, ActorId senderId, string senderStateName, Event e, Guid opGroupId, bool isTargetHalted)
+        public override void OnSendEvent(ActorId targetActorId, string senderName, string senderType, string senderStateName, Event e, Guid opGroupId, bool isTargetHalted)
         {
             senderStateName = this.GetShortName(senderStateName);
             string eventName = this.GetEventNameWithPayload(e);
             var opGroupIdMsg = opGroupId != Guid.Empty ? $" (operation group '{opGroupId}')" : string.Empty;
             var isHalted = isTargetHalted ? $" which has halted" : string.Empty;
-            var sender = senderId != null ? $"'{senderId}' in state '{senderStateName}'" : $"The runtime";
+            var sender = !string.IsNullOrEmpty(senderName) ? $"'{senderName}' in state '{senderStateName}'" : $"The runtime";
             var text = $"<SendLog> {sender} sent event '{eventName}' to '{targetActorId}'{isHalted}{opGroupIdMsg}.";
             this.Logger.WriteLine(text);
         }
@@ -200,11 +200,11 @@ namespace Plang.PrtSharp
             base.OnGotoState(id, this.GetShortName(currStateName), this.GetShortName(newStateName));
         }
 
-        public override void OnExecuteAction(ActorId id, string stateName, string actionName)
+        public override void OnExecuteAction(ActorId id, string handlingStateName, string currentStateName, string actionName)
         {
         }
 
-        public override void OnMonitorExecuteAction(string monitorTypeName, ActorId id, string stateName, string actionName)
+        public override void OnMonitorExecuteAction(string monitorType, string stateName, string actionName)
         {
         }
 
@@ -218,16 +218,16 @@ namespace Plang.PrtSharp
             base.OnExceptionThrown(id: id, stateName: this.GetShortName(stateName), actionName: actionName, ex: ex);
         }
 
-        public override void OnCreateMonitor(string monitorTypeName, ActorId id)
+        public override void OnCreateMonitor(string monitorType)
         {
-            base.OnCreateMonitor(this.GetShortName(monitorTypeName), id);
+            base.OnCreateMonitor(this.GetShortName(monitorType));
         }
 
         public override void OnHandleRaisedEvent(ActorId id, string stateName, Event e)
         {
         }
 
-        public override void OnMonitorProcessEvent(ActorId senderId, string senderStateName, string monitorTypeName, ActorId id, string stateName, Event e)
+        public override void OnMonitorProcessEvent(string monitorType, string stateName, string senderName, string senderType, string senderStateName, Event e)
         {
         }
     }

--- a/Src/CoyoteRuntime/PMachine.cs
+++ b/Src/CoyoteRuntime/PMachine.cs
@@ -121,12 +121,12 @@ namespace Plang.PrtSharp
 
         public bool TryRandomBool(int maxValue)
         {
-            return base.Random(maxValue);
+            return base.RandomBoolean(maxValue);
         }
 
         public bool TryRandomBool()
         {
-            return base.Random();
+            return base.RandomBoolean();
         }
 
         public IPrtValue TryRandom(IPrtValue param)

--- a/Src/CoyoteRuntime/PMachine.cs
+++ b/Src/CoyoteRuntime/PMachine.cs
@@ -28,7 +28,7 @@ namespace Plang.PrtSharp
             base.Assert(predicate, s, args);
         }
 
-        protected Transition InitializeParametersFunction(Event e)
+        protected void InitializeParametersFunction(Event e)
         {
             if (!(e is InitializeParametersEvent @event))
             {
@@ -38,7 +38,7 @@ namespace Plang.PrtSharp
             InitializeParameters initParam = @event.Payload as InitializeParameters;
             interfaceName = initParam.InterfaceName;
             self = new PMachineValue(Id, receives.ToList());
-            return TryRaiseEvent(GetConstructorEvent(initParam.Payload), initParam.Payload);
+            TryRaiseEvent(GetConstructorEvent(initParam.Payload), initParam.Payload);
         }
 
         protected virtual Event GetConstructorEvent(IPrtValue value)
@@ -85,12 +85,12 @@ namespace Plang.PrtSharp
             base.SendEvent(target.Id, ev);
         }
 
-        public Transition TryRaiseEvent(Event ev, object payload = null)
+        public void TryRaiseEvent(Event ev, object payload = null)
         {
             Assert(ev != null, "Machine cannot raise a null event");
             System.Reflection.ConstructorInfo oneArgConstructor = ev.GetType().GetConstructors().First(x => x.GetParameters().Length > 0);
             ev = (Event)oneArgConstructor.Invoke(new[] { payload });
-            return base.RaiseEvent(ev);
+            base.RaiseEvent(ev);
         }
 
         public Task<Event> TryReceiveEvent(params Type[] events)
@@ -98,15 +98,15 @@ namespace Plang.PrtSharp
             return base.ReceiveEventAsync(events);
         }
 
-        public Transition TryGotoState<T>(IPrtValue payload = null) where T : State
+        public void TryGotoState<T>(IPrtValue payload = null) where T : State
         {
             gotoPayload = payload;
-            return base.GotoState<T>();
+            base.RaiseGotoStateEvent<T>();
         }
 
-        public Transition TryPopState()
+        public void TryPopState()
         {
-            return base.PopState();
+            base.RaisePopStateEvent();
         }
 
         public int TryRandomInt(int maxValue)

--- a/Src/CoyoteRuntime/PModule.cs
+++ b/Src/CoyoteRuntime/PModule.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Coyote.Runtime;
+﻿using Microsoft.Coyote.Actors;
 using System;
 using System.Collections.Generic;
 

--- a/Src/CoyoteRuntime/PMonitor.cs
+++ b/Src/CoyoteRuntime/PMonitor.cs
@@ -12,18 +12,18 @@ namespace Plang.PrtSharp
 
         public object gotoPayload;
 
-        public Transition TryRaiseEvent(Event ev, object payload = null)
+        public void TryRaiseEvent(Event ev, object payload = null)
         {
             Assert(!(ev is DefaultEvent), "Monitor cannot raise a null event");
             System.Reflection.ConstructorInfo oneArgConstructor = ev.GetType().GetConstructors().First(x => x.GetParameters().Length > 0);
             Event @event = (Event)oneArgConstructor.Invoke(new[] { payload });
-            return base.RaiseEvent(@event);
+            base.RaiseEvent(@event);
         }
 
-        public Transition TryGotoState<T>(object payload = null) where T : State
+        public void TryGotoState<T>(object payload = null) where T : State
         {
             gotoPayload = payload;
-            return base.GotoState<T>();
+            base.RaiseGotoStateEvent<T>();
         }
 
         public void TryAssert(bool predicate)

--- a/Src/Samples/PingPongCoyote/Main.cs
+++ b/Src/Samples/PingPongCoyote/Main.cs
@@ -234,7 +234,7 @@ namespace pingpong
             PModule.monitorMap.Clear();
         }
 
-        [Microsoft.Coyote.TestingServices.Test]
+        [Microsoft.Coyote.SystematicTesting.Test]
         public static void Execute(IActorRuntime runtime)
         {
             runtime.RegisterLog(new PLogFormatter());

--- a/Src/Samples/PingPongCoyote/Main.cs
+++ b/Src/Samples/PingPongCoyote/Main.cs
@@ -89,18 +89,18 @@ namespace pingpong
             creates.Add(nameof(I_PONG));
         }
 
-        public Transition Anon()
+        public void Anon()
         {
             Main currentMachine = this;
-                PMachineValue TMP_tmp0 = null;
-                PEvent TMP_tmp1 = null;
-                TMP_tmp0 = currentMachine.CreateInterface<I_PONG>(currentMachine);
-                pongId = TMP_tmp0;
-                TMP_tmp1 = new Success(null);
-                return currentMachine.TryRaiseEvent(TMP_tmp1);
+            PMachineValue TMP_tmp0 = null;
+            PEvent TMP_tmp1 = null;
+            TMP_tmp0 = currentMachine.CreateInterface<I_PONG>(currentMachine);
+            pongId = TMP_tmp0;
+            TMP_tmp1 = new Success(null);
+            currentMachine.TryRaiseEvent(TMP_tmp1);
         }
 
-        public Transition Anon_1()
+        public void Anon_1()
         {
             Main currentMachine = this;
             PMachineValue TMP_tmp0_1 = null;
@@ -112,7 +112,7 @@ namespace pingpong
             TMP_tmp2 = currentMachine.self;
             currentMachine.TrySendEvent(TMP_tmp0_1, TMP_tmp1_1, TMP_tmp2);
             TMP_tmp3 = new Success(null);
-            return currentMachine.TryRaiseEvent(TMP_tmp3);
+            currentMachine.TryRaiseEvent(TMP_tmp3);
         }
 
         [Start]
@@ -172,7 +172,7 @@ namespace pingpong
             PONG currentMachine = this;
         }
 
-        public Transition Anon_3(Event currentMachine_dequeuedEvent)
+        public void Anon_3(Event currentMachine_dequeuedEvent)
         {
             PONG currentMachine = this;
             PMachineValue payload = (PMachineValue)(gotoPayload ?? ((PEvent)currentMachine_dequeuedEvent).Payload);
@@ -184,7 +184,7 @@ namespace pingpong
             TMP_tmp1_2 = new Pong(null);
             currentMachine.TrySendEvent(TMP_tmp0_2, TMP_tmp1_2);
             TMP_tmp2_1 = new Success(null);
-            return currentMachine.TryRaiseEvent(TMP_tmp2_1);
+            currentMachine.TryRaiseEvent(TMP_tmp2_1);
         }
 
         [Start]

--- a/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
+++ b/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
+++ b/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
+++ b/Src/Samples/PingPongCoyote/PingPongCoyote.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Samples/PingPongCoyote/Test.cs
+++ b/Src/Samples/PingPongCoyote/Test.cs
@@ -1,5 +1,5 @@
 using Microsoft.Coyote;
-using Microsoft.Coyote.TestingServices;
+using Microsoft.Coyote.SystematicTesting;
 using System;
 using System.Linq;
 
@@ -10,9 +10,8 @@ namespace pingpong
         public static void Main(string[] args)
         {
             // Optional: increases verbosity level to see the Coyote runtime log.
-            Configuration configuration = Configuration.Create();
-            configuration.SchedulingIterations = 10;
-            ITestingEngine engine = TestingEngineFactory.CreateBugFindingEngine(configuration, DefaultImpl.Execute);
+            Configuration configuration = Configuration.Create().WithTestingIterations(10);
+            TestingEngine engine = TestingEngine.Create(configuration, DefaultImpl.Execute);
             engine.Run();
             string bug = engine.TestReport.BugReports.FirstOrDefault();
             if (bug != null)

--- a/Src/Samples/TwoPhaseCommit/TwoPhaseCommit.csproj
+++ b/Src/Samples/TwoPhaseCommit/TwoPhaseCommit.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Main.cs" />

--- a/Tst/UnitTests/Runners/CoyoteRunner.cs
+++ b/Tst/UnitTests/Runners/CoyoteRunner.cs
@@ -91,7 +91,7 @@ namespace UnitTests.Runners
         {
             string testCode = @"
 using Microsoft.Coyote;
-using Microsoft.Coyote.TestingServices;
+using Microsoft.Coyote.SystematicTesting;
 using System;
 using System.Linq;
 
@@ -100,9 +100,9 @@ namespace Main
     public class _TestRegression {
         public static void Main(string[] args)
         {
-            Configuration configuration = Configuration.Create();
-            configuration.SchedulingIterations = 10;
-            ITestingEngine engine = TestingEngineFactory.CreateBugFindingEngine(configuration, DefaultImpl.Execute);
+            // Optional: increases verbosity level to see the Coyote runtime log.
+            Configuration configuration = Configuration.Create().WithTestingIterations(10);
+            TestingEngine engine = TestingEngine.Create(configuration, DefaultImpl.Execute);
             engine.Run();
             string bug = engine.TestReport.BugReports.FirstOrDefault();
             if (bug != null)
@@ -135,7 +135,7 @@ namespace Main
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.Coyote"" Version=""1.0.0-rc9""/>
+    <PackageReference Include=""Microsoft.Coyote"" Version=""1.0.3""/>
     <Reference Include = ""CoyoteRuntime.dll""/>
   </ItemGroup>
 </Project>";

--- a/Tst/UnitTests/Runners/CoyoteRunner.cs
+++ b/Tst/UnitTests/Runners/CoyoteRunner.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Coyote.TestingServices;
+﻿using Microsoft.Coyote.SystematicTesting;
 using Plang.Compiler;
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace UnitTests.Runners
     internal class CoyoteRunner : ICompilerTestRunner
     {
         private static readonly string CoyoteAssemblyLocation =
-            Path.GetDirectoryName(typeof(TestingEngineFactory).GetTypeInfo().Assembly.Location);
+            Path.GetDirectoryName(typeof(TestingEngine).GetTypeInfo().Assembly.Location);
 
         private readonly FileInfo[] nativeSources;
         private readonly FileInfo[] sources;

--- a/Tst/UnitTests/UnitTests.csproj
+++ b/Tst/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Tst/UnitTests/UnitTests.csproj
+++ b/Tst/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.3" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Tst/UnitTests/UnitTests.csproj
+++ b/Tst/UnitTests/UnitTests.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.2" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Tutorial/TwoPhaseCommit/TwoPhaseCommit.csproj
+++ b/Tutorial/TwoPhaseCommit/TwoPhaseCommit.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc9" />
+    <PackageReference Include="Microsoft.Coyote" Version="1.0.0-rc11" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Main.cs" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
     buildConfiguration: 'Release'
   steps:
     - script: dotnet build --configuration $(buildConfiguration)
-    - script: dotnet test --configuration $(buildConfiguration) --filter "PrtSharpRegressionTests"
+    - script: dotnet test --configuration $(buildConfiguration)
 
 
 


### PR DESCRIPTION
There is no reason to expose Transition objects and force users to "return" a Transition.  As is evidenced by the dangling Transition PR, it didn't actually improve things and the solution to dangling Transitions shows that exposing Transition is not required to ensure the same contract (namely, that only one is created per action) as shown by the internal PendingTransition member variable.

We also decided to rename some methods to make them all have a similar and therefore consistent name:

```
RaiseEvent is unchanged
Rename “GotoState” to “RaiseGotoStateEvent”
Rename “PushState” to “RaisePushStateEvent”
Rename “PopState” to “RaisePopStateEvent”
Rename “Halt” to “RaiseHaltEvent”
```

The idea being that the "Raise...Event" language more clearly communicates to the user that these operations are queuing something up to happen after the action completes and they are not processed immediately.  This also makes it easier for the user to remember the idea that currently you can only do one Raise operation per action.

I tried to fix the CoyoteCodeGenerator, and most of the PrtSharpRegressionTests are passing, but occassionally I'm seeing an error about access denied trying to copy CoyoteRuntime.dll saying the file is in use.  I added some retry logic to the File.Copy operation in CoyoteRunner.dll but it still seems to happen.  Perhaps we just need to increase the number of retries, or investigate more deeply why this is happening, but I don't think it is the result of this PR.