### PR TITLE
[Java] Emit FFI stub implementations

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace Plang.Compiler.Backend.Java
 {
@@ -51,8 +52,34 @@ namespace Plang.Compiler.Backend.Java
 
         #region FFI generation
 
-        internal static string FFIPackage = "PForeign";
-        internal static string GlobalFFIPackage = $"{FFIPackage}.globals";
+        private static readonly string rawFFIBanner = $@"
+P <-> Java Foreign Function Interface Stubs
+
+This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.  
+
+Please separate each generated class into its own .java file (detailed throughout the file), filling
+in the body of each function definition as necessary for your project's business logic.
+";
+
+        internal static readonly string FFIStubFileName = "FFIStubs.txt";
+
+        internal static readonly string FFIPackage = "PForeign";
+        internal static readonly string GlobalFFIPackage = $"{FFIPackage}.globals";
+
+        // Something that is clearly not valid Java.
+        private static readonly string FFICommentToken = "%";
+
+        public static string FFICommentDivider = new StringBuilder(72).Insert(0, FFICommentToken, 72).ToString();
+
+        internal static string AsFFIComment(string line)
+        {
+            return FFICommentToken + " " + line;
+        }
+
+        internal static string[] FfiBanner => rawFFIBanner
+            .Split("\n")
+            .Select(AsFFIComment)
+            .ToArray();
 
         #endregion
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+using Plang.Compiler.TypeChecker.AST.Declarations;
+using System.Linq;
+using Plang.Compiler.TypeChecker.Types;
+
+namespace Plang.Compiler.Backend.Java
+{
+    internal class FFIStubGenerator : JavaSourceGenerator
+    {
+
+        internal FFIStubGenerator(string filename) : base(filename)
+        {
+        }
+
+        protected override void WriteFileHeader()
+        {
+            WriteLine(Constants.FFICommentDivider);
+
+            foreach (var line in Constants.FfiBanner)
+            {
+                WriteLine(line);
+            }
+            WriteLine(Constants.FFICommentDivider);
+
+            WriteLine();
+            WriteLine();
+        }
+
+        private IEnumerable<ForeignType> resolveForeignType(Variable v)
+        {
+                PLanguageType type = v.Type;
+
+                // In the case where the field type is a typedef, follow
+                // the typename resolution until we've found the actual type.
+                while (type is TypeDefType tdef)
+                {
+                    type = tdef.TypeDefDecl.Type;
+                }
+
+                if (type is ForeignType f)
+                {
+                    return new[] { f };
+                }
+
+                return new ForeignType[] {} ;
+        }
+
+        /// <summary>
+        /// Extracts all the foreign types used by monitors in this program: namely, foreign types as fields
+        /// in some monitor, or, foreign types used in the body of a monitor method.
+        /// </summary>
+        private IEnumerable<ForeignType> ExtractForeignTypesFromMonitors()
+        {
+            return GlobalScope.Machines.Where(m => m.IsSpec)
+                    .SelectMany(ExtractForeignTypesFrom)
+                    .ToHashSet();
+        }
+
+        /// <summary>
+        /// Extracts all the foreign types used by a given machine.
+        /// </summary>
+        /// <param name="m"></param>
+        /// <returns></returns>
+        private IEnumerable<ForeignType> ExtractForeignTypesFrom(Machine m)
+        {
+            IEnumerable<ForeignType> foreignFields =
+                    m.Fields.Where(f => f.Type is ForeignType _)
+                    .SelectMany(resolveForeignType);
+
+            IEnumerable<ForeignType> foreignFnVars =
+                    m.Methods
+                    .SelectMany(f => f.LocalVariables)
+                    .SelectMany(resolveForeignType);
+
+            return foreignFields.Concat(foreignFnVars).ToHashSet();
+        }
+
+        /// <summary>
+        /// Extract all foreign functions called by the supplied monitor.
+        /// </summary>
+        private IEnumerable<Function> ExtractForeignFunctionsFrom(Machine m)
+        {
+            return m.Methods.Where(f => f.IsForeign);
+        }
+
+        /// <summary>
+        /// Generates Java code for a given compilation job's used events.
+        ///
+        /// We only emit code for events that are actually used in Monitors (i.e. they
+        /// appear in at least one Monitor's `observes` set.)
+        /// </summary>
+        protected override void GenerateCodeImpl()
+        {
+
+            foreach (var t in ExtractForeignTypesFromMonitors())
+            {
+                WriteLine(Constants.FFICommentDivider);
+                WriteForeignTypeStub(t);
+            }
+
+            foreach (Machine m in GlobalScope.Machines.Where(m => m.IsSpec))
+            {
+                WriteLine(Constants.FFICommentDivider);
+                WriteForeignFunctions(m);
+            }
+        }
+
+        private void WriteFFIGlobalHeader(string classname)
+        {
+            WriteLine(Constants.AsFFIComment($"Please place and complete the following class in {Constants.FFIPackage}/globals/{classname}.java :"));
+        }
+
+        private void WriteFFIHeader(string monitorName)
+        {
+            WriteLine(Constants.AsFFIComment($"Please place and complete the following class in {Constants.FFIPackage}/{monitorName}.java :"));
+        }
+
+        private void WriteForeignTypeStub(ForeignType t)
+        {
+            WriteFFIGlobalHeader(t.CanonicalRepresentation);
+            WriteLine();
+
+            WriteLine($"package {Constants.GlobalFFIPackage};");
+            WriteLine();
+
+            string cname = t.CanonicalRepresentation;
+            WriteLine($"public class {cname} implements prt.values.PValue<{cname}> {{");
+
+            // Constructor.
+            WriteLine($"public {cname}() {{ }}");
+            WriteLine();
+
+            // PValue interfaces.
+            WriteLine($"public {cname} deepClone() {{");
+            WriteLine($"throw new RuntimeException(\"{cname}#deepClone() not implemented yet!\"); // TODO");
+            WriteLine("}");
+            WriteLine();
+
+            WriteLine($"public boolean deepEquals({cname} other) {{");
+            WriteLine($"throw new RuntimeException(\"{cname}#deepEquals() not implemented yet!\"); // TODO");
+            WriteLine("}");
+            WriteLine();
+
+            WriteLine("}");
+            WriteLine();
+        }
+
+        private void WriteForeignFunctions(Machine m)
+        {
+            IEnumerable<Function> ffs = ExtractForeignFunctionsFrom(m);
+            if (!ffs.Any())
+            {
+                return;
+            }
+
+            WriteLine();
+            WriteFFIHeader(m.Name);
+            WriteLine();
+
+            WriteLine($"package {Constants.FFIPackage};");
+            WriteLine();
+
+            // Any foreign types that this function depends on should be imported too.
+            foreach (ForeignType t in ExtractForeignTypesFrom(m))
+            {
+                TypeManager.JType toImport = Types.JavaTypeFor(t);
+                WriteLine($"import {Constants.GlobalFFIPackage}.{toImport.TypeName};");
+                WriteLine();
+            }
+
+            // Class definition: By convention, this "para-class" has the same name as
+            // the P machine that imports it, to mimic the C#-style partial class mixin
+            // functionalty that we are not afforded in Java, unfortunately.
+            WriteLine($"public class {m.Name} {{");
+            foreach (Function f in ffs)
+            {
+                TypeManager.JType ret = Types.JavaTypeFor(f.Signature.ReturnType);
+
+                Write($"public static {ret.TypeName} {f.Name}(");
+
+                foreach (var (sep, param) in f.Signature.Parameters.WithPrefixSep(", "))
+                {
+                    string pname = param.Name;
+                    TypeManager.JType ptype = Types.JavaTypeFor(param.Type);
+
+                    Write($"{sep}{ptype.TypeName} {pname}");
+                }
+
+                WriteLine(") {");
+                WriteLine($"return {ret.DefaultValue}; // TODO");
+                WriteLine("}");
+                WriteLine();
+            }
+            WriteLine("}");
+            WriteLine();
+        }
+    }
+}

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
@@ -33,7 +33,8 @@ namespace Plang.Compiler.Backend.Java
             {
                 new MachineGenerator(Constants.MachineDefnFileName),
                 new EventGenerator(Constants.EventDefnFileName),
-                new TypesGenerator(Constants.TypesDefnFileName)
+                new TypesGenerator(Constants.TypesDefnFileName),
+                new FFIStubGenerator(Constants.FFIStubFileName)
             };
 
             return generators.SelectMany(g => g.GenerateCode(job, scope));

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -29,7 +29,7 @@ namespace Plang.Compiler.Backend.Java
             GlobalScope = scope;
         }
 
-        private void WriteFileHeader()
+        protected virtual void WriteFileHeader()
         {
             WriteLine("package PGenerated;");
 

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/exceptions/IncomparableValuesException.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/exceptions/IncomparableValuesException.java
@@ -1,0 +1,7 @@
+package prt.exceptions;
+
+public class IncomparableValuesException extends RuntimeException {
+    public IncomparableValuesException(Class<?> c1, Class<?> c2) {
+        super(String.format("Can't compare values of type %s and %s", c1.getName(), c2.getName()));
+    }
+}

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Equality.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Equality.java
@@ -1,6 +1,7 @@
 package prt.values;
 
 import prt.events.PEvent;
+import prt.exceptions.IncomparableValuesException;
 
 import java.util.*;
 
@@ -106,12 +107,13 @@ public class Equality {
                 return deepHashMapEquals((HashMap<?, ?>) o1, (HashMap<?, ?>) o2);
             if (c1 == LinkedHashSet.class && c2 == LinkedHashSet.class)
                 return deepLinkedHashSetEquals((LinkedHashSet<?>) o1, (LinkedHashSet<?>) o2);
+
+            throw new IncomparableValuesException(c1, c2);
         } catch (ClassCastException e) {
             // The C# P runtime is pretty permissive about comparing different types (no runtime exception,
             // they just evaluate to false) so we do the same here in case we are passed incomparable types.
             return false;
         }
-        return false;
     }
 
 }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCompareTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCompareTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import prt.exceptions.IncomparableValuesException;
 import prt.values.*;
 
 import java.util.ArrayList;
@@ -77,16 +78,16 @@ public class ValueCompareTest {
     @DisplayName("equals() does not coerse numeric types")
     public void testNoCorersionForEquality() {
         // int <-> bool
-        assertFalse(Equality.deepEquals(0, false));
-        assertFalse(Equality.deepEquals(1, true));
+        assertThrows(IncomparableValuesException.class, () -> Equality.deepEquals(0, false));
+        assertThrows(IncomparableValuesException.class, () -> Equality.deepEquals(1, true));
 
         // int <-> float
-        assertFalse(Equality.deepEquals(0, 0.0));
-        assertFalse(Equality.deepEquals(42, 42.0f));
+        assertThrows(IncomparableValuesException.class, () -> Equality.deepEquals(0, 0.0f));
+        assertThrows(IncomparableValuesException.class, () -> Equality.deepEquals(1, 1.0f));
 
         // int <-> long
-        assertFalse(Equality.deepEquals(0, 0L));
-        assertFalse(Equality.deepEquals(42, 42L));
+        assertThrows(IncomparableValuesException.class, () -> Equality.deepEquals(0, 0L));
+        assertThrows(IncomparableValuesException.class, () -> Equality.deepEquals(1, 1L));
     }
 
     @Test


### PR DESCRIPTION
This is a partial solution to an issue I noticed this morning:

I noticed a problem with the pproj FFI example: it compiles cleanly, but would behave incorrectly should it execute: [The FFI type](https://github.com/dijkstracula/pprojexample/blob/main/PForeign/globals/Counter.java) needs to implement `deepEquals` and `deepClone`, but doesn't (it should have implemented an interface), so we would find ourselves in a situation where we emit compiling Java code that calls into runtime type checking code on the PRT side, and would do the wrong thing - essentially, the "do these values inherit from PValue" checks would fail, so identical Counters [would fall through and test as being unequal](https://github.com/p-org/P/blob/2f060bf22f1f1d449c23a99ebfa4cffc298e2267/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Equality.java#L114). Bad!

## The best solution and why we can't do it

The best thing would be to avoid this runtime dispatching and overload `values.deepEquals()` for every possible P runtime value (for instance, `deepEquals(boolean, boolean)`, `deepEquals(int, int)`, `deepEquals(ArrayList<T>, ArrayList<T>`, and so on.). Because not every value inherits from a common interface, though, bounding the type parameters for this becomes gnarly so I think we do need some form of runtime dispatch (at least to handle `any` types).  I tried pushing this as far as I could this morning but got caught by the typechecker, so I'll keep plugging away at it over time but I'm not sure the best thing is really possible unfortunately.

## The next-best solution and why we can't mostly do it, maybe

The next best thing would have been, for the case where we didn't implement the interface correctly for two `Counter` foreign types, to throw an exception during comparison so as to say "hey, I don't know what these types are meant to be".  I think this is safe, but it changes the semantics of object comparison vis a vis the C# version, which [allows for disparate types to be compared (but evalutates to false in such cases)](https://github.com/p-org/P/blob/master/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs#L78-L82).  So, we'd have to be sure that stricter behaviour is safe (i.e. would the P compiler frontend fail to typecheck in all cases?  I suspect not in the case of comparing two `any`s.). 

_This patch additionally includes a fix where we at least throw an exception if we can't compare two types, which changes the above described behaviour.  If we are not convinced this is safe we should remove that commit before merging._

## The next-next best thing

The _next_ best thing is at least to help future developers not make the same mistake I did: emit FFI stubs that show what the skeleton of the code _ought_ to look like.  This generates a single text file (with a .txt file extension, so Maven will not pick it up ever) demonstrating what each native FFI file should look like and where it should reside in the package hierarchy.

```
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
% 
% P <-> Java Foreign Function Interface Stubs
% 
% This file was auto-generated on Friday, 01 July 2022 at 11:22:33.  
% 
% Please separate each generated class into its own .java file (detailed throughout the file), filling
% in the body of each function definition as necessary for your project's business logic.
% 
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
% Please place and complete the following class in PForeign/globals/Counter.java :

package PForeign.globals;

public class Counter implements prt.values.PValue<Counter> {
    public Counter() { }
    
    public Counter deepClone() {
        throw new RuntimeException("Counter#deepClone() not implemented yet!"); // TODO
    }
    
    public boolean deepEquals(Counter other) {
        throw new RuntimeException("Counter#deepEquals() not implemented yet!"); // TODO
    }
    
}

%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

% Please place and complete the following class in PForeign/myMonitor.java :

package PForeign;

import PForeign.globals.Counter;

public class myMonitor {
    public static Counter NewCounter() {
        return null; // TODO
    }
    
    public static int GetNextCount(Counter counter) {
        return 0; // TODO
    }
    
}
```