### PR TITLE
Nathan/entry handler args

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -482,12 +482,26 @@ namespace Plang.Compiler.Backend.Java {
             WriteLine($"addState(new State.Builder({_context.Names.IdentForState(s)})");
             WriteLine($".isInitialState({TypeManager.JType.JBool.ToJavaLiteral(s.IsStart)})");
 
+            if (s.Entry != null)
+            {
+                WriteStateBuilderEntryHandler(s.Entry);
+            }
             foreach (var (e, a) in s.AllEventHandlers)
             {
                 WriteStateBuilderEventHandler(e, a);
             }
+            if (s.Exit != null)
+            {
+                WriteStateBuilderExitHandler(s.Exit);
+            }
 
             WriteLine(".build());");
+        }
+
+        private void WriteStateBuilderEntryHandler(Function f)
+        {
+            string fname = _context.Names.GetNameForDecl(f);
+            WriteLine($".withEntry(this::{fname})");
         }
 
         private void WriteStateBuilderEventHandler(PEvent e, IStateAction a)
@@ -542,6 +556,12 @@ namespace Plang.Compiler.Backend.Java {
                 default:
                     throw new NotImplementedException($"TODO: {a.GetType()} not implemented.");
             }
+        }
+
+        private void WriteStateBuilderExitHandler(Function f)
+        {
+            string fname = _context.Names.GetNameForDecl(f);
+            WriteLine($".withExit(this::{fname})");
         }
 
         private void WriteStmt(IPStmt stmt)

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -454,7 +454,7 @@ namespace Plang.Compiler.Backend.Java {
                             WriteLine($".withEvent({ename}.class, __ -> {{ {tname}(); gotoState({sname}); }})");
                             break;
                         case 1:
-                            WriteLine($".withEvent({ename}.class, e -> {{ {tname}(e); gotoState({sname}); }})");
+                            WriteLine($".withEvent({ename}.class, p -> {{ {tname}(p); gotoState({sname}); }})");
                             break;
                         default:
                             throw new Exception($"Unexpected {argcount}-arity for event handler for {ename}");


### PR DESCRIPTION
    Event handler functions consume a subclass of PEvent and then in the
    function body the payload is extracted.  However, non-nullary entry
    and exit handlers don't consume a PEvent but rather take a "payload"
    directly, so some infrastructure needed to be built up to accommodate
    those functions.

Following that, we now emit entry/exit handler function wiring (oops!)
