### PR TITLE
[TypeChecker] After TypeDef type resolution, stash tuples' name

### DIFF
--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -58,6 +58,19 @@ namespace Plang.Compiler.TypeChecker
             // (COLON type)?
             pEvent.PayloadType = ResolveType(context.type());
 
+            // For Tuple types, now that we have resolved the type of the typedef
+            // we set the tuple's type's name.
+            // TODO: this seems like the wrong place for this?
+            switch (pEvent.PayloadType)
+            {
+                case NamedTupleType nt:
+                    nt.TypeDefedName = pEvent.Name;
+                    break;
+                case TupleType tt:
+                    tt.TypeDefedName = pEvent.Name;
+                    break;
+            }
+            
             // SEMI 
             return pEvent;
         }
@@ -160,6 +173,20 @@ namespace Plang.Compiler.TypeChecker
             var typedef = (TypeDef) nodesToDeclarations.Get(context);
             // ASSIGN type 
             typedef.Type = ResolveType(context.type());
+           
+            // For Tuple types, now that we have resolved the type of the typedef
+            // we set the tuple's type's name.
+            // TODO: this seems like the wrong place for this?
+            switch (typedef.Type)
+            {
+                case NamedTupleType nt:
+                    nt.TypeDefedName = typedef.Name;
+                    break;
+                case TupleType tt:
+                    tt.TypeDefedName = typedef.Name;
+                    break;
+            }
+            
             // SEMI
             return typedef;
         }

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/NamedTupleType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/NamedTupleType.cs
@@ -7,6 +7,9 @@ namespace Plang.Compiler.TypeChecker.Types
 {
     public class NamedTupleType : PLanguageType
     {
+        // null if this type was not defined as part of a TypeDefDecl.
+        public string TypeDefedName { get; set; }
+        
         private readonly IDictionary<string, NamedTupleEntry> lookupTable;
 
         public NamedTupleType(IReadOnlyList<NamedTupleEntry> fields) : base(TypeKind.NamedTuple)

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
@@ -7,6 +7,9 @@ namespace Plang.Compiler.TypeChecker.Types
 {
     public class TupleType : PLanguageType
     {
+        // null if this type was not defined as part of a TypeDefDecl.
+        public string TypeDefedName { get; set; }
+        
         public TupleType(params PLanguageType[] types) : base(TypeKind.Tuple)
         {
             Types = new List<PLanguageType>(types);


### PR DESCRIPTION
This is needed to improve the ergonomics of generated payload classes.

I'm not sure DeclarationVisitor is the right place for this; it almost feels like it should live in a separate Visitor that walks the AST after the current DeclarationVisitor.  What do you think?