### PR TITLE
[TypeChecker] Stash typedefed identifier for tuples

### DIFF
--- a/Src/PCompiler/CompilerCore/TypeChecker/Analyzer.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Analyzer.cs
@@ -158,6 +158,7 @@ namespace Plang.Compiler.TypeChecker
             foreach (PParser.ProgramContext programUnit in programUnits)
             {
                 DeclarationVisitor.PopulateDeclarations(handler, globalScope, programUnit, nodesToDeclarations);
+                TupleDeclNameVisitor.HydrateTupleDecls(handler, globalScope, programUnit, nodesToDeclarations);
             }
 
             return globalScope;

--- a/Src/PCompiler/CompilerCore/TypeChecker/TupleDeclNameVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/TupleDeclNameVisitor.cs
@@ -1,0 +1,120 @@
+using System;
+using Antlr4.Runtime.Tree;
+using Plang.Compiler.TypeChecker.AST;
+using Plang.Compiler.TypeChecker.AST.Declarations;
+using Plang.Compiler.TypeChecker.Types;
+using Plang.Compiler.Util;
+
+namespace Plang.Compiler.TypeChecker
+{
+    public class TupleDeclNameVisitor : PParserBaseVisitor<object>
+    {
+        private readonly StackProperty<Machine> _currentMachine = new StackProperty<Machine>();
+        private readonly StackProperty<Scope> _currentScope;
+        private readonly ParseTreeProperty<IPDecl> _nodesToDeclarations;
+
+        private Scope CurrentScope => _currentScope.Value;
+        private Machine CurrentMachine => _currentMachine.Value;
+        private ITranslationErrorHandler Handler { get; }
+
+        private TupleDeclNameVisitor(
+            ITranslationErrorHandler handler,
+            Scope topLevelScope,
+            ParseTreeProperty<IPDecl> nodesToDeclarations)
+        {
+            Handler = handler;
+            _currentScope = new StackProperty<Scope>(topLevelScope);
+            _nodesToDeclarations = nodesToDeclarations;
+        }
+
+        /// <summary>
+        /// Once all declarations have been resolved by the DeclarationVisitor pass, we patch up any
+        /// tuple declarations that were declared in the context of a TypeDef[1] or an Event declaration[2].
+        ///
+        /// [1]: example: `type tTrans = (key: string, val: int, transId: int);`
+        /// [2]: example: `event eWriteTransReq : tWriteTransReq;`
+        /// </summary>
+        /// <param name="handler"></param>
+        /// <param name="topLevelScope"></param>
+        /// <param name="context"></param>
+        /// <param name="nodesToDeclarations"></param>
+        public static void HydrateTupleDecls(
+            ITranslationErrorHandler handler,
+            Scope topLevelScope,
+            PParser.ProgramContext context,
+            ParseTreeProperty<IPDecl> nodesToDeclarations)
+        {
+            var visitor = new TupleDeclNameVisitor(handler, topLevelScope, nodesToDeclarations);
+            visitor.Visit(context);
+        }
+
+        public override object VisitEventDecl(PParser.EventDeclContext context)
+        {
+            // EVENT name=Iden
+            var pEvent = (PEvent) _nodesToDeclarations.Get(context);
+
+            if (pEvent.PayloadType == null)
+            {
+                throw new Exception("pEvent.PayloadType is null (did DeclarationVisitor not run already?)");
+            }
+
+            // For Tuple types, now that we have resolved the type of the typedef
+            // we set the tuple's type's name.
+            if (pEvent.PayloadType is TypeDefType td)
+            {
+                switch (resolveTypeDefs(pEvent.PayloadType))
+                {
+                case NamedTupleType nt when nt.TypeDefedName == null:
+                    nt.TypeDefedName = td.TypeDefDecl.Name;
+                    break;
+                case TupleType tt when tt.TypeDefedName == null:
+                    tt.TypeDefedName = td.TypeDefDecl.Name;
+                    break;
+                }
+            }
+
+            // SEMI
+            return pEvent;
+        }
+
+
+        public override object VisitPTypeDef(PParser.PTypeDefContext context)
+        {
+            // TYPE name=iden
+            var typedef = (TypeDef) _nodesToDeclarations.Get(context);
+
+            // ASSIGN type
+            if (typedef.Type == null)
+            {
+                throw new Exception("typedef.Type is null (did DeclarationVisitor not run already?)");
+            }
+
+            // For Tuple types, now that we have resolved the type of the typedef
+            // we set the tuple's type's name.
+            PLanguageType resolved = resolveTypeDefs(typedef.Type);
+            switch (resolved)
+            {
+                case NamedTupleType nt when nt.TypeDefedName == null:
+                    nt.TypeDefedName = typedef.Name;
+                    break;
+                case TupleType tt when tt.TypeDefedName == null:
+                    tt.TypeDefedName = typedef.Name;
+                    break;
+            }
+
+            // SEMI
+            return typedef;
+        }
+
+        private PLanguageType resolveTypeDefs(PLanguageType decl)
+        {
+            PLanguageType curr = decl;
+            while (curr is TypeDefType td)
+            {
+                curr = td.TypeDefDecl.Type;
+            }
+
+            return curr;
+        }
+    }
+}

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/NamedTupleType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/NamedTupleType.cs
@@ -7,6 +7,9 @@ namespace Plang.Compiler.TypeChecker.Types
 {
     public class NamedTupleType : PLanguageType
     {
+        // null if this type was not defined as part of a TypeDefDecl.
+        public string TypeDefedName { get; set; }
+
         private readonly IDictionary<string, NamedTupleEntry> lookupTable;
 
         public NamedTupleType(IReadOnlyList<NamedTupleEntry> fields) : base(TypeKind.NamedTuple)

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
@@ -7,6 +7,9 @@ namespace Plang.Compiler.TypeChecker.Types
 {
     public class TupleType : PLanguageType
     {
+        // null if this type was not defined as part of a TypeDefDecl.
+        public string TypeDefedName { get; set; }
+        
         public TupleType(params PLanguageType[] types) : base(TypeKind.Tuple)
         {
             Types = new List<PLanguageType>(types);


### PR DESCRIPTION
This will help generate more descriptive class names for Tuples and NamedTuples.

There is a small issue here that I can't quite figure out, but maybe you have a sense:  This is able to successfully (with integration into Java extraction here: https://github.com/p-org/P/commit/0a4a94436ca7bb93f04d11eadc93c53f18820397 ) stash all the class names we want for the 2PC tutorial, _with the exception of the following one:

```
 35 /* Events used for communication between the coordinator and the participants */
 36 // event: prepare request for a transaction (coordinator to participant)
 37 event ePrepareReq: tPrepareReq;
 38 // event: prepare response for a transaction (participant to coodinator)
 39 event ePrepareResp: tPrepareResp;
...
 45 /* User Defined Types */
 46 // payload type associated with the `ePrepareReq` event
 47 type tPrepareReq = tTrans;
 48 // payload type assocated with the `ePrepareResp` event where `participant` is the participant machine
 49 // sending the response, `transId` is the transaction id, and `status` is the status of the prepare
 50 // request for that transaction.
 51 type tPrepareResp = (participant: Participant, transId: int, status: tTransStatus);
```

In these cases, the typedef _follows_ its use in the event declaration.  That should be fine as we are doing a separate pass over the AST.  However, while `ePrepareReq`'s payload is correctly determined to be `tTrans`, `ePrepareResp`'s TypeDefName field remains null at Java code extraction time.  

```java
309     record ePrepareReq(tPrepareReq payload) implements PObserveEvent.PEvent { }
310     record ePrepareResp(PTuple_participant_transId_status payload) implements PObserveEvent.PEvent { }
```
This is weird because I can set a breakpoint in `TupleDeclNameVisitor`'s node handlers and see `ePrepareResp` being handled correctly!  So I wonder if there's something goofy where we're inserting that declaration node in a map by key and then mutating it (hence changing the hashcode) or something?  I can't see exactly where that's happening but maybe there's some ANTLRism that I'm missing.

It'd be nice to sort this corner case out but hopefully the `PTuple_participant_transId_status` is at least somewhat-human readable.