### PR TITLE
[Java] share compilation contexts across different Java code generators

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaCompiler.cs
@@ -29,15 +29,16 @@ namespace Plang.Compiler.Backend.Java
         {
             GenerateBuildScript(job);
 
-            List<ICodeGenerator> generators = new List<ICodeGenerator>()
+            List<JavaSourceGenerator> generators = new List<JavaSourceGenerator>()
             {
-                new MachineGenerator(Constants.MachineDefnFileName),
-                new EventGenerator(Constants.EventDefnFileName),
                 new TypesGenerator(Constants.TypesDefnFileName),
+                new EventGenerator(Constants.EventDefnFileName),
+                new MachineGenerator(Constants.MachineDefnFileName),
                 new FFIStubGenerator(Constants.FFIStubFileName)
             };
 
-            return generators.SelectMany(g => g.GenerateCode(job, scope));
+            CompilationContext ctx = new CompilationContext(job);
+            return generators.SelectMany(g => g.GenerateCode(ctx, scope));
         }
 
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -5,7 +5,7 @@ using Plang.Compiler.TypeChecker;
 
 namespace Plang.Compiler.Backend.Java
 {
-    public abstract class JavaSourceGenerator : ICodeGenerator
+    public abstract class JavaSourceGenerator
     {
         private CompilationContext _context;
         protected CompiledFile Source;
@@ -23,9 +23,9 @@ namespace Plang.Compiler.Backend.Java
             Source = new CompiledFile(filename);
         }
 
-        private void Initialize(ICompilationJob job, Scope scope)
+        private void Initialize(CompilationContext ctx, Scope scope)
         {
-            _context = new CompilationContext(job);
+            _context = ctx;
             GlobalScope = scope;
         }
 
@@ -54,12 +54,12 @@ namespace Plang.Compiler.Backend.Java
         /// imports and "do not edit" comment blocks, the functionality in `GenerateCodeImpl`
         /// will be invoked.
         /// </summary>
-        /// <param name="job"></param>
+        /// <param name="ctx"></param>
         /// <param name="scope"></param>
         /// <returns>The single compiled file.</returns>
-        public IEnumerable<CompiledFile> GenerateCode(ICompilationJob job, Scope scope)
+        internal IEnumerable<CompiledFile> GenerateCode(CompilationContext ctx, Scope scope)
         {
-            Initialize(job, scope);
+            Initialize(ctx, scope);
             WriteFileHeader();
             GenerateCodeImpl();
             return new List<CompiledFile> { Source };

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -166,7 +166,7 @@ namespace Plang.Compiler.Backend.Java
 
                 internal static string ToJavaLiteral(double d)
                 {
-                    return d + "d";
+                    return d + "f";
                 }
             }
 


### PR DESCRIPTION
Previously the code generator for the events, types, and machines Java files would not share a compilation context.  This means that NameManagers (and therefore TypeManagers) would not be shared between files.  This is problematic for the case where we have to disambiguate identifier names; the following code would fail to compile,

```
nathta@bcd0741cf59d /tmp % cat -n foo.p
     1  type t1 = (a: int, b: float);
     2  type t2 = (a: int, b: string);
     3
     4  event e: t2;
     5
     6  spec m observes e {
     7    var s: string;
     8    start state Init {
     9      on e do (ev: t2) {
    10        s = ev.b;
    11      }
    12    }
    13  }
    14
    15  machine Driver {
    16    start state Init {}
    17  }
    18
    19  test doIt [main=Driver]: {Driver};
nathta@bcd0741cf59d /tmp %
```

because a different unique name for `t2` would be generated in the Events file than in the Machine file, so the named tuple where `b` is a float would be used in place of the one where `b` is a string.  This patch refactors the code generators so there is only one compilation context, so they can be reused across generated files.