### PR TITLE
[Java] Emit proper Java enums for P enums

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -30,7 +30,7 @@ namespace Plang.Compiler.Backend.Java
         }
 
 
-        public static readonly string MachineNamespaceName = "Machines";
+        public static readonly string MachineNamespaceName = "PMachines";
         public static readonly string MachineDefnFileName = $"{MachineNamespaceName}.java";
 
         #endregion

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -88,6 +88,7 @@ namespace Plang.Compiler.Backend.Java
 
                 /* Same with immutable types. */
                 case TypeManager.JType.JString _:
+                case TypeManager.JType.JEnum _:
                 case TypeManager.JType.JMachine _:
                     writeTermToBeCloned();
                     break;

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -635,7 +635,7 @@ namespace Plang.Compiler.Backend.Java {
                 case EnumElemRefExpr ee:
                     string typeName = ee.Value.ParentEnum.Name;
                     string valueName = ee.Value.Name;
-                    Write($"{typeName}.{valueName}");
+                    Write($"{Constants.TypesNamespaceName}.{typeName}.{valueName}");
                     break;
                 case EventRefExpr _:
                     goto default; //TODO

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -38,7 +38,7 @@ namespace Plang.Compiler.Backend.Java
                         throw new Exception($"TypeName not implemented for {this.GetType()}");
                     }
 
-                    string prefix = (isUserDefined ? Constants.MachineNamespaceName + "." : "");
+                    string prefix = (isUserDefined ? Constants.TypesNamespaceName + "." : "");
                     return prefix + _unboxedType;
                 }
             }
@@ -301,6 +301,21 @@ namespace Plang.Compiler.Backend.Java
                 internal override string DefaultValue => "null";
             }
 
+            internal class JEnum : JType
+            {
+                private readonly string _defaultValue;
+
+                internal JEnum(EnumType e)
+                {
+                    _unboxedType = e.CanonicalRepresentation;
+                    _defaultValue = e.EnumDecl.Values.First().Name; // An arbitrary enum value is fine.
+                }
+
+                internal override bool isUserDefined => true;
+
+                internal override string DefaultValue => $"{Constants.TypesNamespaceName}.{_unboxedType}.{_defaultValue}";
+            }
+
             //TODO: not sure about this one.  Is the base class sufficient?
             //Generate some Java files and see.
             internal class JEvent : JType
@@ -384,8 +399,8 @@ namespace Plang.Compiler.Backend.Java
                 case DataType _:
                     throw new NotImplementedException($"{type.CanonicalRepresentation} values not implemented");
 
-                case EnumType _:
-                    return new JType.JInt();
+                case EnumType e:
+                    return new JType.JEnum(e);
 
                 case ForeignType ft:
                     return new JType.JForeign(ft.CanonicalRepresentation);

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
@@ -44,12 +44,16 @@ namespace Plang.Compiler.Backend.Java
 
         private void WriteEnumDecl(PEnum e)
         {
-            WriteLine($"public static class {e.Name} {{");
+            WriteLine($"public enum {e.Name} {{");
 
-            foreach (var param in e.Values)
+            int numFields = e.Values.Count();
+            foreach (var (param, sep) in e.Values.Select((pair, i) => (pair, i < numFields - 1? "," : ";")))
             {
-                WriteLine($"public static final int {param.Name} = {param.Value.ToString()};");
+                WriteLine($"{param.Name}({param.Value.ToString()}){sep}");
             }
+
+            WriteLine("private final int value;");
+            WriteLine($"{e.Name}(int i) {{ value = i; }}");
 
             WriteLine("}");
         }


### PR DESCRIPTION
Initially, for simplicity, P enums were just extracted to Java as
plain old static ints, and we lost all P enum-specific type information
in Java.  Consider the very silly P program:

```
nathta@bcd0741cf59d pprojtest_enum % cat -n PSpec/foo.p
     1  enum anEnum {
     2    VALUE_ZERO,
     3    VALUE_ONE
     4  }
     5
     6  event eIncr : anEnum;
     7
     8
     9  spec monitorA observes eIncr {
    10    var myE : anEnum;
    11    start state Init {
    12      entry {
    13        myE = VALUE_ZERO;
    14      }
    15      on eIncr do (e: anEnum) {
    16        assert e == VALUE_ONE, "uh oh";
    17      }
    18    }
    19  }
nathta@bcd0741cf59d pprojtest_enum %
```


As of tag 1.13:
```java
 12     /* Enums */
 13     public static class anEnum {
 14         public static final int VALUE_ZERO = 0;
 15         public static final int VALUE_ONE = 1;
 16     }
...
 53     public static class monitorA extends prt.Monitor {
 54         private int myE = 0;
 55         public int get_myE() { return this.myE; };
...
 60         private void Anon() {
 61             myE = anEnum.VALUE_ZERO;
 62         }
 63         private void Anon_1(int e) {
 64             boolean TMP_tmp0 = false;
 65             String TMP_tmp1 = "";
 66
 67             TMP_tmp0 = e == anEnum.VALUE_ONE;
 68             TMP_tmp1 = "uh oh";
 69             tryAssert(TMP_tmp0, TMP_tmp1);
 70         }
```

This patch makes them Java enums so there's no opportunity
to use an invalid integral value where an enum is expected.

```java
// in PTypes.java
 11     /* Enums */
 12     public enum anEnum {
 13         VALUE_ZERO(0),
 14         VALUE_ONE(1);
 15         private final int value;
 16         anEnum(int i) { value = i; }
 17     }
// in PMachines.java
 11     public static class monitorA extends prt.Monitor {
 12         private PTypes.anEnum myE = PTypes.anEnum.VALUE_ZERO;
...
 18         private void Anon() {
 19             myE = PTypes.anEnum.VALUE_ZERO;
 20         }
 21         private void Anon_1(PTypes.anEnum e) {
 22             boolean TMP_tmp0 = false;
 23             String TMP_tmp1 = "";
 24
 25             TMP_tmp0 = e == PTypes.anEnum.VALUE_ONE;
 26             TMP_tmp1 = "uh oh";
 27             tryAssert(TMP_tmp0, TMP_tmp1);
 28         }
```

The downside of this is now that all enums are boxed.