### PR TITLE
[Java] Handle event handler reuse across multiple states

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -21,12 +21,12 @@ namespace Plang.Compiler.Backend.Java {
         private CompiledFile _source;
         private Scope _globalScope;
 
-        // In the C# and Rvm compilers, ANONs' function signatures are hard-coded to
+        // In the C# and Rvm compilers, event handlers' signatures are hard-coded to
         // be an abstract Event type.  However, our Java runtime takes advantage of the
-        // typechecker to be able to specify exactly _which_ subclass it is going to be
+        // typechecker to be able to specify exactly _which_ event it is going to be
         // handed.  This isn't something explicitly handed to us in the AST so we
         // accumulate it ourselves before proceeding with code generation.
-        private Dictionary<Function, PEvent> _argumentForAnon;
+        private Dictionary<Function, PEvent> _eventArgForFn;
 
         /// <summary>
         /// Generates Java code for a given compilation job.
@@ -44,7 +44,7 @@ namespace Plang.Compiler.Backend.Java {
             _source = new CompiledFile(_context.FileName);
             _globalScope = scope;
 
-            _argumentForAnon = GenerateAnonArgLookup();
+            _eventArgForFn = GenerateFunctionToArgMapping();
 
             WriteImports();
             WriteLine();
@@ -95,7 +95,7 @@ namespace Plang.Compiler.Backend.Java {
             return new List<CompiledFile> { _source };
         }
 
-        private Dictionary<Function, PEvent> GenerateAnonArgLookup()
+        private Dictionary<Function, PEvent> GenerateFunctionToArgMapping()
         {
             Dictionary<Function, PEvent> ret = new Dictionary<Function, PEvent>();
 
@@ -106,13 +106,24 @@ namespace Plang.Compiler.Backend.Java {
                 {
                     foreach (var (e, a) in s.AllEventHandlers)
                     {
+                        PEvent e2;
                         switch (a)
                         {
                             case EventDoAction da:
-                                ret.Add(da.Target, e);
+                                if (ret.TryGetValue(da.Target, out e2) && e != e2)
+                                {
+                                    throw new Exception(
+                                        $"Inconsistent argument type to {da.Target.Name}: seen both {e2.Name} and {e.Name}");
+                                }
+                                ret[da.Target] = e;
                                 break;
                             case EventGotoState { TransitionFunction: { } } gs:
-                                ret.Add(gs.TransitionFunction, e);
+                                if (ret.TryGetValue(gs.TransitionFunction, out e2) && e != e2)
+                                {
+                                    throw new Exception(
+                                        $"Inconsistent argument type to {gs.TransitionFunction.Name}: seen both {e2.Name} and {e.Name}");
+                                }
+                                ret[gs.TransitionFunction] = e;
                                 break;
                             case EventDefer _:
                                 goto default;
@@ -392,7 +403,7 @@ namespace Plang.Compiler.Backend.Java {
             string args;
             if (f.IsAnon)
             {
-                args = $"{_argumentForAnon[f].Name} pEvent";
+                args = $"{_eventArgForFn[f].Name} pEvent";
             }
             else
             {


### PR DESCRIPTION
The Java code generator accumulates the argument types for all Functions in
advance.  This allows us to emit a specific event type rather than an abstract
`PEvent` type for the function argument.  However, when mapping Functions
to their PEvent arguments, `.Add()` was used rather than direct dictionary
indexing.  The former throws an exception if a key already exists.  This is
problematic in the following example:

```
     1  type t = (a : seq[int]);
     2
     3  event ev : t;
     4
     5  spec foo observes ev {
     6
     7    fun Handler(req: t) {
     8
     9    }
    10
    11    start state Init {
    12      on ev do Handler;
    13    }
    14
    15    state Other {
    16      on ev do Handler;
    17    }
    18
    19  }
```

This is safe to do; the second assocation between `Handler` and `ev`
should be a no-op, but the current implementation would raise an exception.  

```
nathta@bcd0741cf59d /tmp % pcl -generate:java foo.p
----------------------------------------
....... includes p file: /private/tmp/foo.p
----------------------------------------
----------------------------------------
Parsing ..
Type checking ...
Code generation ....
<Internal Error>:
 An item with the same key has already been added. Key: Plang.Compiler.TypeChecker.AST.Declarations.Function
```

The following patch makes redundant insertions okay and compilation
is allowed to proceed.  This is safe because if the PEvent values were
different, the TypeChecker would have already complained with an error
of the form `got type: somethingElse, expected: t`.  (We explicitly check
The event types for safety and throw if they differ, however.).  The above
P code now generates the correct Java code:

```
 62         public foo() {
 63             super();
 64             addState(new State.Builder(INIT_STATE)
 65                 .isInitialState(true)
 66                 .withEvent(ev.class, this::Handler)
 67                 .build());
 68             addState(new State.Builder(OTHER_STATE)
 69                 .isInitialState(false)
 70                 .withEvent(ev.class, this::Handler)
 71                 .build());
 72         } // constructor
```