### PR TITLE
[TypeChecker] Accumulate all tuple types into Scope

### DIFF
--- a/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
@@ -5,6 +5,7 @@ using Plang.Compiler.TypeChecker.AST.States;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Plang.Compiler.TypeChecker.Types;
 
 namespace Plang.Compiler.TypeChecker
 {
@@ -27,6 +28,7 @@ namespace Plang.Compiler.TypeChecker
         private readonly IDictionary<string, RefinementTest> refinementTests = new Dictionary<string, RefinementTest>();
         private readonly IDictionary<string, SafetyTest> safetyTests = new Dictionary<string, SafetyTest>();
         private readonly IDictionary<string, State> states = new Dictionary<string, State>();
+        private readonly IDictionary<string, NamedTupleType> tuples = new Dictionary<string, NamedTupleType>();
         private readonly IDictionary<string, TypeDef> typedefs = new Dictionary<string, TypeDef>();
         private readonly IDictionary<string, Variable> variables = new Dictionary<string, Variable>();
 
@@ -70,6 +72,7 @@ namespace Plang.Compiler.TypeChecker
         public IEnumerable<Interface> Interfaces => interfaces.Values;
         public IEnumerable<Machine> Machines => machines.Values;
         public IEnumerable<State> States => states.Values;
+        public IEnumerable<NamedTupleType> Tuples => tuples.Values;
         public IEnumerable<TypeDef> Typedefs => typedefs.Values;
         public IEnumerable<Variable> Variables => variables.Values;
         public IEnumerable<SafetyTest> SafetyTests => safetyTests.Values;
@@ -110,8 +113,24 @@ namespace Plang.Compiler.TypeChecker
             Debug.Assert(!implementations.Any());
             implementations.Add(defaultImplDecl.Name, defaultImplDecl);
         }
-
         #endregion Add Default Impl. Declaration
+        
+        #region Add Tuple Declaration
+        public bool AddTuple(TupleType tuple)
+        {
+            return AddTuple(tuple.ToNamedTuple());
+        }
+        public bool AddTuple(NamedTupleType tuple)
+        {
+            if (tuples.ContainsKey(tuple.CanonicalRepresentation))
+            {
+                return true;
+            }
+            tuples.Add(tuple.CanonicalRepresentation, tuple);
+            return false;
+        }
+
+        #endregion Add Tuple Declaration
 
         #region Overloaded getters
 
@@ -154,7 +173,7 @@ namespace Plang.Compiler.TypeChecker
         {
             return states.TryGetValue(name, out tree);
         }
-
+        
         public bool Get(string name, out TypeDef tree)
         {
             return typedefs.TryGetValue(name, out tree);

--- a/Src/PCompiler/CompilerCore/TypeChecker/TypeResolver.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/TypeResolver.cs
@@ -100,7 +100,9 @@ namespace Plang.Compiler.TypeChecker
 
             public override PLanguageType VisitTupleType(PParser.TupleTypeContext context)
             {
-                return new TupleType(context._tupTypes.Select(Visit).ToArray());
+                TupleType ret = new TupleType(context._tupTypes.Select(Visit).ToArray());
+                scope.AddTuple(ret);
+                return ret;
             }
 
             public override PLanguageType VisitNamedTupleType(PParser.NamedTupleTypeContext context)
@@ -122,7 +124,9 @@ namespace Plang.Compiler.TypeChecker
                     fields[i] = new NamedTupleEntry { Name = fieldName, FieldNo = i, Type = Visit(field.type()) };
                 }
 
-                return new NamedTupleType(fields);
+                NamedTupleType ret = new NamedTupleType(fields);
+                scope.AddTuple(ret);
+                return ret;
             }
 
             public override PLanguageType VisitPrimitiveType(PParser.PrimitiveTypeContext context)

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
@@ -17,6 +17,22 @@ namespace Plang.Compiler.TypeChecker.Types
                 : new Lazy<IReadOnlyList<PEvent>>(() => Types.SelectMany(t => t.AllowedPermissions.Value).ToList());
         }
 
+        // Lifts a TupleType into an equivalent NamedTupleType, where the names of each field are numbers
+        // starting from 0 (matching how non-NamedTuples are accessed in P and extracted code).
+        public NamedTupleType ToNamedTuple()
+        {
+            List<NamedTupleEntry> fields = Types.Select((t, i) =>
+            {
+                NamedTupleEntry e = new NamedTupleEntry();
+                e.Name = i.ToString();
+                e.FieldNo = i;
+                e.Type = t;
+                return e;
+            }).ToList();
+            
+            return new NamedTupleType(fields);
+        }
+
         public IReadOnlyList<PLanguageType> Types { get; }
 
         public override string OriginalRepresentation { get; }


### PR DESCRIPTION
This is part of the non-Java compiler work required to implement https://github.com/dijkstracula/prtsandbox/issues/12 .

Ankush, you might not like my choice of implementing `TupleType::ToNamedTupleType()`.  Let me know and we can iterate on that.