### PR TITLE
[Java] prt.Monitor to implement Consumer<PEvent>

### DIFF
--- a/Src/PRuntimes/PJavaRuntime/src/test/java/MonitorTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/MonitorTest.java
@@ -353,7 +353,7 @@ public class MonitorTest {
     @DisplayName("Monitors must be ready()ied before events can be processed")
     public void testNonReadyMonitors() {
         CounterMonitor m = new CounterMonitor();
-        Throwable e = assertThrows(RuntimeException.class, () -> m.process(m.new AddEvent(42)));
+        Throwable e = assertThrows(RuntimeException.class, () -> m.accept(m.new AddEvent(42)));
         assertTrue(e.getMessage().contains("not running"));
     }
 
@@ -364,9 +364,9 @@ public class MonitorTest {
         m.ready();
 
         assertEquals(m.count, 0);
-        m.process(m.new AddEvent(1));
-        m.process(m.new AddEvent(2));
-        m.process(m.new AddEvent(3));
+        m.accept(m.new AddEvent(1));
+        m.accept(m.new AddEvent(2));
+        m.accept(m.new AddEvent(3));
         assertEquals(m.count, 6);
     }
 
@@ -448,6 +448,6 @@ public class MonitorTest {
         RaiseEventMonitor m = new RaiseEventMonitor();
         m.ready();
 
-        m.process(m.new testEvent());
+        m.accept(m.new testEvent());
     }
 }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/clientserver/ClientServerTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/clientserver/ClientServerTest.java
@@ -24,7 +24,7 @@ public class ClientServerTest {
 
         BankBalanceIsAlwaysCorrect m = new BankBalanceIsAlwaysCorrect();
         m.ready();
-        m.process(new eSpec_BankBalanceIsAlwaysCorrect_Init(initialBalances));
+        m.accept(new eSpec_BankBalanceIsAlwaysCorrect_Init(initialBalances));
 
         return m;
     }
@@ -42,7 +42,7 @@ public class ClientServerTest {
         BankBalanceIsAlwaysCorrect m = initedBankBalanceIsAlwaysCorrect();
 
         assertThrows(PAssertionFailureException.class,
-                () -> m.process(new eWithDrawReq(
+                () -> m.accept(new eWithDrawReq(
                         new PTuple_src_accnt_amnt_rId(0L, 31337, 10, 0))),
                 "Assertion failure: Unknown accountId 102 in the withdraw request. Valid accountIds = [100, 101]");
     }
@@ -53,11 +53,11 @@ public class ClientServerTest {
     void testProcessValidWithdraws() {
         BankBalanceIsAlwaysCorrect m = initedBankBalanceIsAlwaysCorrect();
 
-        m.process(new eWithDrawReq(
+        m.accept(new eWithDrawReq(
                 new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)
         ));
 
-        m.process(new eWithDrawResp(
+        m.accept(new eWithDrawResp(
                 new PTuple_stts_accnt_blnc_rId(
                         tWithDrawRespStatus.WITHDRAW_SUCCESS, 100, 32, 0)));
     }
@@ -67,10 +67,10 @@ public class ClientServerTest {
     void testThrowsOnInvalidWithdraws() {
         BankBalanceIsAlwaysCorrect m = initedBankBalanceIsAlwaysCorrect();
 
-        m.process(new eWithDrawReq(new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)));
+        m.accept(new eWithDrawReq(new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)));
 
         assertThrows(PAssertionFailureException.class,
-                () -> m.process(new eWithDrawResp(new PTuple_stts_accnt_blnc_rId(
+                () -> m.accept(new eWithDrawResp(new PTuple_stts_accnt_blnc_rId(
                         tWithDrawRespStatus.WITHDRAW_SUCCESS,
                         100,
                         1000, /* Uh oh! The balance should be 42 - 10 = 32. */
@@ -89,9 +89,9 @@ public class ClientServerTest {
     public void testWithDrawReqs() {
         Monitor m = initedGuaranteWDProgress();
 
-        m.process(new eWithDrawReq(new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)));
+        m.accept(new eWithDrawReq(new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)));
 
-        m.process(new eWithDrawResp(new PTuple_stts_accnt_blnc_rId(
+        m.accept(new eWithDrawResp(new PTuple_stts_accnt_blnc_rId(
                 tWithDrawRespStatus.WITHDRAW_SUCCESS,
                 100,
                 90,
@@ -105,7 +105,7 @@ public class ClientServerTest {
 
         // We begin in the NopendingRequests state, but that state has no handler
         // for a withDrawRewp.
-        assertThrows(UnhandledEventException.class, () -> m.process(new eWithDrawResp(
+        assertThrows(UnhandledEventException.class, () -> m.accept(new eWithDrawResp(
                 new PTuple_stts_accnt_blnc_rId(
                         tWithDrawRespStatus.WITHDRAW_ERROR,
                         100,
@@ -118,11 +118,11 @@ public class ClientServerTest {
     public void testInvalidWithDrawReqs2() {
         Monitor m = initedGuaranteWDProgress();
 
-        m.process(new eWithDrawReq(new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)));
+        m.accept(new eWithDrawReq(new PTuple_src_accnt_amnt_rId(1L, 100, 10, 0)));
 
         // We begin in the NopendingRequests state, but that state has no handler
         // for a withDrawRewp.
-        assertThrows(PAssertionFailureException.class, () -> m.process(new eWithDrawResp(
+        assertThrows(PAssertionFailureException.class, () -> m.accept(new eWithDrawResp(
                 new PTuple_stts_accnt_blnc_rId(
                         tWithDrawRespStatus.WITHDRAW_SUCCESS,
                         100,

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/espressomachine/EspressoMachineTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/espressomachine/EspressoMachineTest.java
@@ -14,7 +14,7 @@ public class EspressoMachineTest {
         m.ready();
 
         assertEquals(m.getCurrentState(), "StartUp");
-        m.process(new eInWarmUpState());
+        m.accept(new eInWarmUpState());
         assertEquals(m.getCurrentState(), "WarmUp");
     }
 
@@ -24,12 +24,12 @@ public class EspressoMachineTest {
         EspressoMachineModesOfOperation m = new EspressoMachineModesOfOperation();
         m.ready();
 
-        m.process(new eInWarmUpState());
-        m.process(new eInReadyState());
-        m.process(new eInReadyState()); // Duplicate; should be ignored.
-        m.process(new eInBeansGrindingState());
-        m.process(new eInCoffeeBrewingState());
-        m.process(new eInReadyState());
+        m.accept(new eInWarmUpState());
+        m.accept(new eInReadyState());
+        m.accept(new eInReadyState()); // Duplicate; should be ignored.
+        m.accept(new eInBeansGrindingState());
+        m.accept(new eInCoffeeBrewingState());
+        m.accept(new eInReadyState());
     }
 
     @Test
@@ -38,13 +38,13 @@ public class EspressoMachineTest {
         EspressoMachineModesOfOperation m = new EspressoMachineModesOfOperation();
         m.ready();
 
-        m.process(new eInWarmUpState());
-        m.process(new eInReadyState());
-        m.process(new eInBeansGrindingState());
+        m.accept(new eInWarmUpState());
+        m.accept(new eInReadyState());
+        m.accept(new eInBeansGrindingState());
 
-        m.process(new eErrorHappened());
+        m.accept(new eErrorHappened());
         assertEquals(m.getCurrentState(), "Error");
-        m.process(new eResetPerformed());
+        m.accept(new eResetPerformed());
         assertEquals(m.getCurrentState(), "StartUp");
     }
 }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/failuredetector/FailureDetectorTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/failuredetector/FailureDetectorTest.java
@@ -19,12 +19,12 @@ public class FailureDetectorTest {
 
         assertEquals(0, m.get_nodesDownDetected().size());
         assertEquals(0, m.get_nodesShutdownAndNotDetected().size());
-        m.process(new eShutDown(1L));
+        m.accept(new eShutDown(1L));
         assertEquals(0, m.get_nodesDownDetected().size());
         assertEquals(1, m.get_nodesShutdownAndNotDetected().size());
 
         LinkedHashSet<Long> nodes = new LinkedHashSet<>(Set.of(1L, 2L, 3L));
-        m.process(new eNotifyNodesDown(nodes));
+        m.accept(new eNotifyNodesDown(nodes));
         assertEquals(3, m.get_nodesDownDetected().size());
         assertEquals(0, m.get_nodesShutdownAndNotDetected().size());
     }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/twophasecommit/TwoPhaseCommitTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/tutorialmonitors/twophasecommit/TwoPhaseCommitTest.java
@@ -14,7 +14,7 @@ public class TwoPhaseCommitTest {
     private AtomicityInvariant initedMonitor() {
         AtomicityInvariant m = new AtomicityInvariant();
         m.ready();
-        m.process(new eMonitor_AtomicityInitialize(3)); // We'll now be in WaitForEvents
+        m.accept(new eMonitor_AtomicityInitialize(3)); // We'll now be in WaitForEvents
         return m;
     }
 
@@ -24,11 +24,11 @@ public class TwoPhaseCommitTest {
         AtomicityInvariant m = initedMonitor();
 
         for (long participant : List.of(1L,2L,3L)) {
-            m.process(new ePrepareResp(
+            m.accept(new ePrepareResp(
                     new PTuple_prtcp_trans_stts(participant, 0, tTransStatus.SUCCESS)));
         }
 
-        m.process(new eWriteTransResp(
+        m.accept(new eWriteTransResp(
                 new PTuple_trans_stts(0, tTransStatus.SUCCESS)));
     }
 
@@ -39,15 +39,15 @@ public class TwoPhaseCommitTest {
 
         // Participants 1 and two say yes...
         for (long participant : List.of(1L,2L)) {
-            m.process(new ePrepareResp(
+            m.accept(new ePrepareResp(
                     new PTuple_prtcp_trans_stts(participant, 0, tTransStatus.SUCCESS)));
         }
         // Participant 3 says no!
-        m.process(new ePrepareResp(
+        m.accept(new ePrepareResp(
                 new PTuple_prtcp_trans_stts(3L, 0, tTransStatus.ERROR)));
 
         // should be able to handle a txn response with an error
-        m.process(new eWriteTransResp(
+        m.accept(new eWriteTransResp(
                 new PTuple_trans_stts(0, tTransStatus.ERROR)));
     }
 
@@ -58,12 +58,12 @@ public class TwoPhaseCommitTest {
 
         /* Only two SUCCESSes; one never arrives! */
         for (long participant : List.of(1L,2L)) {
-            m.process(new ePrepareResp(
+            m.accept(new ePrepareResp(
                     new PTuple_prtcp_trans_stts(participant, 0, tTransStatus.SUCCESS)));
         }
 
         assertThrows(PAssertionFailureException.class,
-                () -> m.process(new eWriteTransResp(
+                () -> m.accept(new eWriteTransResp(
                         new PTuple_trans_stts(0, tTransStatus.SUCCESS))));
     }
 
@@ -73,11 +73,11 @@ public class TwoPhaseCommitTest {
         AtomicityInvariant m = initedMonitor();
 
         for (long participant : List.of(1L,2L)) {
-            m.process(new ePrepareResp(
+            m.accept(new ePrepareResp(
                     new PTuple_prtcp_trans_stts(participant, 0, tTransStatus.SUCCESS)));
         }
         // Participant 3 says no dice!
-        m.process(
+        m.accept(
                 new ePrepareResp(
                         new PTuple_prtcp_trans_stts(
                                 3L,
@@ -85,7 +85,7 @@ public class TwoPhaseCommitTest {
                                 tTransStatus.ERROR)));
 
         assertThrows(PAssertionFailureException.class,
-                () -> m.process(new eWriteTransResp(
+                () -> m.accept(new eWriteTransResp(
                         new PTuple_trans_stts(0, tTransStatus.SUCCESS))));
     }
 }


### PR DESCRIPTION
Having this interface inherit directly from a built-in Java type
simplifies code-sharing across different projects.