### PR TITLE
Fix command in Debugging Error Traces page

### DIFF
--- a/Docs/docs/advanced/debuggingerror.md
+++ b/Docs/docs/advanced/debuggingerror.md
@@ -8,7 +8,7 @@ pmc <Path>/ClientServer.dll \
 
 ??? info "Expected Output"
     ``` hl_lines="9 11 12 15"
-    pmc <Path>/ClientServer.dll -m PImplementation.multipleClientsServer.Execute -i 100
+    pmc <Path>/ClientServer.dll -m PImplementation.tcSingleClientAbstractServer.Execute -i 100
 
     . Testing <Path>/ClientServer.dll
     ... Method PImplementation.tcSingleClientAbstractServer.Execute


### PR DESCRIPTION
The command that was copied in the Expected Output box did not
actually match with the error trace and with the command reported
above.