### PR TITLE
[Java] do not generate tuple fields as final

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
@@ -92,7 +92,7 @@ namespace Plang.Compiler.Backend.Java
             // Write the fields.
             foreach (var (jType, fieldName) in fields)
             {
-                WriteLine($"public final {jType.TypeName} {fieldName};");
+                WriteLine($"public {jType.TypeName} {fieldName};");
             }
             WriteLine();
 


### PR DESCRIPTION
The following spec should compile:

```
  1 type t = (a: int, b: int);
  2 event e: int;
  3
  4 spec m observes e {
  5   var v: t;
  6   start state Init {
  7     on e do {
  8       v.a = 42;
  9       v.b = 99;
 10     }
 11   }
 12 }
```

However, as part of the assertion that all P values are values, the generated fields in the class definition for `t` were marked as final, so this code wouldn't compile at the Java end:

```
[ERROR] /private/tmp/PMachines.java:[32,14] cannot assign a value to final variable a
[ERROR] /private/tmp/PMachines.java:[33,14] cannot assign a value to final variable b
```

This patch simply removes the `final` designation of those fields.