### PR TITLE
fix pproj path extraction on unix case sensitive file systems

### DIFF
--- a/Src/PCompiler/CommandLine/CommandLineOptions.cs
+++ b/Src/PCompiler/CommandLine/CommandLineOptions.cs
@@ -51,7 +51,7 @@ namespace Plang.Compiler
                 }
                 else
                 {
-                    var option = args.First().ToLowerInvariant();
+                    var option = args.First();
                     var projectPath = option.Substring(option.IndexOf(":") + 1);
                     // Parse the project file and generate the compilation job
                     return commandlineParser.ParseProjectFile(projectPath, out job) ? Success : Failure;


### PR DESCRIPTION
`option` does not require to preliminary be lower cased.
Case sensitivy is further detected by the IsCorrectPProjFileName.

Without this patch any call on unix cs fs does not work:

    $ ./Bld/Drops/Release/Binaries/netcoreapp3.1/P -proj:./Tutorial/TwoPhaseCommit/TwoPhaseCommit.pproj