### PR TITLE
[Java] better FFI stub formatting

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -94,13 +94,11 @@ namespace Plang.Compiler.Backend.Java
 
             foreach (var t in ExtractForeignTypesFromMonitors())
             {
-                WriteLine(Constants.FFICommentDivider);
                 WriteForeignTypeStub(t);
             }
 
             foreach (Machine m in GlobalScope.Machines.Where(m => m.IsSpec))
             {
-                WriteLine(Constants.FFICommentDivider);
                 WriteForeignFunctions(m);
             }
         }
@@ -117,6 +115,9 @@ namespace Plang.Compiler.Backend.Java
 
         private void WriteForeignTypeStub(ForeignType t)
         {
+            WriteLine(Constants.FFICommentDivider);
+            WriteLine();
+
             WriteFFIGlobalHeader(t.CanonicalRepresentation);
             WriteLine();
 
@@ -153,6 +154,8 @@ namespace Plang.Compiler.Backend.Java
                 return;
             }
 
+            WriteLine(Constants.FFICommentDivider);
+
             WriteLine();
             WriteFFIHeader(m.Name);
             WriteLine();
@@ -164,6 +167,7 @@ namespace Plang.Compiler.Backend.Java
             foreach (ForeignType t in ExtractForeignTypesFrom(m))
             {
                 TypeManager.JType toImport = Types.JavaTypeFor(t);
+                WriteLine($"import java.util.*;"); // To avoid having to fully-qualify e.g. j.u.HashMap, etc.
                 WriteLine($"import {Constants.GlobalFFIPackage}.{toImport.TypeName};");
                 WriteLine();
             }
@@ -176,14 +180,14 @@ namespace Plang.Compiler.Backend.Java
             {
                 TypeManager.JType ret = Types.JavaTypeFor(f.Signature.ReturnType);
 
-                Write($"public static {ret.TypeName} {f.Name}(");
+                WriteLine($"public static {ret.TypeName} {f.Name}(");
 
-                foreach (var (sep, param) in f.Signature.Parameters.WithPrefixSep(", "))
+                foreach (var (param, sep) in f.Signature.Parameters.WithPostfixSep(","))
                 {
                     string pname = param.Name;
                     TypeManager.JType ptype = Types.JavaTypeFor(param.Type);
 
-                    Write($"{sep}{ptype.TypeName} {pname}");
+                    WriteLine($"{ptype.TypeName} {pname}{sep}");
                 }
 
                 WriteLine(") {");

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -136,7 +136,7 @@ namespace Plang.Compiler.Backend.Java
         /// the prefix is the empty string, and on all other iterations it is the supplied prefix.  We
         /// can use this for emitting values from `it` where `prefix` is a separator string.  For instance,
         ///
-        /// `foreach (s, i) in WithPrefixSep(",", [1,2,3]) { Console.Out.Write(sep + i) }` would emit `"1,2,3"`.
+        /// `foreach (sep, i) in [1,2,3].withPrefixSep(",") { Console.Out.Write(sep + i) }` would emit `"1,2,3"`.
         ///
         /// </summary>
         /// <param name="prefix">The separator value.</param>
@@ -146,6 +146,24 @@ namespace Plang.Compiler.Backend.Java
         internal static IEnumerable<(string, T)> WithPrefixSep<T>(this IEnumerable<T> it, string prefix)
         {
             return it.Select((val, i) => (i > 0 ? prefix : "", val));
+        }
+
+        /// <summary>
+        /// Given some sequence and a separator value, emit a sequence such that on the final iteration
+        /// the suffix is the empty string, and on all other iterations it is the supplied suffix.  We
+        /// can use this for emitting values from `it` where `suffix` is a separator string.  For instance,
+        ///
+        /// `foreach (i, sep) in [1,2,3].withPostfixSep(",") { Console.Out.Write(i + sep) }` would emit `"1,2,3"`.
+        ///
+        /// </summary>
+        /// <param name="prefix">The separator value.</param>
+        /// <param name="it">The sequence of Ts to iterate through</param>
+        /// <typeparam name="T">The type of the values in it.</typeparam>
+        /// <returns>A sequence of (T, string) pairs, where the string is either the empty string or the separator.</returns>
+        internal static IEnumerable<(T, string)> WithPostfixSep<T>(this IEnumerable<T> it, string suffix)
+        {
+            int len = it.Count();
+            return it.Select((val, i) => (val, i < len - 1 ? suffix : ""));
         }
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -223,7 +223,7 @@ namespace Plang.Compiler.Backend.Java
                 {
                     _k = k;
                     _v = v;
-                    _unboxedType = $"HashMap<{_k.ReferenceTypeName},{_v.ReferenceTypeName}>";
+                    _unboxedType = $"HashMap<{_k.ReferenceTypeName}, {_v.ReferenceTypeName}>";
                 }
 
                 internal override bool IsPrimitive => false;


### PR DESCRIPTION
This patch puts out all arguments to foreign function stubs on their own line;
previously, all arguments were on one line and it they proved to be difficult
to read; this now matches hand-written C# FFI bindings observed elsewhere.

Additionally, a divider line was emitted for every P Machine, even if there
were no foreign functions for that machine.  As a result, the stub file would
have multiple lines delimiting no lines of Java stubs.  This patch only emits
the dividing line if there is anything to emit for a given machine.