### PR TITLE
[PCSharpRuntime] Log an escaped string representation of PrtValues

### DIFF
--- a/Src/PRuntimes/PCSharpRuntime/PLogFormatter.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PLogFormatter.cs
@@ -28,7 +28,7 @@ namespace Plang.CSharpRuntime
             }
             else
             {
-                var withPayload = ((PEvent)e).Payload == null ? "" : $" with payload ({((PEvent)e).Payload})";
+                var withPayload = ((PEvent)e).Payload == null ? "" : $" with payload ({((PEvent)e).Payload.ToEscapedString()})";
                 return $"{e.GetType().Name}{withPayload}";
             }
         }
@@ -78,7 +78,7 @@ namespace Plang.CSharpRuntime
         {
             base.OnWaitEvent(id, this.GetShortName(stateName), eventType);
         }
-        
+
         public override void OnMonitorStateTransition(string monitorType, string stateName, bool isEntry, bool? isInHotState)
         {
             if (stateName.Contains("__InitState__"))

--- a/Src/PRuntimes/PCSharpRuntime/Values/IPrtValue.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/IPrtValue.cs
@@ -5,5 +5,14 @@ namespace Plang.CSharpRuntime.Values
     public interface IPrtValue : IEquatable<IPrtValue>
     {
         IPrtValue Clone();
+
+        /// <summary>
+        /// Returns a string representation of this Value, such that strings are
+        /// escaped along with any necessary metacharacters.
+        /// </summary>
+        string ToEscapedString()
+        {
+            return ToString();
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtMap.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtMap.cs
@@ -193,5 +193,25 @@ namespace Plang.CSharpRuntime.Values
             sb.Append(")");
             return sb.ToString();
         }
+
+        public string ToEscapedString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("(");
+            string sep = "";
+            foreach (KeyValuePair<IPrtValue, IPrtValue> value in map)
+            {
+                sb.Append(sep);
+                sb.Append("<");
+                sb.Append(value.Key.ToEscapedString());
+                sb.Append("->");
+                sb.Append(value.Value.ToEscapedString());
+                sb.Append(">");
+                sep = ", ";
+            }
+
+            sb.Append(")");
+            return sb.ToString();
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtSeq.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtSeq.cs
@@ -146,5 +146,21 @@ namespace Plang.CSharpRuntime.Values
             sb.Append(")");
             return sb.ToString();
         }
+
+        public string ToEscapedString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("(");
+            string sep = "";
+            foreach (IPrtValue value in values)
+            {
+                sb.Append(sep);
+                sb.Append(value.ToEscapedString());
+                sep = ", ";
+            }
+
+            sb.Append(")");
+            return sb.ToString();
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs
@@ -116,7 +116,25 @@ namespace Plang.CSharpRuntime.Values
             sb.Append(")");
             return sb.ToString();
         }
-        
+
+        public string ToEscapedString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("(");
+            var sep = "";
+            foreach (var value in set)
+            {
+                sb.Append(sep);
+                sb.Append("<");
+                sb.Append(value.ToEscapedString());
+                sb.Append(">");
+                sep = ", ";
+            }
+
+            sb.Append(")");
+            return sb.ToString();
+        }
+
         public IPrtValue this[int index]
         {
             get => set.ElementAt(index);

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtString.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtString.cs
@@ -176,5 +176,15 @@ namespace Plang.CSharpRuntime.Values
         {
             return value;
         }
+
+        /// <summary>
+        /// Like ToString, but emits a representation of a string literal, surrounded by double-quotes,
+        /// and where all interior double-quotes are escaped.
+        /// </summary>
+        /// <returns></returns>
+        public string ToEscapedString()
+        {
+            return $"\"{value.Replace("\"", "\\\"")}\"";
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
@@ -194,5 +194,17 @@ namespace Plang.CSharpRuntime.Values
             retStr += ">";
             return retStr;
         }
+
+        public string ToEscapedString()
+        {
+            string retStr = "<";
+            for (int i = 0; i < fieldValues.Count; i++)
+            {
+                retStr += fieldNames[i] + ":" + fieldValues[i].ToEscapedString() + ", ";
+            }
+
+            retStr += ">";
+            return retStr;
+        }
     }
 }


### PR DESCRIPTION
This is an attempt to address https://github.com/p-org/P/issues/447 , but we
should think carefully about whether we've covered our bases on this.

Previously, the PLogFormatter would emit the direct string representation
of any PrtValues in an event payload.  This means that there could be ambiguity
owing to PrtStrings not being escaped.  For instance, the P statement

```
send f, ev, (s = "a:string, with:\"problems",);
```

Would yield a log line of the form:

```
<SendLog> 'PImplementation.Driver(2)' in state 'Init_1' sent event 'ev with payload (<s:a:string, with:"problems, >)' to 'Foo(3)'
```

Which is ambiguous in terms of what the NamedTuple arity is, and also
results in an unclosed string literal.

This patch introduces a variation on ToString(), called ToEscapedString(),
which ensures that problematic metacharacters are quoted, and PrtStrings
are themselves enclosed in double-quotes.  The above log line would now be

```
<SendLog> 'PImplementation.Driver(2)' in state 'Init_1' sent event 'ev with payload (<s:"a:string, with:\"problems", >)' to 'Foo(3)'.
```

This change could not be done as a modification of ToString(), since the P
runtime relies on a "naked" representation of the value.