### PR TITLE
More specific error on a `goto` argument arity mismatch

### DIFF
--- a/Src/PCompiler/CompilerCore/DefaultTranslationErrorHandler.cs
+++ b/Src/PCompiler/CompilerCore/DefaultTranslationErrorHandler.cs
@@ -58,7 +58,7 @@ namespace Plang.Compiler
         public Exception IncorrectArgumentCount(ParserRuleContext location, int actualCount, int expectedCount)
         {
             return IssueError(location,
-                $"function or constructor call expected {expectedCount} arguments, got {actualCount}");
+                $"goto, function or constructor call expected {expectedCount} arguments, got {actualCount}");
         }
 
         public Exception MissingDeclaration(ParserRuleContext location, string declarationKind, string missingName)

--- a/Src/PCompiler/CompilerCore/TypeChecker/StatementVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/StatementVisitor.cs
@@ -420,6 +420,12 @@ namespace Plang.Compiler.TypeChecker
                 state.Entry?.Signature.ParameterTypes.ElementAtOrDefault(0) ?? PrimitiveType.Null;
             IPExpr[] rvaluesList = TypeCheckingUtils.VisitRvalueList(context.rvalueList(), exprVisitor).ToArray();
 
+            int expectedArgs = state.Entry?.Signature.Parameters.Count() ?? 0;
+            if (rvaluesList.Length != expectedArgs)
+            {
+                throw handler.IncorrectArgumentCount(context, rvaluesList.Length, expectedArgs);
+            }
+
             IPExpr payload;
             if (rvaluesList.Length == 0)
             {


### PR DESCRIPTION
Currently, if a `goto` is used with an incorrect number of arguments, the typechecker reports a type mismatch.  For instance, consider the following program:

```
  1 machine Node
  2 {
  3   start state Init {
  4   entry
  5     {
  6       goto NewState; // Missing an argument!
  7     }
  8   }
  9
 10   state NewState {
 11     entry (arg: int) {
 12       print format ("Transitioned to NewState with {0}", arg);
 13     }
 14   }
 15 }
```

Presently the error on line 6 is: `got type: (), expected: Node`. This is confusing for two reasons: the user didn't explicitly construct the empty tuple (it's a second-order effect of not passing arguments to the state transition), and because `NewState::entry` expects a single argument (which gets collapsed to a scalar value in `VisitGotoStmt()`), there's no indication that there's actually "a sequence of things" that _should_ be assigned to.

I think the better error here is to report the incorrect number of arguments. This patch simply explicitly checks the number of expected vs actual parameters and raises a more specific exception in the case where they do not. Concretely, the new error is: `[PSrc/ArityBug.p:6:7] goto, function or constructor call expected 1 arguments, got 0`.  (It would be nice if this could be done entirely within `isAssignableFrom`, but because that simply returns a Boolean we don't know exactly _why_ one isn't assignable to the other; we lose whether it's an arity issue or a subtyping one, etc.  Fixing this would be slightly more invasive and I'm not sure if you think it's worth doing but I could take a crack at it if you like.)

This branch builds and passes tests per CONTRIBUTING.md.