### PR TITLE
Fix typos in the Language Manual

### DIFF
--- a/Docs/docs/manual/datatypes.md
+++ b/Docs/docs/manual/datatypes.md
@@ -161,9 +161,9 @@ namedTupleEx.x1 = namedTupleEx.x1 + namedTupleEx.x3;
 
 !!! note "Note"
     Tuple and Named tuple types are disjoint, i.e., a tuple of type `(int,
-    bool, int)` cannot to assigned to a variable of tuple `(x1: int, x2: bool, x3: int)`
+    bool, int)` cannot be assigned to a variable of tuple `(x1: int, x2: bool, x3: int)`
     though the elements of the tuple have same types (and vice versa). And similarly, a named
-    tuple of type `(x1: int, x2: bool, x3: int)` cannot to assigned to a variable of tuple
+    tuple of type `(x1: int, x2: bool, x3: int)` cannot be assigned to a variable of tuple
     `(y1: int, y2: bool, y3: int)` they are two distinct types.
 
 ### Collection
@@ -263,7 +263,7 @@ initialized to their default values.
     | string                         | ""                                                                 |
     | event                          | null                                                               |
     | machine                        | null                                                               |
-    | enum                           | element of the enum with lowest (int) value                        |
+    | enum                           | Element of the enum with lowest (int) value                        |
     | Record (tuple or named tuple)  | Each field in the record type is initialized to its default value. |
     | Collection (set, seq, and map) | Empty collection                                                   |
     | Foreign                        | null                                                               |

--- a/Docs/docs/manual/events.md
+++ b/Docs/docs/manual/events.md
@@ -8,11 +8,11 @@ An event in P has two parts, an event name and a payload value (optional) that c
         | event iden (: type)?;     # P Event Declaration
     ```
 
-    `iden` is the name of the event and `type` is any P data type ([decribed here](datatypes.md)).
+    `iden` is the name of the event and `type` is any P data type ([described here](datatypes.md)).
 
 **Syntax:** `event eName;` or `event eName : payloadType;`
 
-`eName` is the name of the P event and `payloadType` is the type of payload values that can sent along with this event.
+`eName` is the name of the P event and `payloadType` is the type of payload values that can be sent along with this event.
 
 === "Event Declarations"
 

--- a/Docs/docs/manual/expressions.md
+++ b/Docs/docs/manual/expressions.md
@@ -173,7 +173,7 @@ P supports three collection types: `map`, `seq`, and `set`. We can index into th
 
 **Syntax:** `expr_c[expr_i]` 
 
-If `expr_c` is a value of sequence type then `expr_i` must be an integer expression and `expr_c[expr_i]` represents the element at index `expr_i`. Similarly, If `expr_c` is a value of set type then `expr_i` must be an integer expression and `expr_c[expr_i]` represents the element at index `expr_i` but not that for a set there is no guarantee for the order in which elements are stored in the set.
+If `expr_c` is a value of sequence type then `expr_i` must be an integer expression and `expr_c[expr_i]` represents the element at index `expr_i`. Similarly, If `expr_c` is a value of set type then `expr_i` must be an integer expression and `expr_c[expr_i]` represents the element at index `expr_i` but note that for a set there is no guarantee for the order in which elements are stored in the set.
 Finally, if `expr_c` is a value of map type then `expr_i` represents the key to look up and `expr_c[expr_i]` represents the value for the key `expr_i`.
 
 ### Operations on Collections
@@ -182,7 +182,7 @@ P supports four other operations on collection types:
 
 #### sizeof
 
-**Syntax:**: `sizeof(expr)` where `expr` is a value of type `set`, `seq` or `map` and it returns an integer value representing the size or length of the collection.
+**Syntax:**: `sizeof(expr)`, where `expr` is a value of type `set`, `seq` or `map`, returns an integer value representing the size or length of the collection.
 
 ``` java
 var sq: seq[int];
@@ -232,7 +232,7 @@ New expression is used to create an instance of a machine, `new` returns a machi
 
 **Syntax**: `new iden (rvalue?) ;`
 
-`iden` is the name of the machine to be create and `rvalue` is the optional constructor parameter that becomes the input parameter of the entry function of the start state of the machine.
+`iden` is the name of the machine to be created and `rvalue` is the optional constructor parameter that becomes the input parameter of the entry function of the start state of the machine.
 
 === "Create a machine"
 
@@ -262,7 +262,7 @@ Function calls in P are similar to any other imperative programming languages.
 
 ### Negation and Not
 
-P supports two unary operations: `-` on integers and floats values (i.e., negation) and `!` on boolean values(i.e., logical not).
+P supports two unary operations: `-` on integers and floats values (i.e., negation) and `!` on boolean values (i.e., logical not).
 
 ### Arithmetic
 
@@ -270,7 +270,7 @@ P supports the following arithmetic binary operations on integers or floats: `+`
 
 ### Comparison
 
-P supports the following comparison binary operations on integers or floats: `<` (i.e., less-than), `<=` (i.e., less-than-equal), `>` (i.e., greator-than), and `>=` (i.e., greator-than-equal).
+P supports the following comparison binary operations on integers or floats: `<` (i.e., less-than), `<=` (i.e., less-than-equal), `>` (i.e., greater-than), and `>=` (i.e., greater-than-equal).
 
 ### Cast
 

--- a/Docs/docs/manual/modulesystem.md
+++ b/Docs/docs/manual/modulesystem.md
@@ -1,9 +1,9 @@
 The P module system allows programmers to decompose their complex system into modules to
 implement and test the system compositionally. More details about the underlying theory
-for the P module system (assume-guarantee style compositional reasoning) is described in
+for the P module system (assume-guarantee style compositional reasoning) are described in
 the [paper](https://ankushdesai.github.io/assets/papers/modp.pdf)
 
-In its simplest form, a module in P is a collection of state machines. The P module system allows constructing larger modules by composing or unioning modules together. Hence, a distributed system under test which is a composition of multiple components together can be constructed by composing (or unioning) modules corresponding to those components. The [P test cases](testcases.md) takes as input a module that represents the **closed**[^1] system to be validated which is the union or composition of all the component modules.
+In its simplest form, a module in P is a collection of state machines. The P module system allows constructing larger modules by composing or unioning modules together. Hence, a distributed system under test which is a composition of multiple components together can be constructed by composing (or unioning) modules corresponding to those components. The [P test cases](testcases.md) take as input a module that represents the **closed**[^1] system to be validated which is the union or composition of all the component modules.
 
 [^1]: A closed system is a system where all the machines or interfaces that are created are defined or implemented in the unioned modules.
 
@@ -44,7 +44,7 @@ A named module declaration simply assigns a name to a module expression.
 
 ### Primitive Module
 
-A primitive module is a (annonymous) collection of state machines.
+A primitive module is a (anonymous) collection of state machines.
 
 **Syntax**: `{ bindExpr (, bindExpr)* }`
 
@@ -69,7 +69,7 @@ In most cases, a primitive module is simply a list of state machines that togeth
     module server = { Server, Timer };
     module serverAbs = {Server -> AbstractServer, Timer};
     ```
-    `client` is a primitive module consisting of the `Client` machine and the `server` module is a primitive module consistency of machines `Server` and `Timer`. The module `serverAbs` represents a primitive module consistency of machines `AbstractServer` and `Timer` machines with the difference that wherever the `serverAbs` module is used the creation of machine `Server` will in turn lead to creation of the `AbstractServer` machine.
+    `client` is a primitive module consisting of the `Client` machine and the `server` module is a primitive module consisting of machines `Server` and `Timer`. The module `serverAbs` represents a primitive module consisting of machines `AbstractServer` and `Timer` machines with the difference that wherever the `serverAbs` module is used the creation of machine `Server` will in turn lead to creation of the `AbstractServer` machine.
 
 ### Union Module
 

--- a/Docs/docs/manual/monitors.md
+++ b/Docs/docs/manual/monitors.md
@@ -6,11 +6,11 @@ assert the desired correctness specifications based on these observations.
 
     Syntactically, machines and spec machines in P **are very similar in terms of the state machine structure**. But, they have some key differences:
 
-    - `spec` machines in P are **observer machines** (imagine runtime monitors), they observe a set of events in the execution of the system and based on these observed events (may keep track on local state) it asserts the desired global safety and liveness specifications.
+    - `spec` machines in P are **observer machines** (imagine runtime monitors), they observe a set of events in the execution of the system and based on these observed events (may keep track on local state) assert the desired global safety and liveness specifications.
     - Since `spec` machines are observer machines, they **cannot have any side effects** on the system behavior and hence, `spec` machines cannot perform `send`, `receive`, `new`, and `annouce`.
     - `spec` machines are **global machines**, in other words, there is only a single instance of each monitor created at the start of the execution of the system. We currently do not support dynamic creation of monitors. Hence, `spec` machines cannot use `this` expression.
-    - `spec` machines are **synchronously composed** with the system that it is monitoring. The way this is acheived is: each time there is a `send` or `announce` of an event during the execution of a system, all the monitors or specifications that are observing that event are executed synchronously at that point. Another way to imagine this is: just before `send` or `annouce` of an event, we deliver this event to all the monitors that are observing the event and **synchronously** execute the monitor at that point.
-    - Finally, `spec` machines can have `hot` and `cold` annotations on its states to model liveness specifiations.
+    - `spec` machines are **synchronously composed** with the system that it is monitored. The way this is achieved is: each time there is a `send` or `announce` of an event during the execution of a system, all the monitors or specifications that are observing that event are executed synchronously at that point. Another way to imagine this is: just before `send` or `annouce` of an event, we deliver this event to all the monitors that are observing the event and **synchronously** execute the monitor at that point.
+    - Finally, `spec` machines can have `hot` and `cold` annotations on their states to model liveness specifications.
 
 ???+ note "P Spec Machine Grammar"
 
@@ -43,7 +43,7 @@ assert the desired correctness specifications based on these observations.
         }
     }
     ```
-    The above specifications checks a very simple global invariant that all `eRequest` events that are being sent by clients in the system have a globally monotonically increasing `rId`s.
+    The above specification checks a very simple global invariant that all `eRequest` events that are being sent by clients in the system have a globally monotonically increasing `rId`.
 
 === "Liveness specification"
 

--- a/Docs/docs/manual/statements.md
+++ b/Docs/docs/manual/statements.md
@@ -236,7 +236,7 @@ Note that because of value semantics assignment in P copies the value of the `rv
     a = b; // copy value
     a += (1, "a");
     print a; // will print ["b", "a"]
-    print b; // will print ["a"]
+    print b; // will print ["b"]
     ```
 
 === "Assignments .."

--- a/Docs/docs/manualoutline.md
+++ b/Docs/docs/manualoutline.md
@@ -6,7 +6,7 @@
 
     ```
     topDecl:                # Top-level P Program Declarations
-    | typeDefDecl           # UserDefinedTypeDeclaration
+    | typeDecl              # UserDefinedTypeDeclaration
     | enumTypeDecl          # EnumTypeDeclaration
     | eventDecl             # EventDeclaration
     | machineDecl           # MachineDeclaration
@@ -27,8 +27,8 @@ A P program consists of a collection of following top-level declarations:
 | [State Machines](manual/statemachines.md)    | P state machines are used to model or implement the behavior of the system                                                              |
 | [Specification Monitors](manual/monitors.md) | P specification monitors are used to write the safety and liveness specifications the system must satisfy for correctness               |
 | [Global Functions](manual/functions.md)      | P supports declaring global functions that can be shared across state machines and spec monitors                                        |
-| [Module System](manual/modulesystem.md)      | P supports a module system for implementing and testing the system modularly by dividing them into separate components                  |
-| [Test Cases](manual/testcases.md)            | P test cases helps programmers to write different finite scenarios under which they would like to check the correctness of their system |
+| [Module System](manual/modulesystem.md)      | P supports a module system for implementing and testing the system modularly by dividing it into separate components                  |
+| [Test Cases](manual/testcases.md)            | P test cases help programmers to write different finite scenarios under which they would like to check the correctness of their system |
 
 !!! Tip "Models, Specifications, Model Checking Scenario"  
     A quick primer on what a model


### PR DESCRIPTION
Spotted these while reading, hope it helps :)

- In P top-level grammar, changed 'TypeDefDecl' to 'TypeDecl' to be consistent
with the syntax given for the type declarations in datatypes.md
- In description of type declarations Module System, changed 'them' to 'it' as
it seems to be that the pronoun refers to "system".
- 'helps' -> 'help'
- In datatypes.md, 'cannot to assigned to' -> 'cannot be...'
- In monitors.md, 'it asserts' -> 'assert' as it seems to me that the sentence
is talking about 'spec machines'; and few more similar typos.
- In statements.md, b should print ["b"] (not "a").
- And a few more similar ones :)