### PR TITLE
[Java] Generate extracted JARs with PRT

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -91,10 +91,38 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
             <groupId>p.runtime</groupId>
             <artifactId>PJavaRuntime</artifactId>
             <version>1.0-SNAPSHOT</version>
+
+            <!-- Do not transitively bundle log4j as whoever uses this jar will also depend on it. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <directory>${{buildDirectory}}</directory>
         <sourceDirectory>.</sourceDirectory>
     </build>


### PR DESCRIPTION
This patch makes any P projects that compile to Java include the Java P runtime within the JAR.

Additionally: we do not include transitive dependencies like log4j in here, since if whoever is loading this jar also uses it then there would be a namespace collision.

```
nathta@bcd0741cf59d 1_ClientServer % pcl -proj:ClientServer.pproj
----------------------------------------
==== Loading project file: ClientServer.pproj
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PSrc/Server.p
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PSrc/Client.p
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PSrc/AbstractBankServer.p
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PSrc/ClientServerModules.p
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PSpec/BankBalanceCorrect.p
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PTst/TestDriver.p
....... includes p file: /Users/nathta/code/P/Tutorial/1_ClientServer/PTst/Testscript.p
----------------------------------------
----------------------------------------
Parsing ...
Type checking ...
Code generation ...
Generated pom.xml
Generated PMachines.java.
Generated PEvents.java.
Generated PTypes.java.
----------------------------------------
Compiling ClientServer...
----------------------------------------
nathta@bcd0741cf59d 1_ClientServer % ls -l POutput/ClientServer-1.0-SNAPSHOT*
-rw-r--r--  1 nathta  staff  44948 Jun 30 14:36 POutput/ClientServer-1.0-SNAPSHOT-jar-with-dependencies.jar
-rw-r--r--  1 nathta  staff  18668 Jun 30 14:36 POutput/ClientServer-1.0-SNAPSHOT.jar
nathta@bcd0741cf59d 1_ClientServer % tar -tf POutput/ClientServer-1.0-SNAPSHOT.jar | grep prt | wc
       0       0       0
nathta@bcd0741cf59d 1_ClientServer % tar -tf POutput/ClientServer-1.0-SNAPSHOT-jar-with-dependencies.jar | grep prt | wc
      22      22     595
nathta@bcd0741cf59d 1_ClientServer %
```