### PR TITLE
[Java] generate Java source for events in their own file

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -9,11 +9,11 @@ namespace Plang.Compiler.Backend.Java
     /// </summary>
     internal static class Constants
     {
-        #region Machine source code generation
+
+        #region Machine source generation
 
         private static readonly string[] JreDefaultImports =
         {
-            "java.text.MessageFormat",
             "java.util.*",
         };
 
@@ -29,17 +29,15 @@ namespace Plang.Compiler.Backend.Java
             return classes.Select(pkg => $"import {pkg};");
         }
 
-        internal static string DoNotEditWarning => $@"
-/***************************************************************************
- * This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.  
- * Please do not edit manually!
- **************************************************************************/";
+
+        public static readonly string MachineNamespaceName = "TopDeclarations";
+        public static readonly string MachineDefnFileName = $"{MachineNamespaceName}.java";
 
         #endregion
 
         #region Event source generation
 
-        public static readonly string EventNamespaceName = "Events";
+        public static readonly string EventNamespaceName = "PEvents";
         public static readonly string EventDefnFileName = $"{EventNamespaceName}.java";
 
         #endregion
@@ -52,6 +50,12 @@ namespace Plang.Compiler.Backend.Java
         #endregion
 
         #region Project build file generation
+
+        internal static string DoNotEditWarning => $@"
+/***************************************************************************
+ * This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.  
+ * Please do not edit manually!
+ **************************************************************************/";
 
         internal static string BuildFileName => "pom.xml";
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -9,7 +9,7 @@ namespace Plang.Compiler.Backend.Java
     /// </summary>
     internal static class Constants
     {
-        #region Java source code generation
+        #region Machine source code generation
 
         private static readonly string[] JreDefaultImports =
         {
@@ -34,6 +34,13 @@ namespace Plang.Compiler.Backend.Java
  * This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.  
  * Please do not edit manually!
  **************************************************************************/";
+
+        #endregion
+
+        #region Event source generation
+
+        public static readonly string EventNamespaceName = "Events";
+        public static readonly string EventDefnFileName = $"{EventNamespaceName}.java";
 
         #endregion
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/EventGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/EventGenerator.cs
@@ -1,0 +1,94 @@
+using Plang.Compiler.TypeChecker;
+using Plang.Compiler.TypeChecker.AST.Declarations;
+using System;
+using System.Collections.Generic;
+
+namespace Plang.Compiler.Backend.Java
+{
+    internal class EventGenerator : ICodeGenerator {
+
+        private CompilationContext _context;
+        private CompiledFile _source;
+        private Scope _globalScope;
+
+        /// <summary>
+        /// Generates Java code for a given compilation job's machine and monitor definitions.
+        ///
+        /// Currently, we should be able to use nested classes to put everything we need in a single
+        /// Java file, in a manner similar to how the C# extractor uses namespaces.
+        /// </summary>
+        /// <param name="job"></param>
+        /// <param name="scope"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public IEnumerable<CompiledFile> GenerateCode(ICompilationJob job, Scope scope)
+        {
+            _context = new CompilationContext(job);
+            _source = new CompiledFile(Constants.EventDefnFileName);
+            _globalScope = scope;
+
+            WriteLine("package PGenerated; ");
+
+            WriteLine(Constants.DoNotEditWarning);
+            WriteLine();
+
+            WriteLine();
+
+            WriteLine($"public class Events {Constants.EventNamespaceName} {{");
+            foreach (var e in _globalScope.Events)
+            {
+                WriteEventDecl(e);
+            }
+            WriteLine("}");
+            return new List<CompiledFile> { _source };
+        }
+
+        private void WriteEventDecl(PEvent e)
+        {
+            string eventName = _context.Names.GetNameForDecl(e);
+
+            TypeManager.JType argType = _context.Types.JavaTypeFor(e.PayloadType);
+            bool hasPayload = !(argType is TypeManager.JType.JVoid);
+
+            WriteLine($"public static class {eventName} extends {Constants.PEventsClass}<{argType.ReferenceTypeName}> {{");
+
+            if (hasPayload)
+            {
+                WriteLine($"public {eventName}({argType.TypeName} p) {{ this.payload = p; }}");
+            }
+            else
+            {
+                WriteLine($"public {eventName}() {{ }}");
+            }
+
+            WriteLine($"private {argType.ReferenceTypeName} payload; ");
+            WriteLine($"public {argType.ReferenceTypeName} getPayload() {{ return payload; }}");
+            WriteLine();
+
+            WriteLine("@Override");
+            WriteLine("public String toString() {");
+            if (hasPayload)
+            {
+                WriteLine($"return \"{eventName}[\" + payload + \"]\";");
+            }
+            else
+            {
+                WriteLine($"return \"{eventName}\";");
+            }
+            WriteLine("} // toString()");
+            WriteLine();
+
+            WriteLine($"}} // {eventName}");
+        }
+
+        private void WriteLine(string s = "")
+        {
+            _context.WriteLine(_source.Stream, s);
+        }
+
+        private void Write(string s)
+        {
+            _context.Write(_source.Stream, s);
+        }
+    }
+}

--- a/Src/PCompiler/CompilerCore/Backend/Java/EventGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/EventGenerator.cs
@@ -41,6 +41,7 @@ namespace Plang.Compiler.Backend.Java
             _globalScope = scope;
 
             WriteLine("package PGenerated; ");
+            WriteLine("import java.util.*;");
 
             WriteLine(Constants.DoNotEditWarning);
             WriteLine();
@@ -64,21 +65,27 @@ namespace Plang.Compiler.Backend.Java
             TypeManager.JType argType = _context.Types.JavaTypeFor(e.PayloadType);
             bool hasPayload = !(argType is TypeManager.JType.JVoid);
 
-            WriteLine($"public static class {eventName} extends {Constants.PEventsClass}<{argType.ReferenceTypeName}> {{");
+            string payloadType = argType.TypeName;
+            string payloadRefType = argType.ReferenceTypeName;
+
+            WriteLine($"public static class {eventName} extends {Constants.PEventsClass}<{payloadRefType}> {{");
+
 
             if (hasPayload)
             {
-                WriteLine($"public {eventName}({argType.TypeName} p) {{ this.payload = p; }}");
+                WriteLine($"public {eventName}({payloadType} p) {{ this.payload = p; }}");
+                WriteLine($"private {payloadType} payload; ");
+                WriteLine($"public {payloadRefType} getPayload() {{ return payload; }}");
             }
             else
             {
                 WriteLine($"public {eventName}() {{ }}");
+                WriteLine($"public {payloadRefType} getPayload() {{ ");
+                WriteLine($"throw new RuntimeException(\"No payload defined for event type {eventName}\");");
+                WriteLine("}");
             }
 
-            WriteLine($"private {argType.ReferenceTypeName} payload; ");
-            WriteLine($"public {argType.ReferenceTypeName} getPayload() {{ return payload; }}");
             WriteLine();
-
             WriteLine("@Override");
             Write("public String toString() {");
             if (hasPayload)

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
@@ -31,7 +31,7 @@ namespace Plang.Compiler.Backend.Java
 
             List<ICodeGenerator> generators = new List<ICodeGenerator>()
             {
-                new MachineCodeGenerator(),
+                new JavaSourceGenerator(),
                 new EventGenerator()
             };
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Plang.Compiler.TypeChecker;
 
 namespace Plang.Compiler.Backend.Java
@@ -27,7 +28,14 @@ namespace Plang.Compiler.Backend.Java
         public IEnumerable<CompiledFile> GenerateCode(ICompilationJob job, Scope scope)
         {
             GenerateBuildScript(job);
-            return new JavaCodeGenerator().GenerateCode(job, scope);
+
+            List<ICodeGenerator> generators = new List<ICodeGenerator>()
+            {
+                new MachineCodeGenerator(),
+                new EventGenerator()
+            };
+
+            return generators.SelectMany(g => g.GenerateCode(job, scope));
         }
 
         /// <summary>

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -12,7 +12,7 @@ using Plang.Compiler.TypeChecker.Types;
 
 namespace Plang.Compiler.Backend.Java {
 
-    internal class MachineCodeGenerator : ICodeGenerator
+    internal class JavaSourceGenerator : ICodeGenerator
     {
 
         private CompilationContext _context;
@@ -34,7 +34,7 @@ namespace Plang.Compiler.Backend.Java {
         public IEnumerable<CompiledFile> GenerateCode(ICompilationJob job, Scope scope)
         {
             _context = new CompilationContext(job);
-            _source = new CompiledFile(_context.FileName);
+            _source = new CompiledFile(Constants.MachineDefnFileName);
             _globalScope = scope;
 
             WriteLine("package PGenerated; ");
@@ -57,7 +57,7 @@ namespace Plang.Compiler.Backend.Java {
                 WriteLine();
             }
 
-            WriteLine($"public class {_context.ProjectName} {{");
+            WriteLine($"public class {Constants.MachineNamespaceName} {{");
 
             if (_globalScope.Enums.Any())
             {
@@ -863,7 +863,7 @@ namespace Plang.Compiler.Backend.Java {
                     }
                     else
                     {
-                        Write($"MessageFormat.format({fmtLit}");
+                        Write($"java.text.MessageFormat.format({fmtLit}");
                         foreach (var arg in se.Args)
                         {
                             Write(", ");


### PR DESCRIPTION
Previously all Java code was emitted into a single Java file, named after the P project.  This was just like the C# code generator.

This patch now generates Events in their own file, called `Events.java` (but still in the same package).  As a forward reference for future changes, that blob of Java code is now called `Machines.java` - as there are now multiple code generators working in tandem, and since identifiers need to be referenced between files, it proved to be exceedingly awkward to thread through the top level name for this file.

```
nathta@bcd0741cf59d pprojtest % cat -n PSpec/foo.p
     1  type t = (a: int, b: seq[int]);
     2
     3  event eIncr : t;
     4  event eOther;
     5  event eYetAnother;
     6
     7  spec monitorA observes eIncr {
     8    start state Init {
     9      entry {}
    10      on eIncr do {}
    11    }
    12  }
    13
    14  spec monitorB observes eOther {
    15    start state Init {
    16      entry {}
    17      on eOther do {}
    18    }
    19  }
nathta@bcd0741cf59d pprojtest % pcl -proj:pprojtest.pproj
----------------------------------------
==== Loading project file: pprojtest.pproj
....... includes p file: /Users/nathta/code/pprojtest/PSpec/foo.p
----------------------------------------
----------------------------------------
Parsing ...
Type checking ...
Code generation ...
Reusing existing pom.xml
Generated Machines.java.
Generated Events.java.
----------------------------------------
Compiling pprojtest...
----------------------------------------
nathta@bcd0741cf59d pprojtest % 
```

The Events file looks thus:

```java
nathta@bcd0741cf59d pprojtest % cat -n PGenerated/Events.java
     1  package PGenerated;
     2  import java.util.*;
     3
     4  /***************************************************************************
     5   * This file was auto-generated on Thursday, 23 June 2022 at 16:45:35.
     6   * Please do not edit manually!
     7   **************************************************************************/
     8
     9
    10  public class Events {
    11      public static class eIncr extends prt.events.PEvent<Machines.PTuple_a_b> {
    12          public eIncr(Machines.PTuple_a_b p) { this.payload = p; }
    13          private Machines.PTuple_a_b payload;
    14          public Machines.PTuple_a_b getPayload() { return payload; }
    15
    16          @Override
    17          public String toString() { return "eIncr[" + payload + "]"; }
    18      } // eIncr
    19
    20      public static class eOther extends prt.events.PEvent<Void> {
    21          public eOther() { }
    22          public Void getPayload() {
    23              throw new RuntimeException("No payload defined for event type eOther");
    24          }
    25
    26          @Override
    27          public String toString() { return "eOther"; }
    28      } // eOther
    29
    30  }
nathta@bcd0741cf59d pprojtest %
```

Note that no code is generated for the unused `eYetAnother` event.

And the remainder of the generated code, thus:

```java
nathta@bcd0741cf59d pprojtest % cat -n PGenerated/Machines.java
     1  package PGenerated;
     2
     3  /***************************************************************************
     4   * This file was auto-generated on Thursday, 23 June 2022 at 16:45:35.
     5   * Please do not edit manually!
     6   **************************************************************************/
     7
     8  import java.util.*;
     9
    10
    11  public class Machines {
    12      /* Tuples */
    13      // (a:int,b:seq[int])
    14      public static class PTuple_a_b implements prt.values.PValue<PTuple_a_b> {
...
    53      } //PTuple_a_b class definition
    54
    55
    56      public static class monitorA extends prt.Monitor {
...
    65          public monitorA() {
    66              super();
    67              addState(new prt.State.Builder(INIT_STATE)
    68                  .isInitialState(true)
    69                  .withEntry(this::Anon)
    70                  .withEvent(Events.eIncr.class, __ -> Anon_1())
    71                  .build());
    72          } // constructor
    73      } // monitorA monitor definition
    74      public static class monitorB extends prt.Monitor {
...
    83          public monitorB() {
    84              super();
    85              addState(new prt.State.Builder(INIT_STATE)
    86                  .isInitialState(true)
    87                  .withEntry(this::Anon_2)
    88                  .withEvent(Events.eOther.class, __ -> Anon_3())
    89                  .build());
    90          } // constructor
    91      } // monitorB monitor definition
    92  } // pprojtest.java class definition
nathta@bcd0741cf59d pprojtest %
```

Note that references to Event classe are now prefaced with the enclosing "namespace class", i.e. `Events.eIncr.class`.  Similarly, tuples have to refer back to their enclosing class, i.e. `Machines.PTuple_a_b`.  The natural next step would be to bring all the tuple and enum definitions out into their own file, too, but I'm going to leave that for a different PR to keep the size of these reviews small.