### PR TITLE
Java FFI

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/CompilationContext.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/CompilationContext.cs
@@ -20,6 +20,8 @@ namespace Plang.Compiler.Backend.Java
         public NameManager Names { get; }
         public TypeManager Types { get; }
 
+        public string GlobalFunctionClassName => "GlobalFunctions";
+
         //public IEnumerable<PLanguageType> UsedTypes => Names.UsedTypes;
 
         public string FileName { get; }

--- a/Src/PCompiler/CompilerCore/Backend/Java/CompilationContext.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/CompilationContext.cs
@@ -10,7 +10,7 @@ namespace Plang.Compiler.Backend.Java
         public CompilationContext(ICompilationJob job)
             : base(job)
         {
-            Names = new NameManager("PGEN_");
+            Names = new NameManager(job.ProjectName, "PGEN_");
             Types = new TypeManager(Names);
 
             FileName = $"{ProjectName}.java";
@@ -19,8 +19,6 @@ namespace Plang.Compiler.Backend.Java
 
         public NameManager Names { get; }
         public TypeManager Types { get; }
-
-        public string GlobalFunctionClassName => "GlobalFunctions";
 
         //public IEnumerable<PLanguageType> UsedTypes => Names.UsedTypes;
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -9,13 +9,14 @@ namespace Plang.Compiler.Backend.Java
     /// </summary>
     internal static class Constants
     {
-        private static string[] defaultImports = {
-            "com.amazon.pobserve.todo.Event",
-            "com.amazon.pobserve.todo.Monitor",
-            "com.amazon.pobserve.todo.State",
+        private static readonly string[] PrtImports = {
+            "events.PObserveEvent",
+            "prt.State",
+            "prt.Monitor",
+            "prt.Values"
         };
 
-        private static string[] jreDefaultImports =
+        private static readonly string[] JreDefaultImports =
         {
             "java.text.MessageFormat",
             "java.util.*",
@@ -28,9 +29,12 @@ namespace Plang.Compiler.Backend.Java
         /// <returns></returns>
         internal static IEnumerable<string> ImportStatements()
         {
-            return defaultImports
-                .Concat(jreDefaultImports)
-                .Select(pkg => $"import {pkg};");
+            List<string> classes = PrtImports
+                .Concat(JreDefaultImports)
+                .ToList();
+            classes.Sort();
+
+            return classes.Select(pkg => $"import {pkg};");
         }
 
         internal static string GlobalForeignFunClassName => "GlobalFFI";

--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -33,6 +33,7 @@ namespace Plang.Compiler.Backend.Java
                 .Select(pkg => $"import {pkg};");
         }
 
+        internal static string GlobalForeignFunClassName => "GlobalFFI";
 
         internal static string DoNotEditWarning => $@"
 /***************************************************************************

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -227,7 +227,7 @@ namespace Plang.Compiler.Backend.Java {
 
         private void WriteForeignType(ForeignType ft)
         {
-            WriteLine($"import {ft.CanonicalRepresentation};");
+            WriteLine($"// Ensure that {ft.CanonicalRepresentation}.class is on your classpath");
         }
 
         private void WriteEnumDecl(PEnum e)

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -19,6 +19,8 @@ namespace Plang.Compiler.Backend.Java {
         private CompiledFile _source;
         private Scope _globalScope;
 
+        private Machine _currentMachine; // Some generated code is machine-dependent, so stash the current machine here.
+
         /// <summary>
         /// Generates Java code for a given compilation job.
         ///
@@ -35,35 +37,52 @@ namespace Plang.Compiler.Backend.Java {
             _source = new CompiledFile(_context.FileName);
             _globalScope = scope;
 
-            WriteImports();
-            WriteLine();
-
             WriteLine(Constants.DoNotEditWarning);
             WriteLine();
 
+            WriteImports();
+            WriteLine();
+
+            foreach (var t in _globalScope.Typedefs)
+            {
+                if (t.Type is ForeignType foreignType)
+                {
+                    WriteForeignType(foreignType);
+                }
+            }
+            WriteLine();
 
             WriteLine($"public class {_context.FileName.Replace(".java", "")} {{");
 
-            WriteLine("/** Enums */");
-            foreach (var e in _globalScope.Enums)
+            if (_globalScope.Enums.Any())
             {
-                WriteEnumDecl(e);
+                WriteLine("/* Enums */");
+                foreach (var e in _globalScope.Enums)
+                {
+                    WriteEnumDecl(e);
+                }
+                WriteLine();
             }
-            WriteLine();
 
-            WriteLine("/** Tuples */");
-            foreach (var t in _globalScope.Tuples)
+            if (_globalScope.Tuples.Any())
             {
-                WriteNamedTupleDecl(t);
+                WriteLine("/* Tuples */");
+                foreach (var t in _globalScope.Tuples)
+                {
+                    WriteNamedTupleDecl(t);
+                }
+                WriteLine();
             }
-            WriteLine();
 
-            WriteLine("/** Events */");
-            foreach (var e in _globalScope.Events)
+            if (_globalScope.Events.Any())
             {
-                WriteEventDecl(e);
+                WriteLine("/* Events */");
+                foreach (var e in _globalScope.Events)
+                {
+                    WriteEventDecl(e);
+                }
+                WriteLine();
             }
-            WriteLine();
 
             //TODO: Do specs need interfaces?
 
@@ -203,6 +222,11 @@ namespace Plang.Compiler.Backend.Java {
             WriteLine();
         }
 
+        private void WriteForeignType(ForeignType ft)
+        {
+            WriteLine($"import {ft.CanonicalRepresentation};");
+        }
+
         private void WriteEnumDecl(PEnum e)
         {
             WriteLine($"public static class {e.Name} {{");
@@ -235,11 +259,24 @@ namespace Plang.Compiler.Backend.Java {
 
         private void WriteMachineDecl(Machine m)
         {
+            if (_currentMachine != null)
+            {
+                throw new Exception($"Already processing machine {_currentMachine.Name}");
+            }
+            _currentMachine = m;
+
             WriteLine($"// PMachine {m.Name} elided ");
+            _currentMachine = null;
         }
 
         private void WriteMonitorDecl(Machine m)
         {
+            if (_currentMachine != null)
+            {
+                throw new Exception($"Already processing machine {_currentMachine.Name}");
+            }
+            _currentMachine = m;
+
             string cname = _context.Names.GetNameForDecl(m);
 
             WriteLine($"public static class {cname} extends Monitor {{");
@@ -249,10 +286,9 @@ namespace Plang.Compiler.Backend.Java {
             {
                 TypeManager.JType type = _context.Types.JavaTypeFor(field.Type);
                 string name = _context.Names.GetNameForDecl(field);
-                string methodName = name[0].ToString().ToUpper() + name.Substring(1);
 
                 WriteLine($"private {type.TypeName} {name} = {type.DefaultValue};");
-                WriteLine($"public {type.TypeName} get{methodName}() {{ return this.{name}; }};");
+                WriteLine($"public {type.TypeName} get_{name}() {{ return this.{name}; }};");
                 WriteLine();
             }
             WriteLine();
@@ -275,8 +311,9 @@ namespace Plang.Compiler.Backend.Java {
             // constructor
             WriteMonitorCstr(m);
 
-
             WriteLine($"}} // {cname} monitor definition");
+
+            _currentMachine = null;
         }
 
 
@@ -284,23 +321,28 @@ namespace Plang.Compiler.Backend.Java {
         {
             if (f.IsForeign)
             {
-                WriteLine($"// Foreign function {f.Name} elided");
+                WriteLine($"// Ensure foreign function {f.Name} is on the classpath");
+                return;
             }
 
             if (f.CanReceive == true)
             {
                 WriteLine($"// Async function {f.Name} elided");
+                return;
             }
 
             WriteFunctionSignature(f); WriteLine(" {");
 
-            foreach (var decl in f.LocalVariables)
+            if (f.LocalVariables.Any())
             {
-                //TODO: for reference types the default value can simply be null; it will be reassigned later.
-                TypeManager.JType t = _context.Types.JavaTypeFor(decl.Type);
-                WriteLine($"{t.TypeName} {_context.Names.GetNameForDecl(decl)} = {t.DefaultValue};");
+                foreach (var decl in f.LocalVariables)
+                {
+                    //TODO: for reference types the default value can simply be null; it will be reassigned later.
+                    TypeManager.JType t = _context.Types.JavaTypeFor(decl.Type);
+                    WriteLine($"{t.TypeName} {_context.Names.GetNameForDecl(decl)} = {t.DefaultValue};");
+                }
+                WriteLine();
             }
-            WriteLine();
 
             foreach (var stmt in f.Body.Statements)
             {
@@ -713,14 +755,19 @@ namespace Plang.Compiler.Backend.Java {
 
         private void WriteFunctionCall(Function f, IEnumerable<IPExpr> args)
         {
-            if (f.Owner == null)
+            bool isStatic = f.Owner == null;
+            if (isStatic && !f.IsForeign)
             {
                 throw new NotImplementedException("StaticFunCallExpr is not implemented.");
             }
 
+            string ffiBridge = f.IsForeign ?
+                (isStatic
+                    ? Constants.GlobalForeignFunClassName
+                    : _context.Names.FFIBridgeForMachine(_currentMachine.Name)) + "." : "";
             string fname = _context.Names.GetNameForDecl(f);
 
-            Write($"{fname}(");
+            Write($"{ffiBridge}{fname}(");
             foreach (var (param, sep)in args.Select((p, i) => (p, i > 0 ? ", " : "")))
             {
                 Write(sep);

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCodeGenerator.cs
@@ -43,16 +43,19 @@ namespace Plang.Compiler.Backend.Java {
             WriteImports();
             WriteLine();
 
-            foreach (var t in _globalScope.Typedefs)
+            if (_globalScope.Typedefs.Any())
             {
-                if (t.Type is ForeignType foreignType)
+                foreach (var t in _globalScope.Typedefs)
                 {
-                    WriteForeignType(foreignType);
+                    if (t.Type is ForeignType foreignType)
+                    {
+                        WriteForeignType(foreignType);
+                    }
                 }
+                WriteLine();
             }
-            WriteLine();
 
-            WriteLine($"public class {_context.FileName.Replace(".java", "")} {{");
+            WriteLine($"public class {_context.ProjectName} {{");
 
             if (_globalScope.Enums.Any())
             {

--- a/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
@@ -79,5 +79,28 @@ namespace Plang.Compiler.Backend.Java
 
             return UniquifyName(name);
         }
+
+        /// <summary>
+        /// Produces the class name for the foreign function bridge class for a given machine.
+        ///
+        /// In the C# code generator, partial classes are used to automatically weave together
+        /// the machine class and its foreign functions.  For instance, a machine called Client
+        /// that relies on foreign functions would have the latter implemented in a partial class
+        /// also called Client.  The C# compiler would then merge the two together into a final
+        /// class definition.
+        ///
+        /// Java does not have this language feature, unfortunately, so we need a different approach:
+        /// we need foreign function writers to implement foreign functions as static methods
+        /// in a class whose name is derived from the monitor class.  The naming convention is
+        /// specified by the return value of this function.
+        ///
+        /// <see url="https://en.wikipedia.org/wiki/Bridge_pattern"/>
+        /// </summary>
+        /// <param name="machineName"></param>
+        /// <returns></returns>
+        public string FFIBridgeForMachine(string machineName)
+        {
+            return $"{machineName}FFI";
+        }
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
@@ -14,8 +14,11 @@ namespace Plang.Compiler.Backend.Java
         // Maps the NamedTuple to some generated Java class name;
         private readonly Dictionary<NamedTupleType, string> _namedTupleJTypes = new Dictionary<NamedTupleType, string>();
 
-        public NameManager(string namePrefix) : base(namePrefix)
+        public string TopLevelCName { get; }
+
+        public NameManager(string topLevelCName, string namePrefix) : base(namePrefix)
         {
+            TopLevelCName = topLevelCName;
         }
 
         /// <summary>
@@ -111,6 +114,15 @@ namespace Plang.Compiler.Backend.Java
             if (name.StartsWith("$"))
             {
                 name = "TMP_" + name.Substring(1);
+            }
+
+            // Handle the case where a declaration happens to match the name of the top level
+            // classname (which, as it isn't strictly a declaration in the grammar, doesn't
+            // pass through here)
+            if (name == TopLevelCName)
+            {
+                string cname = decl.GetType().ToString().Split(".").Last();
+                name = $"{name}_{cname}";
             }
 
             return UniquifyName(name);

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -26,7 +26,8 @@ namespace Plang.Compiler.Backend.Java
             /// <summary>
             /// The name of the Java class that corresponds to this type.
             /// </summary>
-            internal virtual string TypeName => "Object";
+            internal virtual string TypeName =>
+                throw new Exception($"TypeName not implemented for {this.GetType()}");
 
             /// <summary>
             /// The name of the Java class that corresponds to this type, should it be treated.
@@ -74,6 +75,18 @@ namespace Plang.Compiler.Backend.Java
             /// </summary>
             internal virtual string RemoveMethodName =>
                 throw new Exception($"RemoveMethodName not implemented for {this.TypeName}");
+
+            internal class JAny : JType
+            {
+                /// "PValue" is the interface in the Java runtime that requires deepClone() and deepEquals() to
+                /// be implemented.
+                internal override string TypeName => "PValue";
+                internal override bool IsPrimitive => false;
+
+                /// We don't know how to construct a value of this type and it might not have a nullary constructor.
+                /// TODO: how safe is this?  values.deepClone() and values.deepEqual() are null-safe, at least.
+                internal override string DefaultValue => "null";
+            }
 
             internal class JBool : JType
             {
@@ -232,7 +245,7 @@ namespace Plang.Compiler.Backend.Java
             internal class JForeign : JType
             {
                 /// <summary>
-                /// The name of the generated Java class name for this tuple.
+                /// The name of the Java class that this foreign type corresponds to.
                 /// </summary>
                 internal string JClassName { get; }
                 internal JForeign(string clazz)
@@ -350,7 +363,7 @@ namespace Plang.Compiler.Backend.Java
                     return new JType.JMachine();
 
                 case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Any):
-                    return new JType();
+                    return new JType.JAny();
 
                 case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Bool):
                     return new JType.JBool();

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -229,6 +229,25 @@ namespace Plang.Compiler.Backend.Java
                 internal override string TypeName => JClassName;
             }
 
+            internal class JForeign : JType
+            {
+                /// <summary>
+                /// The name of the generated Java class name for this tuple.
+                /// </summary>
+                internal string JClassName { get; }
+                internal JForeign(string clazz)
+                {
+                    JClassName = clazz;
+                }
+
+                internal override string TypeName => JClassName;
+                internal override bool IsPrimitive => false;
+
+                /// We don't know how to construct a value of this type and it might not have a nullary constructor.
+                /// TODO: how safe is this?  values.deepClone() and values.deepEqual() are null-safe, at least.
+                internal override string DefaultValue => "null";
+            }
+
             //TODO: not sure about this one.  Is the base class sufficient?
             //Generate some Java files and see.
             internal class JEvent : JType
@@ -309,10 +328,8 @@ namespace Plang.Compiler.Backend.Java
                 case EnumType _:
                     return new JType.JInt();
 
-                case ForeignType _:
-                    // return type.CanonicalRepresentation;
-                    // TODO: The above might be wrong for .NET -> Java extraction!
-                    throw new NotImplementedException($"{type.CanonicalRepresentation} values not implemented");
+                case ForeignType ft:
+                    return new JType.JForeign(ft.CanonicalRepresentation);
 
                 case MapType m:
                     JType k = JavaTypeFor(m.KeyType);


### PR DESCRIPTION
This is the foreign function interface for P -> Java compilation.

so I have foreign functions working and compiling, I think.

Consider the following P program:

```
nathta@bcd0741cf59d /tmp % cat -n foo.p
     1  event eIncr;
     2
     3  // A foreign type
     4  type Counter;
     5
     6  // Foreign functions that operate on a foreign type
     7  fun NewCounter(): Counter;
     8  fun GetNextCount(counter: Counter): int;
     9
    10  spec foo observes eIncr {
    11    var i : int;
    12    var c : Counter;
    13
    14    start state Init {
    15      entry {
    16        i = 0;
    17        c = NewCounter();
    18      }
    19
    20      on eIncr do {
    21        i = i + 1;
    22        assert i == GetNextCount(c), "uh oh";
    23      }
    24    }
    25  }
```

Nothing too terribly interesting.  In the way similar to the C# compilation path, programmers will define the Counter class:

```
nathta@bcd0741cf59d /tmp % cat -n Counter.java
     1  public class Counter {
     2      public int i;
     3      public Counter() { i = 0; }
     4  }
```

 And then a set of static methods to act as foreign functions.  Because we. don’t have partial classes in Java, we have to create a proxy class to bridge them together:

```
nathta@bcd0741cf59d /tmp % cat -n foo_FFIBridge.java
     1
     2  public class foo_FFIBridge {
     3      public static Counter NewCounter() {
     4          return new Counter();
     5      }
     6
     7      public static int GetNextCount(Counter c) {
     8          c.i += 1;
     9          return c.i;
    10      }
    11  }
```

The naming convention is that foreign functions for XYZ should go in a file called XYZ_FFIBridge.java in lieu of implementing a partial class named XYZ.  So it goes.

We need a way of generating a `pom.xml` or some such build script to compile everything, which I'll put out as a separate ticket.  In the mean time, we can compile things manually with `javac`. Of course, this is not the most ergonomic way to compile and we wouldn’t ask customers to do this.

```

nathta@bcd0741cf59d /tmp % pcl -generate:java foo.p
----------------------------------------
....... includes p file: /private/tmp/foo.p
----------------------------------------
----------------------------------------
Parsing ..
Type checking ...
Code generation ....
Generated foo.java
----------------------------------------
nathta@bcd0741cf59d /tmp % javac -source 11 -cp ~/IdeaProjects/EventExperiments/target/EventExperiments-1.0-SNAPSHOT.jar foo.java Counter.java foo_FFIBridge.java
warning: [options] system modules path not set in conjunction with -source 11
1 warning
nathta@bcd0741cf59d /tmp % jar -cf foo.jar foo.class Counter.class foo_FFIBridge.class
nathta@bcd0741cf59d /tmp % jar -tf foo.jar
META-INF/
META-INF/MANIFEST.MF
foo.class
Counter.class
foo_FFIBridge.class
nathta@bcd0741cf59d /tmp %
```