### PR TITLE
[Tutorial] minor fix in BankBalanceCorrect.p assert message

### DIFF
--- a/Tutorial/1_ClientServer/PSpec/BankBalanceCorrect.p
+++ b/Tutorial/1_ClientServer/PSpec/BankBalanceCorrect.p
@@ -66,7 +66,7 @@ spec BankBalanceIsAlwaysCorrect observes eWithDrawReq,  eWithDrawResp, eSpec_Ban
       {
         assert resp.balance == bankBalance[resp.accountId] - pendingWithDraws[resp.rId].amount,
           format ("Bank balance for the account {0} is {1} and not the expected value {2}, Bank is lying!",
-            resp.accountId, resp.balance, bankBalance[resp.accountId]);
+            resp.accountId, resp.balance, bankBalance[resp.accountId] - pendingWithDraws[resp.rId].amount);
         // update the new account balance
         bankBalance[resp.accountId] = resp.balance;
       }


### PR DESCRIPTION
Currently, on processing a WithDrawResp, if the new balance from the bank
doesn't match what the spec expects, we print out our balance, not the balance
with the withdraw applied to it.  Concretely, consider the following
events:

```
eInit( { 100: 42, 101: 10 } )
eWithDrawReq(Client: 1, accountId: 100, amount: 10, rId: 0)
eWithDrawResp(status: WITHDRAW_SUCCESS, accountId: 100, balance: 1000, rId: 0)
```

Note that the "balance" field is described as "`balance`: bank balance after withdrawal".
Clearly this should violate the spec: withdrawing 10 from a balance of 42
should yield a new balance of 32, not 1000!  However, the assert message
states,

```
Transitioning to Init
DEBUG: In prt.State[Init]: processing event pEvent eSpec_BankBalanceIsAlwaysCorrect_Init[payload={100=42, 101=10}]
Transitioning to WaitForWithDrawReqAndResp
DEBUG: In prt.State[WaitForWithDrawReqAndResp]: processing event pEvent eWithDrawReq[payload={accountId=100, amount=10, rId=0, Client=1}]
DEBUG: In prt.State[WaitForWithDrawReqAndResp]: processing event pEvent eWithDrawResp[payload={accountId=100, rId=0, balance=1000, status=0}]

prt.PAssertionFailureException: Assertion failure: Bank balance for the account 100 is 1,000 and not the expected value 42, Bank is lying!
```

This patch modifies the assert statement to simply reflect the RHS of the
equality asserted.  The error now reads:

```
Transitioning to Init
DEBUG: In prt.State[Init]: processing event pEvent eSpec_BankBalanceIsAlwaysCorrect_Init[payload={100=42, 101=10}]
Transitioning to WaitForWithDrawReqAndResp
DEBUG: In prt.State[WaitForWithDrawReqAndResp]: processing event pEvent eWithDrawReq[payload={accountId=100, amount=10, Client=1, rId=0}]
DEBUG: In prt.State[WaitForWithDrawReqAndResp]: processing event pEvent eWithDrawResp[payload={accountId=100, balance=1000, rId=0, status=0}]

prt.PAssertionFailureException: Assertion failure: Bank balance for the account 100 is 1,000 and not the expected value 32, Bank is lying!
```