### PR TITLE
[PSymbolicRuntime] Bump dependency versions

### DIFF
--- a/Src/PRuntimes/PSymbolicRuntime/build.gradle
+++ b/Src/PRuntimes/PSymbolicRuntime/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'p.runtime:PJavaRuntime:1.0.0'
     implementation 'org.reflections:reflections:0.9.12'
-    implementation 'log4j:log4j:1.2.12'
+    Implementation 'org.apache.logging.log4j:log4j-1.2-api:2.17.2'
     implementation 'org.apache.logging.log4j:log4j-core:2.13.2'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.0'
     implementation 'backport-util-concurrent:backport-util-concurrent:3.1'

--- a/Src/PRuntimes/PSymbolicRuntime/build.gradle
+++ b/Src/PRuntimes/PSymbolicRuntime/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
     implementation 'org.jooq:joor:0.9.12'
     implementation 'org.jetbrains:annotations:17.0.0'
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:30.0-jre'
     implementation 'p.runtime:PJavaRuntime:1.0.0'
     implementation 'org.reflections:reflections:0.9.12'
     Implementation 'org.apache.logging.log4j:log4j-1.2-api:2.17.2'

--- a/Src/PRuntimes/PSymbolicRuntime/pom.xml
+++ b/Src/PRuntimes/PSymbolicRuntime/pom.xml
@@ -267,9 +267,9 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.17.2</version>
     </dependency>
 
     <dependency>

--- a/Src/PRuntimes/PSymbolicRuntime/pom.xml
+++ b/Src/PRuntimes/PSymbolicRuntime/pom.xml
@@ -242,7 +242,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>30.0-jre</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->


### PR DESCRIPTION
Swap out Log4J 1.x dependency with the Log4j1-2 adaptor instead and upgrade guava to 30.0.

Tested with the `./build.sh` script in `Src/PRuntimes/PSymbolicRuntime/scripts`.