### PR TITLE
CompilerCore build: Use "java" in $PATH instead of hard-coding to /usr/bin/java

### DIFF
--- a/Src/PCompiler/CompilerCore/CompilerCore.csproj
+++ b/Src/PCompiler/CompilerCore/CompilerCore.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Plang.Compiler</RootNamespace>
-    <Antlr4JavaExecutable Condition=" '$(OS)' != 'Windows_NT' ">/usr/bin/java</Antlr4JavaExecutable>
+    <Antlr4JavaExecutable Condition=" '$(OS)' != 'Windows_NT' ">java</Antlr4JavaExecutable>
     <OutputPath>$(PSdkFolder)\Binaries</OutputPath>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Not all users install Java into /usr/bin/java, but we can expect it to be available in the PATH variable.