### PR TITLE
Modify equals() in EnumValue to handle duplicated enum types

### DIFF
--- a/Src/PRuntimes/RvmRuntime/src/main/java/p/runtime/values/EnumValue.java
+++ b/Src/PRuntimes/RvmRuntime/src/main/java/p/runtime/values/EnumValue.java
@@ -1,7 +1,7 @@
 /* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. */
 package p.runtime.values;
 
-public class EnumValue<T> implements IValue<EnumValue<T>> {
+public class EnumValue<T extends java.lang.Enum> implements IValue<EnumValue<T>> {
     private T value;
 
     public EnumValue(T value) {
@@ -27,6 +27,12 @@ public class EnumValue<T> implements IValue<EnumValue<T>> {
         }
 
         EnumValue<?> other = (EnumValue) obj;
+        if (!value.getClass().equals(other.value.getClass())){
+            if (!value.getClass().getSimpleName().equals(other.value.getClass().getSimpleName())) {
+                return false;
+            }
+            return this.value.ordinal() == other.value.ordinal();
+        }
         return this.value.equals(other.value);
     }
 


### PR DESCRIPTION
Modify equals() in EnumValue so that duplicated enum types from different places can be compared if they have the same enum name