### PR TITLE
[Java] emit code for .getEventType()

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Plang.Compiler.TypeChecker;
 
 namespace Plang.Compiler.Backend.Java
@@ -124,6 +125,27 @@ namespace Plang.Compiler.Backend.Java
         protected void Write(string s)
         {
             _context.Write(Source.Stream, s);
+        }
+    }
+
+    static class IEnumerableExtensions
+    {
+
+        /// <summary>
+        /// Given some sequence and a separator value, emit a sequence such that on the first iteration
+        /// the prefix is the empty string, and on all other iterations it is the supplied prefix.  We
+        /// can use this for emitting values from `it` where `prefix` is a separator string.  For instance,
+        ///
+        /// `foreach (s, i) in WithPrefixSep(",", [1,2,3]) { Console.Out.Write(sep + i) }` would emit `"1,2,3"`.
+        ///
+        /// </summary>
+        /// <param name="prefix">The separator value.</param>
+        /// <param name="it">The sequence of Ts to iterate through</param>
+        /// <typeparam name="T">The type of the values in it.</typeparam>
+        /// <returns>A sequence of (string, T) pairs, where the string is either the empty string or the separator.</returns>
+        internal static IEnumerable<(string, T)> WithPrefixSep<T>(this IEnumerable<T> it, string prefix)
+        {
+            return it.Select((val, i) => (i > 0 ? prefix : "", val));
         }
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -237,7 +237,7 @@ namespace Plang.Compiler.Backend.Java {
         {
             WriteLine("public java.util.List<Class<? extends prt.events.PEvent>> getEventTypes() {");
             Write("return java.util.Arrays.asList(");
-            foreach (var (ev, sep) in _currentMachine.Observes.Events.Select((p, i) => (p, i > 0 ? ", " : "")))
+            foreach (var (sep, ev) in _currentMachine.Observes.Events.WithPrefixSep(", "))
             {
                 Write($"{sep}{Constants.EventNamespaceName}.{ev.Name}.class");
             }
@@ -442,10 +442,10 @@ namespace Plang.Compiler.Backend.Java {
                     Write("tryRaiseEvent(new ");
                     WriteExpr(raiseStmt.PEvent);
                     Write("(");
-                    foreach (var (param, sep)in raiseStmt.Payload.Select((p, i) => (p, i > 0 ? ", " : "")))
+                    foreach (var (sep, expr) in raiseStmt.Payload.WithPrefixSep(", "))
                     {
                         Write(sep);
-                        WriteExpr(param);
+                        WriteExpr(expr);
                     }
                     Write(")");
                     WriteLine(");");
@@ -583,10 +583,10 @@ namespace Plang.Compiler.Backend.Java {
             string fname = Names.GetNameForDecl(f);
 
             Write($"{ffiBridge}{fname}(");
-            foreach (var (param, sep)in args.Select((p, i) => (p, i > 0 ? ", " : "")))
+            foreach (var (sep, expr) in args.WithPrefixSep(", "))
             {
                 Write(sep);
-                WriteExpr(param);
+                WriteExpr(expr);
             }
             Write($")");
         }
@@ -675,7 +675,7 @@ namespace Plang.Compiler.Backend.Java {
                 {
                     t = Types.JavaTypeFor(te.Type);
                     Write($"new {t.TypeName}(");
-                    foreach (var (field, sep) in te.TupleFields.Select((e, i) => (e, i > 0 ? ", " : "")))
+                    foreach (var (sep, field) in te.TupleFields.WithPrefixSep(", "))
                     {
                         Write(sep);
                         WriteExpr(field);
@@ -734,8 +734,7 @@ namespace Plang.Compiler.Backend.Java {
                 {
                     t = Types.JavaTypeFor(te.Type);
                     Write($"new {t.TypeName}(");
-                    foreach (var (field, sep) in te.TupleFields.Select((e, i) =>
-                                 (e, i > 0 ? ", " : "")))
+                    foreach (var (sep, field) in te.TupleFields.WithPrefixSep(", "))
                     {
                         Write(sep);
                         WriteExpr(field);

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
@@ -106,7 +106,7 @@ namespace Plang.Compiler.Backend.Java
 
             // Write the explicit constructor.
             Write($"public {tname}(");
-            foreach (var ((jType, fieldName), sep) in fields.Select((pair, i) => (pair, i > 0 ? ", " : "")))
+            foreach (var (sep, (jType, fieldName)) in fields.WithPrefixSep(", "))
             {
                 Write($"{sep}{jType.TypeName} {fieldName}");
             }
@@ -121,7 +121,7 @@ namespace Plang.Compiler.Backend.Java
             // Write the copy constructor for cloning.
             WriteLine($"public {tname} deepClone() {{");
             Write($"return new {tname}(");
-            foreach (var ((jType, fieldName), sep) in fields.Select((pair, i) => (pair, i > 0 ? ", " : "")))
+            foreach (var (sep, (jType, fieldName)) in fields.WithPrefixSep(", "))
             {
                 Write(sep);
                 WriteClone(jType, () => Write(fieldName));
@@ -157,7 +157,7 @@ namespace Plang.Compiler.Backend.Java
             WriteLine("public String toString() {");
             WriteLine($"StringBuilder sb = new StringBuilder(\"{tname}\");");
             WriteLine("sb.append(\"[\");");
-            foreach (var ((_, fieldName), sep) in fields.Select((pair, i) => (pair, i > 0 ? "," : "")))
+            foreach (var (sep, (_, fieldName)) in fields.WithPrefixSep(", "))
             {
                 WriteLine($"sb.append(\"{sep}{fieldName}=\" + {fieldName});");
             }


### PR DESCRIPTION
This is needed to fulfill the interface on the PObserve side.

Sample output:

```
 40         public java.util.List<Class<? extends prt.events.PEvent>> getEventTypes() {
 41             return java.util.Arrays.asList(PEvents.eSpec_BankBalanceIsAlwaysCorrect_Init.class, PEvents.eWithDrawReq.class, PEvents.eWithDrawResp.class);
 42         }
```


And also a small refactoring patch to hide a bit of gnarly iteration logic.
