### PR TITLE
[Rvm] reuse same Python interpreter for spawned tests

### DIFF
--- a/Tst/RegressionTests/Rvm/run_all_examples.py
+++ b/Tst/RegressionTests/Rvm/run_all_examples.py
@@ -26,7 +26,7 @@ def getTests():
 def buildCommand(test_root, temporary_directory, test_name):
   """ Builds the command to run an "example" test.
   """
-  return [ "python"
+  return [ sys.executable
       , os.path.join(test_root, test_name, "run_test.py")
       , test_name
       , temporary_directory

--- a/Tst/RegressionTests/Rvm/run_all_unittests.py
+++ b/Tst/RegressionTests/Rvm/run_all_unittests.py
@@ -26,7 +26,7 @@ def getTests():
 def buildCommand(script_directory, temporary_directory, test_name):
   """ Builds the command to run a unit test.
   """
-  return [ "python"
+  return [ sys.executable
       , os.path.join(script_directory, "run_unittest.py")
       , test_name
       , temporary_directory


### PR DESCRIPTION
Currently, the RVM test suite hard-codes the name of the Python interpreter to
be `python`, which is then looked up in the users' PATH of course.  However,
on stock OSX there is no longer a `python`, only a `python3`.  This means the
shabang is broken on OSX:

```
nathta@bcd0741cf59d Rvm % ./run_all_examples.py
env: python: No such file or directory
nathta@bcd0741cf59d Rvm %
```

If the user specifies a different interpeter manually, the test runner fails
because subprocesses spawned make the same assumption:

```
nathta@bcd0741cf59d Rvm % python3 ./run_all_examples.py
...
FileNotFoundError: [Errno 2] No such file or directory: 'python'
nathta@bcd0741cf59d Rvm %
```

This commit simply changes the subprocess interpreter to be the same as the
parent one.  After this patch, if I specify a particular Python interpreter when
I start the test runner, that interpreter is used consistently.

```
nathta@bcd0741cf59d Rvm % python3 run_all_examples.py
====== Temporary directory: /var/folders/rr/zh4gr2jd189g53hgtgry9vkr0000gr/T/tmp1ut_g2ig
Starting: getconsistency
Starting: twophasecommit
...
```

I did not touch the shabang or anything in the Maven files because I don't know what the right
thing to do here is: if we're expecting these tests to run in environments
without a `python3` on the path, then we've solved one problem and then created
another.