### PR TITLE
Fix NPE in ToEscapedString() with null payloads

### DIFF
--- a/Src/PRuntimes/PCSharpRuntime/PLogFormatter.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PLogFormatter.cs
@@ -26,11 +26,10 @@ namespace Plang.CSharpRuntime
             {
                 return e.GetType().Name;
             }
-            else
-            {
-                var withPayload = ((PEvent)e).Payload == null ? "" : $" with payload ({((PEvent)e).Payload.ToEscapedString()})";
-                return $"{e.GetType().Name}{withPayload}";
-            }
+            PEvent pe = (PEvent)(e);
+            string payload = pe.Payload == null ? "null" : pe.Payload.ToEscapedString();
+            var msg = pe.Payload == null ? "" : $" with payload ({payload})";
+            return $"{e.GetType().Name}{msg}";
         }
 
         public override void OnStateTransition(ActorId id, string stateName, bool isEntry)

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtMap.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtMap.cs
@@ -201,11 +201,13 @@ namespace Plang.CSharpRuntime.Values
             string sep = "";
             foreach (KeyValuePair<IPrtValue, IPrtValue> value in map)
             {
+                string k = value.Key == null ? "null" : value.Key.ToEscapedString();
+                string v = value.Value == null ? "null" : value.Key.ToEscapedString();
                 sb.Append(sep);
                 sb.Append("<");
-                sb.Append(value.Key.ToEscapedString());
+                sb.Append(k);
                 sb.Append("->");
-                sb.Append(value.Value.ToEscapedString());
+                sb.Append(v);
                 sb.Append(">");
                 sep = ", ";
             }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtSeq.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtSeq.cs
@@ -154,8 +154,9 @@ namespace Plang.CSharpRuntime.Values
             string sep = "";
             foreach (IPrtValue value in values)
             {
+                string v = value == null ? "null" : value.ToEscapedString();
                 sb.Append(sep);
-                sb.Append(value.ToEscapedString());
+                sb.Append(v);
                 sep = ", ";
             }
 

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs
@@ -124,9 +124,10 @@ namespace Plang.CSharpRuntime.Values
             var sep = "";
             foreach (var value in set)
             {
+                string v = value == null ? "null" : value.ToEscapedString();
                 sb.Append(sep);
                 sb.Append("<");
-                sb.Append(value.ToEscapedString());
+                sb.Append(v);
                 sb.Append(">");
                 sep = ", ";
             }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtString.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtString.cs
@@ -184,7 +184,8 @@ namespace Plang.CSharpRuntime.Values
         /// <returns></returns>
         public string ToEscapedString()
         {
-            return $"\"{value.Replace("\"", "\\\"")}\"";
+            string v = value ?? "";
+            return $"\"{v.Replace("\"", "\\\"")}\"";
         }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
@@ -200,7 +200,8 @@ namespace Plang.CSharpRuntime.Values
             string retStr = "<";
             for (int i = 0; i < fieldValues.Count; i++)
             {
-                retStr += fieldNames[i] + ":" + fieldValues[i].ToEscapedString() + ", ";
+                string v = fieldValues[i] == null ? "null" : fieldValues[i].ToEscapedString();
+                retStr += fieldNames[i] + ":" + v + ", ";
             }
 
             retStr += ">";

--- a/Tst/RegressionTests/Combined/Correct/nullPayload/nullPayload.p
+++ b/Tst/RegressionTests/Combined/Correct/nullPayload/nullPayload.p
@@ -1,0 +1,11 @@
+event ev : any;
+
+machine Main {
+  start state Init {
+    entry {
+      send this, ev, (s = null,);
+    }
+
+    on ev do (x: any) { }
+  }
+}


### PR DESCRIPTION
After ee5f456a9bb30141d2ca24cadff977084bc1fffc , logging output used escaped PrtValue string representations using a `toEscapedString()` method rather than coercing the PRT object to its string representation.  The latter is null-safe:

```
        SomeObject o = null;
        string s = $"The object is \"{o}\"!";
        Console.WriteLine(s);
```

produces `The object is ""!`.  The former, however, is not.  This is problematic for null event payloads.  Consider:

```
     1  event ev : any;
     2
     3  machine Foo {
     4    start state Init {
     5      on ev do (x: any) { }
     6    }
     7  }
     8
     9  machine Driver {
    10    var f: Foo;
    11
    12    start state Init {
    13      entry {
    14        f = new Foo();
    15        send f, ev, (s = null,);
    16      }
    17    }
    18  }
    19
    20  test doIt [main=Driver]: (union {Driver}, {Foo});
```

Which results in a crash inside Coyote:

```
...
<ExceptionLog> PImplementation.Driver(2) running action 'Anon' in state 'Init_1' threw exception 'NullReferenceException'.
<ErrorLog> Exception 'System.NullReferenceException' was thrown in PImplementation.Driver(2) (state 'Init_1', action 'Anon'): Object reference not set to an instance of an object.
from location 'PCSharpRuntime':
The stack trace is:
   at Plang.CSharpRuntime.Values.PrtNamedTuple.ToEscapedString()
   at Plang.CSharpRuntime.PLogFormatter.GetEventNameWithPayload(Event e)
   at Plang.CSharpRuntime.PLogFormatter.OnSendEvent(ActorId targetActorId, String senderName, String senderType, String senderStateName, Event e, Guid opGroupId, Boolean isTargetHalted)
...
```

This patch explicitly checks for null PrtValue objects before calling .toEscapedString()
on them.  After this change, the above program now behaves thus:

```
nathta@bcd0741cf59d /tmp % coyote test POutput/netcoreapp3.1/foo.dll -v
. Testing POutput/netcoreapp3.1/foo.dll
Starting TestingProcessScheduler in process 5718
... Created '1' testing task.
... Task 0 is using 'random' strategy (seed:3045513039).
..... Iteration #1
<TestLog> Running test 'PImplementation.doIt.Execute'.
<CreateLog> Plang.CSharpRuntime._GodMachine(1) was created by task '2'.
<CreateLog> PImplementation.Driver(2) was created by Plang.CSharpRuntime._GodMachine(1).
<StateLog> PImplementation.Driver(2) enters state 'Init_1'.
<CreateLog> Foo(3) was created by PImplementation.Driver(2).
<SendLog> 'PImplementation.Driver(2)' in state 'Init_1' sent event 'ev with payload (<s:null, >)' to 'Foo(3)'.
<StateLog> Foo(3) enters state 'Init'.
<DequeueLog> 'Foo(3)' dequeued event 'ev with payload (<s:null, >)' in state 'Init'.
... ### Task 0 is terminating
... Testing statistics:
..... Found 0 bugs.
... Scheduling statistics:
..... Explored 1 schedule: 1 fair and 0 unfair.
..... Number of scheduling points in fair terminating schedules: 8 (min), 8 (avg), 8 (max).
... Elapsed 0.3927897 sec.
. Done
nathta@bcd0741cf59d /tmp %
```

Note that now, an explicit `null` is printed out, which is probably more intuitive for people reading the logs than the empty string as `null` is the P-language representation of this value.

This patch also includes a test case which fails without the above changes but succeeds with them.

Long-term, we may want to consider making the C# P runtime null-safe by emitting a sentinel `PrtNull` singleton object rather than emitting `null` at code-generation time.