### PR TITLE
[Java] Emit per-field deep equality check

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -222,8 +222,16 @@ namespace Plang.Compiler.Backend.Java {
             WriteLine();
 
             // Deep equality predicate.
-            WriteLine($"public boolean deepEquals({tname} o2) {{");
-            WriteLine("return Values.deepEquals(this, o2);");
+            WriteLine($"public boolean deepEquals({tname} other) {{");
+            WriteLine("return (true");
+            foreach (var (jType, fieldName) in fields)
+            {
+                Write(" && ");
+                WriteLine(jType.IsPrimitive
+                    ? $"this.{fieldName} == other.{fieldName}"
+                    : $"Values.deepEquals(this.{fieldName}, other.{fieldName})");
+            }
+            WriteLine(");");
             WriteLine("} // deepEquals()");
             WriteLine();
 
@@ -969,8 +977,6 @@ namespace Plang.Compiler.Backend.Java {
                     break;
             }
         }
-
-
 
         private void WriteStructureAccess(IPExpr e)
         {

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -221,6 +221,15 @@ namespace Plang.Compiler.Backend.Java {
             WriteLine("} // deepClone()");
             WriteLine();
 
+            // .equals() implementation: this simply defers to deepEquals() but explicitly overriding it is useful
+            // for calling assertEquals() in unit tests, for example.
+            WriteLine($"public boolean equals(Object other) {{");
+            WriteLine("return (this.getClass() == other.getClass() && ");
+            WriteLine($"this.deepEquals(({tname})other)");
+            WriteLine(");");
+            WriteLine("} // equals()");
+            WriteLine();
+
             // Deep equality predicate.
             WriteLine($"public boolean deepEquals({tname} other) {{");
             WriteLine("return (true");

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -176,7 +176,7 @@ namespace Plang.Compiler.Backend.Java {
 
             string tname = _context.Names.NameForNamedTuple(t);
             WriteLine($"// {t.CanonicalRepresentation}");
-            WriteLine($"static class {tname} implements Values.PTuple<{tname}> {{");
+            WriteLine($"public static class {tname} implements Values.PTuple<{tname}> {{");
 
             // Write the fields.
             foreach (var (jType, fieldName) in fields)
@@ -273,10 +273,10 @@ namespace Plang.Compiler.Backend.Java {
             {
                 case TypeManager.JType.JVoid _:
                     // Special-case an event with no payload: just emit an empty record.
-                    WriteLine($"record {eventName}() implements PObserveEvent.PEvent {{ }} ");
+                    WriteLine($"public record {eventName}() implements PObserveEvent.PEvent {{ }} ");
                     break;
                 default:
-                    WriteLine($"record {eventName}({argType.TypeName} payload) implements PObserveEvent.PEvent {{ }} ");
+                    WriteLine($"public record {eventName}({argType.TypeName} payload) implements PObserveEvent.PEvent {{ }} ");
                     break;
             }
 
@@ -291,7 +291,7 @@ namespace Plang.Compiler.Backend.Java {
         {
             string cname = _context.Names.GetNameForDecl(m);
 
-            WriteLine($"static class {cname} extends Monitor {{");
+            WriteLine($"public static class {cname} extends Monitor {{");
 
             // monitor fields
             foreach (var field in m.Fields)

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/BinOpType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/BinOpType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Plang.Compiler.TypeChecker.AST.Expressions
 {
     public enum BinOpType
@@ -15,5 +17,51 @@ namespace Plang.Compiler.TypeChecker.AST.Expressions
         Ge,
         And,
         Or
+    }
+
+    public enum BinOpKind
+    {
+        Boolean,
+        Comparison,
+        Equality,
+        Numeric
+    }
+
+    public static class BinOpExtensions
+    {
+        public static BinOpKind GetKind(this BinOpType op)
+        {
+            switch (op)
+            {
+                // Comparison operators
+                case BinOpType.Lt:
+                case BinOpType.Le:
+                case BinOpType.Ge:
+                case BinOpType.Gt:
+                    return BinOpKind.Comparison;
+
+                // Equality operators
+                case BinOpType.Neq:
+                case BinOpType.Eq:
+                    return BinOpKind.Equality;
+
+                // Arithmetic operators
+                case BinOpType.Add:
+                case BinOpType.Sub:
+                case BinOpType.Mul:
+                case BinOpType.Div:
+                case BinOpType.Mod:
+                    return BinOpKind.Numeric;
+
+                // Boolean operators:
+                case BinOpType.And:
+                case BinOpType.Or:
+                    return BinOpKind.Boolean;
+
+                // This should be dead code.
+                default:
+                    throw new NotImplementedException(op.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
Previously, a generated class `.deepEquals()` would simply call into `Values.deepEquals()`, which would in turn, in the runtime, call `Objects.deepEquals()`.  However, I misunderstood the semantics of Objects.deepEquals() so that wasn't the right thing, so a [patch](https://github.com/dijkstracula/prtsandbox/pull/26) went out to the Java runtime which manually switches on all the PRT types we expect.

For generated classes, though, we need to iterate through all the fields of the class and checking equality on each of them, so there is a compiler component here too.

Here's an example (notice that deepEquals calls are elided for primitive types):

```java
    // (key:string,val:int,transId:int)
    public static class PTuple_key_val_transId implements Values.PTuple<PTuple_key_val_transId> {
        public String key;
        public int val;
        public int transId;
...
        public boolean deepEquals(PTuple_key_val_transId other) {
            return (true
                    && Values.deepEquals(this.key, other.key)
                    && this.val == other.val
                    && this.transId == other.transId
            );
        } // deepEquals()
```

As a side-effect of this work, a bunch of BinOp and Clone generation functions got refactored.  This was overdue as I wasn't happy with them so going through a second pass was probably for the best.

This patch also includes a change that emits a `.equals()` (which just defers to .deepEquals() if the types match) - this isn't strictly needed for anything at runtime but helps writing unit tests that depend on calls to `assertEquals()`, for instance.

Lastly, this patch includes a change that makes nested generated classes more visible.  This work was previously done but somehow got lost in a merge or something.