### PR TITLE
[Java] generate exceptions from prt.exceptions package

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -206,15 +206,15 @@ namespace Plang.Compiler.Backend.Java {
             List<string> throwables = new List<string>();
             if (f.CanChangeState == true)
             {
-                throwables.Add("prt.TransitionException");
+                throwables.Add("prt.exceptions.TransitionException");
             }
             if (f.CanRaiseEvent == true)
             {
-                throwables.Add("prt.RaiseEventException");
+                throwables.Add("prt.exceptions.RaiseEventException");
             }
             if (throwables.Count > 0)
             {
-                Write($"throws {string.Join(", ", throwables)}");
+                Write($" throws {string.Join(", ", throwables)}");
             }
 
         }

--- a/Src/PRuntimes/PJavaRuntime/pom.xml
+++ b/Src/PRuntimes/PJavaRuntime/pom.xml
@@ -75,7 +75,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <log4j2.configurationFile>${project.basedir}/src/main/resources/log4j2.xml</log4j2.configurationFile>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>1.0.0-SNAPSHOT</revision>
+        <revision>1.0-SNAPSHOT</revision>
     </properties>
     
 </project>


### PR DESCRIPTION
This was a PRT refactoring change that somehow didn't get changed on the runtime side, and somehow I missed with testing.  Mea culpa.

```
nathta@bcd0741cf59d /tmp % pcl -generate:Java foo.p
----------------------------------------
....... includes p file: /private/tmp/foo.p
----------------------------------------
----------------------------------------
Parsing ...
Type checking ...
Code generation ...
Reusing existing pom.xml
Generated PMachines.java.
Generated PEvents.java.
Generated PTypes.java.
Generated FFIStubs.txt.
----------------------------------------
Compiling foo...
----------------------------------------
nathta@bcd0741cf59d /tmp % grep 'throws prt\.' PMachines.java
        private void Anon_1() throws prt.exceptions.TransitionException {
nathta@bcd0741cf59d /tmp %
```

This patch also changes back the version number of the PRT, which I had had sitting in my git staging area without having committed it!  Whoops.  Thanks, @beyazit-yalcinkaya .