### PR TITLE
Change input AspectJ code, Add aspectj output dir option, Generate BaseAspect

### DIFF
--- a/Src/PCompiler/CommandLine/CommandLineOptions.cs
+++ b/Src/PCompiler/CommandLine/CommandLineOptions.cs
@@ -77,9 +77,12 @@ namespace Plang.Compiler
             CommandlineOutput.WriteInfo("------------------------------------------");
             CommandlineOutput.WriteInfo("Optional usage:\n");
             CommandlineOutput.WriteInfo(">> pc file1.p [file2.p ...] [-t:tfile] [options]");
-            CommandlineOutput.WriteInfo("    -t:[target project name]   -- name of project (as well as the generated file); if not supplied then file1");
+            CommandlineOutput.WriteInfo("    -t:[target project name]   -- project name (as well as the generated file)");
+            CommandlineOutput.WriteInfo("                                  if not supplied, use file1");
             CommandlineOutput.WriteInfo("    -outputDir:[path]          -- where to write the generated files");
-            CommandlineOutput.WriteInfo("    -generate:[C,CSharp,RVM]       -- select a target language to generate");
+            CommandlineOutput.WriteInfo("    -aspectOutputDir:[path]    -- where to write the generated aspectj files");
+            CommandlineOutput.WriteInfo("                                  if not supplied, use outputDir");
+            CommandlineOutput.WriteInfo("    -generate:[C,CSharp,RVM]   -- select a target language to generate");
             CommandlineOutput.WriteInfo("        C       : generate C code");
             CommandlineOutput.WriteInfo("        CSharp  : generate C# code ");
             CommandlineOutput.WriteInfo("        RVM     : generate Monitor code");

--- a/Src/PCompiler/CompilerCore/Backend/Rvm/AjFileGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Rvm/AjFileGenerator.cs
@@ -8,7 +8,7 @@ using System.IO;
 
 namespace Plang.Compiler.Backend.Rvm
 {
-    // AjFileGenerator generates the template AspectJ file.
+    // AjFileGenerator generates the base AspectJ file that handles MonitorOn annotations and common pointcuts
     internal class AjFileGenerator
     {
         private CompilationContext Context {get;}
@@ -41,8 +41,11 @@ namespace Plang.Compiler.Backend.Rvm
             CompiledFile source = new CompiledFile(Context.GetAjFileName());
 
             WriteSourcePrologue(source.Stream);
-            WriteEventHandlerSignature(source.Stream, specMachines);
-            WriteSpec(source.Stream);
+            foreach (Machine machine in specMachines)
+            {
+                WriteParentClass(source.Stream, machine);
+            }
+            WriteBaseAspect(source.Stream, specMachines);
 
             return source;
         }
@@ -52,12 +55,50 @@ namespace Plang.Compiler.Backend.Rvm
             Context.WriteLine(output);
             Context.WriteLine(output, "import java.lang.ref.*;");
             Context.WriteLine(output, "import org.aspectj.lang.*;");
-            Context.WriteLine(output);
-            Context.WriteLine(output, "import p.runtime.values.*;");
-            Context.WriteLine(output, "// add your own imports.");
+            Context.WriteLine(output, "import java.util.Arrays;");
             Context.WriteLine(output);
 
-            Context.WriteLine(output, "aspect BaseAspect {");
+            Context.WriteLine(output, "import p.runtime.values.*;");
+            Context.WriteLine(output, "import com.runtimeverification.rvmonitor.java.rt.RVMObject;");
+            Context.WriteLine(output, "import com.runtimeverification.rvmonitor.java.rt.annotation.MonitorOn;");
+            Context.WriteLine(output, "import com.runtimeverification.rvmonitor.java.rt.annotation.MonitorsOn;");
+            Context.WriteLine(output);
+
+        }
+
+        private void WriteParentClass(StringWriter output, Machine specMachine)
+        {
+            string declName = Context.Names.GetAspectClassName();
+            string parentClass = Context.Names.GetParentClassName(specMachine);
+
+            Context.WriteLine(output, $"class { parentClass } implements RVMObject {{");
+            Context.WriteLine(output, $"public { parentClass }() {{ }}");
+            Context.WriteLine(output);
+            foreach (PEvent e in specMachine.Observes.Events)
+            {
+                string monitorClassName = Context.Names.GetJavaRuntimeMonitorName(specMachine);
+                string handlerName = Context.Names.GetJavaEventHandlerName(specMachine, e);
+                string payloadType = Context.Names.GetJavaTypeName(e.PayloadType, true);
+                string eventAlias = Context.Names.GetEventAlias(specMachine, e);
+                string parameterTypeAndName = payloadType.Length > 0 ? $"{ payloadType } v" : "";
+                string parameterName = payloadType.Length > 0 ? "v" : "";
+
+                Context.WriteLine(output, $"void { eventAlias }({ parameterTypeAndName }){{");
+                Context.WriteLine(output, $"{ monitorClassName }.{ handlerName }({ parameterName });");
+                Context.WriteLine(output, "}");
+            }
+            Context.WriteLine(output, "}");
+            Context.WriteLine(output);
+        }
+
+        private void WriteBaseAspect(StringWriter output, IEnumerable<Machine> specMachines)
+        {
+            string declName = Context.Names.GetAspectClassName();
+
+            Context.WriteLine(output, $"public aspect { declName } implements RVMObject {{");
+            Context.WriteLine(output, $"{declName}() {{ }}");
+            Context.WriteLine(output);
+
             Context.WriteLine(output, "pointcut notwithin() :");
             Context.WriteLine(output, "    !within(sun..*) &&");
             Context.WriteLine(output, "    !within(java..*) &&");
@@ -70,47 +111,68 @@ namespace Plang.Compiler.Backend.Rvm
             Context.WriteLine(output, "    !within(javamoprt..*) &&");
             Context.WriteLine(output, "    !within(rvmonitorrt..*) &&");
             Context.WriteLine(output, "    !within(com.runtimeverification..*);");
-            Context.WriteLine(output, "}");
-            Context.WriteLine(output);
-        }
-
-        private void WriteSpec(StringWriter output)
-        {
-            string declName = Context.Names.GetAspectClassName();
-            Context.WriteLine(output, $"public aspect { declName } implements com.runtimeverification.rvmonitor.java.rt.RVMObject {{");
-            Context.WriteLine(output, $"{declName}() {{ }}");
-
-            Context.WriteLine(output);
-            Context.WriteLine(output, "pointcut MOP_CommonPointCut() : !within(com.runtimeverification.rvmonitor.java.rt.RVMObject+) && !adviceexecution() && BaseAspect.notwithin();");
-
-            Context.WriteLine(output);
-            Context.WriteLine(output, "// Implement your code here.");
-
-            Context.WriteLine(output);
-            Context.WriteLine(output, "}");
-        }
-
-        private void WriteEventHandlerSignature(StringWriter output, IEnumerable<Machine> specMachines)
-        {
-            Context.WriteLine(output, "// Signatures of all the events that need dispatching.");
+            Context.WriteLine(output, "pointcut CommonPointCut() :");
+            Context.WriteLine(output, "    !within(com.runtimeverification.rvmonitor.java.rt.RVMObject+) &&");
+            Context.WriteLine(output, "    !adviceexecution() &&");
+            Context.WriteLine(output, "    notwithin();");
 
             foreach (Machine machine in specMachines)
             {
+                string specName = Context.Names.GetRvmSpecName(machine);
+                string monitorOn = Context.Names.GetPointCutNameForMonitorOn(machine);
+                string monitorsOn = Context.Names.GetPointCutNameForMonitorsOn(machine);
+                string specPointcut = Context.Names.GetPointCutNameForEnabledTestcases(machine);
+                string aspectNameForSpec = Context.Names.GetAspectInputTemplateClassName(machine);
+                string parentClass = Context.Names.GetParentClassName(machine);
 
-                // We iterate the events that the spec observes instead of all the declared events
-                // because monitors only interact with the external systems through the events that they observe.
-                foreach (PEvent e in machine.Observes.Events)
-                {
-                    string monitorClassName = Context.Names.GetJavaRuntimeMonitorName(machine);
-                    string handlerName = Context.Names.GetJavaEventHandlerName(machine, e);
-                    string payloadType = Context.Names.GetJavaTypeName(e.PayloadType, true);
-                    string handlerSignature = $"{ monitorClassName }.{ handlerName }({payloadType})";
-                    Context.WriteLine(output, $"// {handlerSignature}");
-                }
+                Context.WriteLine(output);
+                Context.WriteLine(output, $"declare parents: { aspectNameForSpec } extends { parentClass };");
+                Context.WriteLine(output, $"pointcut { monitorOn }(MonitorOn monitorOn) : cflow(@annotation(monitorOn)) && if(monitorOn.value().equalsIgnoreCase(\"{specName}\"));");
+                Context.WriteLine(output, $"pointcut { monitorsOn }(MonitorsOn monitorsOn) : cflow(@annotation(monitorsOn)) && if(Arrays.stream(monitorsOn.value()).anyMatch(t -> t.value().equalsIgnoreCase(\"{specName}\")));");
+                Context.WriteLine(output, $"pointcut { specPointcut }() : ({ monitorOn }(MonitorOn) || { monitorsOn }(MonitorsOn)) && CommonPointCut();");
             }
 
             Context.WriteLine(output);
-        }
+            Context.WriteLine(output, "before(MonitorOn monitorOn) : @annotation(monitorOn) {");
+            Context.WriteLine(output, "System.out.println(\"[Start] monitoring \" + thisJoinPoint.getSignature().getName() + \" against \" + monitorOn.value());");
+            foreach (Machine machine in specMachines)
+            {
+                string monitorName = Context.Names.GetJavaRuntimeMonitorName(machine);
+                Context.WriteLine(output, $"{ monitorName }.resetMonitor();");
+                Context.WriteLine(output, $"{ monitorName }.enable();");
+            }
+            Context.WriteLine(output, "}");
+            Context.WriteLine(output, "before(MonitorsOn monitorsOn) : @annotation(monitorsOn) {");
+            Context.WriteLine(output, "String monitors = String.join(\",\", Arrays.stream(monitorsOn.value()).map(t -> (String)t.value()).toArray(String[]::new));");
+            Context.WriteLine(output, "System.out.println(\"[Start] monitoring \" + thisJoinPoint.getSignature().getName() + \" against \" + monitors);");
+            foreach (Machine machine in specMachines)
+            {
+                string monitorName = Context.Names.GetJavaRuntimeMonitorName(machine);
+                Context.WriteLine(output, $"{ monitorName }.resetMonitor();");
+                Context.WriteLine(output, $"{ monitorName }.enable();");
+            }
+            Context.WriteLine(output, "}");
+            Context.WriteLine(output);
 
+            Context.WriteLine(output, "after(MonitorOn monitorOn) : @annotation(monitorOn) {");
+            Context.WriteLine(output, "System.out.println(\"[End] monitoring \" + thisJoinPoint.getSignature().getName() + \" against \" + monitorOn.value());");
+            foreach (Machine machine in specMachines)
+            {
+                string monitorName = Context.Names.GetJavaRuntimeMonitorName(machine);
+                Context.WriteLine(output, $"{ monitorName }.disable();");
+            }
+            Context.WriteLine(output, "}");
+            Context.WriteLine(output, "after(MonitorsOn monitorsOn) : @annotation(monitorsOn) {");
+            Context.WriteLine(output, "String monitors = String.join(\",\", Arrays.stream(monitorsOn.value()).map(t -> (String)t.value()).toArray(String[]::new));");
+            Context.WriteLine(output, "System.out.println(\"[End] monitoring \" + thisJoinPoint.getSignature().getName() + \" against \" + monitors);");
+            foreach (Machine machine in specMachines)
+            {
+                string monitorName = Context.Names.GetJavaRuntimeMonitorName(machine);
+                Context.WriteLine(output, $"{ monitorName }.disable();");
+            }
+            Context.WriteLine(output, "}");
+
+            Context.WriteLine(output, "}");
+        }
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/Rvm/RvmNameManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Rvm/RvmNameManager.cs
@@ -52,9 +52,44 @@ namespace Plang.Compiler.Backend.Rvm
             return $"{GetNameForDecl(m)}RuntimeMonitor";
         }
 
+        public string GetParentClassName(Machine m)
+        {
+            string specName = GetRvmSpecName(m);
+            return $"{specName}__Base";
+        }
+
+        public string GetEventAlias(Machine m, PEvent e)
+        {
+            string eventName = GetRvmEventName(e);
+            return $"event_{ eventName }";
+        }
+
+        public string GetPointCutNameForMonitorOn(Machine m)
+        {
+            string specName = GetRvmSpecName(m);
+            return $"MonitorOn_{specName}";
+        }
+
+        public string GetPointCutNameForMonitorsOn(Machine m)
+        {
+            string specName = GetRvmSpecName(m);
+            return $"MonitorsOn_{specName}";
+        }
+
+        public string GetPointCutNameForEnabledTestcases(Machine m)
+        {
+            string specName = GetRvmSpecName(m);
+            return $"{specName}Test";
+        }
+
         public string GetAspectClassName()
         {
-            return $"PSpecMonitorAspect";
+            return $"BaseAspect";
+        }
+
+        public string GetAspectInputTemplateClassName(Machine m)
+        {
+            return $"{GetNameForDecl(m)}Aspect";
         }
 
         public string GetSpecConstructorName(Machine m)

--- a/Src/PCompiler/CompilerCore/CompilationJob.cs
+++ b/Src/PCompiler/CompilerCore/CompilationJob.cs
@@ -10,7 +10,8 @@ namespace Plang.Compiler
     public class CompilationJob : ICompilationJob
     {
         public CompilationJob(ICompilerOutput output, DirectoryInfo outputDir, CompilerOutput outputLanguage, IReadOnlyList<FileInfo> inputFiles,
-            string projectName, DirectoryInfo projectRoot = null, bool generateSourceMaps = false, IReadOnlyList<string> projectDependencies = null)
+            string projectName, DirectoryInfo projectRoot = null, bool generateSourceMaps = false, IReadOnlyList<string> projectDependencies = null,
+            DirectoryInfo aspectjOutputDir = null)
         {
             if (!inputFiles.Any())
             {
@@ -19,6 +20,7 @@ namespace Plang.Compiler
 
             Output = output;
             OutputDirectory = outputDir;
+            AspectjOutputDirectory = aspectjOutputDir;
             InputFiles = inputFiles;
             ProjectName = projectName ?? Path.GetFileNameWithoutExtension(inputFiles[0].FullName);
             ProjectRootPath = projectRoot;
@@ -33,6 +35,7 @@ namespace Plang.Compiler
         public bool GenerateSourceMaps { get; }
         public ICompilerOutput Output { get; }
         public DirectoryInfo OutputDirectory { get; }
+        public DirectoryInfo AspectjOutputDirectory { get; }
         public CompilerOutput OutputLanguage { get; }
         public string ProjectName { get; }
         public DirectoryInfo ProjectRootPath { get; }

--- a/Src/PCompiler/CompilerCore/DefaultCompilerOutput.cs
+++ b/Src/PCompiler/CompilerCore/DefaultCompilerOutput.cs
@@ -7,10 +7,12 @@ namespace Plang.Compiler
     public class DefaultCompilerOutput : ICompilerOutput
     {
         private readonly DirectoryInfo outputDirectory;
+        private readonly DirectoryInfo aspectjOutputDirectory;
 
-        public DefaultCompilerOutput(DirectoryInfo outputDirectory)
+        public DefaultCompilerOutput(DirectoryInfo outputDirectory, DirectoryInfo aspectjOutputDirectory = null)
         {
             this.outputDirectory = outputDirectory;
+            this.aspectjOutputDirectory = aspectjOutputDirectory;
         }
 
         public void WriteMessage(string msg, SeverityKind severity)
@@ -41,8 +43,13 @@ namespace Plang.Compiler
 
         public void WriteFile(CompiledFile file)
         {
-            string outputPath = Path.Combine(outputDirectory.FullName, file.FileName);
-            File.WriteAllText(outputPath, file.Contents);
+            if (Path.GetExtension(file.FileName) == ".aj"){
+                string outputPath = Path.Combine(aspectjOutputDirectory.FullName, file.FileName);
+                File.WriteAllText(outputPath, file.Contents);
+            } else {
+                string outputPath = Path.Combine(outputDirectory.FullName, file.FileName);
+                File.WriteAllText(outputPath, file.Contents);
+            }
         }
 
         public void WriteError(string msg)

--- a/Src/PCompiler/CompilerCore/ICompilationJob.cs
+++ b/Src/PCompiler/CompilerCore/ICompilationJob.cs
@@ -13,6 +13,7 @@ namespace Plang.Compiler
         CompilerOutput OutputLanguage { get; }
         ICompilerOutput Output { get; }
         DirectoryInfo OutputDirectory { get; }
+        DirectoryInfo AspectjOutputDirectory { get; }
         ICodeGenerator Backend { get; }
         IReadOnlyList<FileInfo> InputFiles { get; }
         IReadOnlyList<string> ProjectDependencies { get; }


### PR DESCRIPTION
1. Instead of generating AspectJ template file, it outputs BaseAspect that a user does not need to modify
2. P compiler takes "-aspectOutputDir" argument to output all aspectj files into this directory
3. BaseAspect file implements the `@MonitorOn` annotation and short aliases of event handler calls