### PR TITLE
[Java] P ints should be extracted as Java Longs

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -875,11 +875,12 @@ namespace Plang.Compiler.Backend.Java {
                     break;
 
                 case SeqAccessExpr seqAccessExpr:
-                    // TODO: do we need to think about handling out of bounds exceptions?
                     WriteExpr(seqAccessExpr.SeqExpr);
-                    Write($".{t.AccessorMethodName}(");
+                    // IndexExpr is a JInt and thus emitted as a long. In this particular case,
+                    // though, `ArrayList#get()` takes an int so we have to downcast.
+                    Write($".{t.AccessorMethodName}((int)(");
                     WriteExpr(seqAccessExpr.IndexExpr);
-                    Write(")");
+                    Write("))");
                     break;
 
                 case TupleAccessExpr tupleAccessExpr:

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -143,15 +143,15 @@ namespace Plang.Compiler.Backend.Java
             {
                 internal JInt()
                 {
-                    _unboxedType = "int";
-                    _refType = "Integer";
+                    _unboxedType = "long";
+                    _refType = "Long";
                 }
 
-                internal override string DefaultValue => ToJavaLiteral(0);
+                internal override string DefaultValue => ToJavaLiteral(0L);
 
-                internal static string ToJavaLiteral(int i)
+                internal static string ToJavaLiteral(long l)
                 {
-                    return i.ToString();
+                    return l + "L";
                 }
             }
 

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Clone.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Clone.java
@@ -19,10 +19,6 @@ public class Clone {
         return b; //already immutable!  No cloning necessary.
     }
 
-    private static Integer cloneInteger(Integer i) {
-        return i; //already immutable!  No cloning necessary.
-    }
-
     private static Long cloneLong(Long l) {
         // NB: Actor IDs are stored as Longs.
         return l; //already immutable!  No cloning necessary.
@@ -90,8 +86,6 @@ public class Clone {
         Class<?> clazz = o.getClass();
         if (clazz == Boolean.class)
             return cloneBoolean((Boolean)o);
-        if (clazz == Integer.class)
-            return cloneInteger((Integer)o);
         if (clazz == Long.class)
             return cloneLong((Long)o);
         if (clazz == Float.class)

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCloneTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCloneTest.java
@@ -4,7 +4,7 @@ import prt.exceptions.UncloneableValueException;
 
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static prt.values.Clone.deepClone;
@@ -23,7 +23,7 @@ public class ValueCloneTest {
         Boolean b = Boolean.valueOf(true);
         assertEquals(deepClone(b), b);
 
-        Integer i = Integer.valueOf(31337);
+        Long i = Long.valueOf(31337);
         assertEquals(deepClone(i), i);
 
         Float f = Float.valueOf(1.61803f);
@@ -37,20 +37,20 @@ public class ValueCloneTest {
     @DisplayName("Can clone lists")
     public void testCloneList() {
         // Ensure the clone completes successfully
-        ArrayList<Integer> a1 = new ArrayList<>(List.of(1,2,3,4,5));
-        ArrayList<Integer> a2 = (ArrayList<Integer>) deepClone(a1);
+        ArrayList<Long> a1 = new ArrayList<>(List.of(1L,2L,3L,4L,5L));
+        ArrayList<Long> a2 = (ArrayList<Long>) deepClone(a1);
         assertEquals(a1, a2);
 
         // Now reassign an element and ensure only structural equality
-        a1.set(1, 42);
+        a1.set(1, 42L);
         assertNotEquals(a1, a2);
-        a2.set(1, 42);
+        a2.set(1, 42L);
         assertEquals(a1, a2);
 
         // Now append an element and ensure only structural equality.
-        a1.add(99);
+        a1.add(99L);
         assertNotEquals(a1, a2);
-        a2.add(99);
+        a2.add(99L);
         assertEquals(a1, a2);
     }
 
@@ -58,32 +58,32 @@ public class ValueCloneTest {
     @DisplayName("Can clone sets")
     public void testCloneSet() {
         // Ensure the clone completes successfully
-        LinkedHashSet<Integer> s1 = new LinkedHashSet<>(List.of(1,2,3,4,5));
-        LinkedHashSet<Integer> s2 = (LinkedHashSet<Integer>) deepClone(s1);
+        LinkedHashSet<Long> s1 = new LinkedHashSet<>(List.of(1L,2L,3L,4L,5L));
+        LinkedHashSet<Long> s2 = (LinkedHashSet<Long>) deepClone(s1);
         assertEquals(s1, s2);
 
         // Now mutate an element and ensure only structural equality
-        s1.add(6);
+        s1.add(6L);
         assertNotEquals(s1, s2);
-        s2.add(6);
+        s2.add(6L);
         assertEquals(s1, s2);
     }
 
     @Test
     @DisplayName("Can clone maps")
     public void testCloneMap() {
-        HashMap<String, Integer> m1 = new HashMap<>(Map.of(
-                "A", 1,
-                "B", 2,
-                "C", 3));
-        HashMap<String, Integer> m2 = (HashMap<String, Integer>) deepClone(m1);
+        HashMap<String, Long> m1 = new HashMap<>(Map.of(
+                "A", 1L,
+                "B", 2L,
+                "C", 3L));
+        HashMap<String, Long> m2 = (HashMap<String, Long>) deepClone(m1);
         assertEquals(m1, m2);
 
 
         // Ensure structural equality under adding elements
-        m1.put("Z", 42);
+        m1.put("Z", 42L);
         assertNotEquals(m1, m2);
-        m2.put("Z", 42);
+        m2.put("Z", 42L);
         assertEquals(m1, m2);
 
         // Ensure structural equality under removing elements
@@ -93,41 +93,41 @@ public class ValueCloneTest {
         assertEquals(m1, m2);
 
         // Ensure structural equality under reassigning values
-        m1.put("C", 99);
+        m1.put("C", 99L);
         assertNotEquals(m1, m2);
-        m2.put("C", 99);
+        m2.put("C", 99L);
         assertEquals(m1, m2);
     }
 
     @Test
     @DisplayName("Can clone nested collections")
     public void testNestedCollections() {
-        HashMap<String, ArrayList<Integer>> m1 = new HashMap<>(Map.of(
-                "123", new ArrayList<>(List.of(1,2,3)),
-                "987", new ArrayList<>(List.of(9,8,7))
+        HashMap<String, ArrayList<Long>> m1 = new HashMap<>(Map.of(
+                "123", new ArrayList<>(List.of(1L,2L,3L)),
+                "987", new ArrayList<>(List.of(9L,8L,7L))
         ));
-        HashMap<String, ArrayList<Integer>> m2 = (HashMap<String, ArrayList<Integer>>) deepClone(m1);
+        HashMap<String, ArrayList<Long>> m2 = (HashMap<String, ArrayList<Long>>) deepClone(m1);
         assertEquals(m1, m2);
 
         // Mutate a mutable reference value and ensure no aliasing
-        m1.get("123").add(4);
+        m1.get("123").add(4L);
         assertNotEquals(m1, m2);
     }
 
 
     public static class PTuple_a implements prt.values.PValue<PTuple_a> {
-        public ArrayList<Integer> a;
+        public ArrayList<Long> a;
 
         public PTuple_a() {
-            this.a = new ArrayList<Integer>();
+            this.a = new ArrayList<Long>();
         }
 
-        public PTuple_a(ArrayList<Integer> a) {
+        public PTuple_a(ArrayList<Long> a) {
             this.a = a;
         }
 
         public PTuple_a deepClone() {
-            return new PTuple_a((ArrayList<Integer>)prt.values.Clone.deepClone(a));
+            return new PTuple_a((ArrayList<Long>)prt.values.Clone.deepClone(a));
         } // deepClone()
 
         public boolean equals(Object other) {
@@ -154,12 +154,12 @@ public class ValueCloneTest {
     @Test
     @DisplayName("Can clone a tuple")
     public void testPtupleClone() {
-        PTuple_a t1 = new PTuple_a(new ArrayList<>(List.of(1,2,3)));
+        PTuple_a t1 = new PTuple_a(new ArrayList<>(List.of(1L,2L,3L)));
         PTuple_a t2 = (PTuple_a) deepClone(t1);
 
         assertTrue(t1.deepEquals(t2));
 
-        t1.a.add(99);
+        t1.a.add(99L);
         assertFalse(t1.deepEquals(t2));
         assertNotEquals(t1.a, t2.a);
     }
@@ -167,9 +167,9 @@ public class ValueCloneTest {
     @Test
     @DisplayName("Cannot clone a non-P value class")
     public void testInvalidCloneOfUnrelatedClass() {
-        // AtomicInteger extends j.l.Number extends j.l.Object - this is a totally
+        // AtomicLong extends j.l.Number extends j.l.Object - this is a totally
         // distinct class from any P value the Java code generator emits.
-        AtomicInteger i = new AtomicInteger(42);
+        AtomicLong i = new AtomicLong(42);
         assertThrows(UncloneableValueException.class, () -> deepClone(i));
     }
 
@@ -183,7 +183,7 @@ public class ValueCloneTest {
         // LinkedHashSet extends hashSet, but we expect this should fail nonetheless.
         // (Relaxing this criterion would require walking the inheritance tree via
         // reflection, and it isn't clear what the return type of the cloned value would be.)
-        FancyLinkedHashSet<Integer> lh = new FancyLinkedHashSet<>(List.of(1,2,3,4,5));
+        FancyLinkedHashSet<Long> lh = new FancyLinkedHashSet<>(List.of(1L,2L,3L,4L,5L));
         assertThrows(UncloneableValueException.class, () -> deepClone(lh));
     }
 

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/ClientServerTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/ClientServerTest.java
@@ -19,8 +19,8 @@ import static testmonitors.clientserver.PTypes.*;
 
 public class ClientServerTest {
     private BankBalanceIsAlwaysCorrect initedBankBalanceIsAlwaysCorrect() {
-        HashMap<Integer, Integer> initialBalances =
-                new HashMap<>(Map.of(100, 42, 101, 10));
+        HashMap<Long, Long> initialBalances =
+                new HashMap<>(Map.of(100L, 42L, 101L, 10L));
 
         BankBalanceIsAlwaysCorrect m = new BankBalanceIsAlwaysCorrect();
         m.ready();

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PEvents.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PEvents.java
@@ -1,17 +1,17 @@
 package testmonitors.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Thursday, 30 June 2022 at 14:23:48.
+ * This file was auto-generated on Wednesday, 20 July 2022 at 14:12:46.
  * Please do not edit manually!
  **************************************************************************/
 
 import java.util.*;
 
 public class PEvents {
-    public static class eSpec_BankBalanceIsAlwaysCorrect_Init extends prt.events.PEvent<HashMap<Integer,Integer>> {
-        public eSpec_BankBalanceIsAlwaysCorrect_Init(HashMap<Integer,Integer> p) { this.payload = p; }
-        private HashMap<Integer,Integer> payload;
-        public HashMap<Integer,Integer> getPayload() { return payload; }
+    public static class eSpec_BankBalanceIsAlwaysCorrect_Init extends prt.events.PEvent<HashMap<Long, Long>> {
+        public eSpec_BankBalanceIsAlwaysCorrect_Init(HashMap<Long, Long> p) { this.payload = p; }
+        private HashMap<Long, Long> payload;
+        public HashMap<Long, Long> getPayload() { return payload; }
 
         @Override
         public String toString() { return "eSpec_BankBalanceIsAlwaysCorrect_Init[" + payload + "]"; }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PMachines.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PMachines.java
@@ -1,11 +1,9 @@
 package testmonitors.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Thursday, 30 June 2022 at 14:23:48.
+ * This file was auto-generated on Wednesday, 20 July 2022 at 14:24:31.
  * Please do not edit manually!
  **************************************************************************/
-
-import prt.exceptions.TransitionException;
 
 import java.util.*;
 
@@ -16,26 +14,25 @@ public class PMachines {
     // PMachine Client elided
     // PMachine AbstractBankServer elided
     public static class BankBalanceIsAlwaysCorrect extends prt.Monitor {
-        private HashMap<Integer,Integer> bankBalance = new HashMap<Integer,Integer>();
-        public HashMap<Integer,Integer> get_bankBalance() { return this.bankBalance; };
+        private HashMap<Long, Long> bankBalance = new HashMap<Long, Long>();
+        public HashMap<Long, Long> get_bankBalance() { return this.bankBalance; };
 
-        private HashMap<Integer,PTypes.PTuple_src_accnt_amnt_rId> pendingWithDraws = new HashMap<Integer,PTypes.PTuple_src_accnt_amnt_rId>();
-        public HashMap<Integer,PTypes.PTuple_src_accnt_amnt_rId> get_pendingWithDraws() { return this.pendingWithDraws; };
+        private HashMap<Long, PTypes.PTuple_src_accnt_amnt_rId> pendingWithDraws = new HashMap<Long, PTypes.PTuple_src_accnt_amnt_rId>();
+        public HashMap<Long, PTypes.PTuple_src_accnt_amnt_rId> get_pendingWithDraws() { return this.pendingWithDraws; };
 
 
-        private enum States {
-            INIT_STATE,
-            WAITFORWITHDRAWREQANDRESP_STATE
+        public enum PrtStates {
+            Init,
+            WaitForWithDrawReqAndResp
         }
 
         public BankBalanceIsAlwaysCorrect() {
             super();
-            addState(prt.State.keyedOn(States.INIT_STATE)
+            addState(prt.State.keyedOn(PrtStates.Init)
                     .isInitialState(true)
-                    .withEvent(PEvents.eSpec_BankBalanceIsAlwaysCorrect_Init.class, p -> { Anon(p); gotoState(States.WAITFORWITHDRAWREQANDRESP_STATE); })
+                    .withEvent(PEvents.eSpec_BankBalanceIsAlwaysCorrect_Init.class, p -> { Anon(p); gotoState(PrtStates.WaitForWithDrawReqAndResp); })
                     .build());
-            addState(prt.State.keyedOn(States.WAITFORWITHDRAWREQANDRESP_STATE)
-                    .isInitialState(false)
+            addState(prt.State.keyedOn(PrtStates.WaitForWithDrawReqAndResp)
                     .withEvent(PEvents.eWithDrawReq.class, this::Anon_1)
                     .withEvent(PEvents.eWithDrawResp.class, this::Anon_2)
                     .build());
@@ -45,80 +42,80 @@ public class PMachines {
             return java.util.Arrays.asList(PEvents.eSpec_BankBalanceIsAlwaysCorrect_Init.class, PEvents.eWithDrawReq.class, PEvents.eWithDrawResp.class);
         }
 
-        private void Anon(HashMap<Integer,Integer> balance) {
-            bankBalance = (HashMap<Integer,Integer>)prt.values.Clone.deepClone(balance);
+        private void Anon(HashMap<Long, Long> balance) {
+            bankBalance = (HashMap<Long, Long>)prt.values.Clone.deepClone(balance);
         }
         private void Anon_1(PTypes.PTuple_src_accnt_amnt_rId req) {
-            int TMP_tmp0 = 0;
+            long TMP_tmp0 = 0L;
             boolean TMP_tmp1 = false;
-            int TMP_tmp2 = 0;
-            ArrayList<Integer> TMP_tmp3 = new ArrayList<Integer>();
+            long TMP_tmp2 = 0L;
+            ArrayList<Long> TMP_tmp3 = new ArrayList<Long>();
             String TMP_tmp4 = "";
-            int TMP_tmp5 = 0;
+            long TMP_tmp5 = 0L;
 
             TMP_tmp0 = req.accountId;
             TMP_tmp1 = bankBalance.containsKey(TMP_tmp0);
             TMP_tmp2 = req.accountId;
-            TMP_tmp3 = new ArrayList<Integer>(bankBalance.keySet());
+            TMP_tmp3 = new ArrayList<Long>(bankBalance.keySet());
             TMP_tmp4 = java.text.MessageFormat.format("Unknown accountId {0} in the withdraw request. Valid accountIds = {1}", TMP_tmp2, TMP_tmp3);
             tryAssert(TMP_tmp1, TMP_tmp4);
             TMP_tmp5 = req.rId;
             pendingWithDraws.put(TMP_tmp5,req.deepClone());
         }
         private void Anon_2(PTypes.PTuple_stts_accnt_blnc_rId resp) {
-            int TMP_tmp0_1 = 0;
+            long TMP_tmp0_1 = 0L;
             boolean TMP_tmp1_1 = false;
-            int TMP_tmp2_1 = 0;
+            long TMP_tmp2_1 = 0L;
             String TMP_tmp3_1 = "";
-            int TMP_tmp4_1 = 0;
+            long TMP_tmp4_1 = 0L;
             boolean TMP_tmp5_1 = false;
-            int TMP_tmp6 = 0;
+            long TMP_tmp6 = 0L;
             String TMP_tmp7 = "";
-            int TMP_tmp8 = 0;
+            long TMP_tmp8 = 0L;
             boolean TMP_tmp9 = false;
             String TMP_tmp10 = "";
             PTypes.tWithDrawRespStatus TMP_tmp11 = PTypes.tWithDrawRespStatus.WITHDRAW_SUCCESS;
             boolean TMP_tmp12 = false;
-            int TMP_tmp13 = 0;
-            int TMP_tmp14 = 0;
-            int TMP_tmp15 = 0;
-            int TMP_tmp16 = 0;
+            long TMP_tmp13 = 0L;
+            long TMP_tmp14 = 0L;
+            long TMP_tmp15 = 0L;
+            long TMP_tmp16 = 0L;
             PTypes.PTuple_src_accnt_amnt_rId TMP_tmp17 = new PTypes.PTuple_src_accnt_amnt_rId();
-            int TMP_tmp18 = 0;
-            int TMP_tmp19 = 0;
+            long TMP_tmp18 = 0L;
+            long TMP_tmp19 = 0L;
             boolean TMP_tmp20 = false;
-            int TMP_tmp21 = 0;
-            int TMP_tmp22 = 0;
-            int TMP_tmp23 = 0;
-            int TMP_tmp24 = 0;
-            int TMP_tmp25 = 0;
+            long TMP_tmp21 = 0L;
+            long TMP_tmp22 = 0L;
+            long TMP_tmp23 = 0L;
+            long TMP_tmp24 = 0L;
+            long TMP_tmp25 = 0L;
             PTypes.PTuple_src_accnt_amnt_rId TMP_tmp26 = new PTypes.PTuple_src_accnt_amnt_rId();
-            int TMP_tmp27 = 0;
-            int TMP_tmp28 = 0;
+            long TMP_tmp27 = 0L;
+            long TMP_tmp28 = 0L;
             String TMP_tmp29 = "";
-            int TMP_tmp30 = 0;
-            int TMP_tmp31 = 0;
-            int TMP_tmp32 = 0;
-            int TMP_tmp33 = 0;
-            int TMP_tmp34 = 0;
-            int TMP_tmp35 = 0;
+            long TMP_tmp30 = 0L;
+            long TMP_tmp31 = 0L;
+            long TMP_tmp32 = 0L;
+            long TMP_tmp33 = 0L;
+            long TMP_tmp34 = 0L;
+            long TMP_tmp35 = 0L;
             PTypes.PTuple_src_accnt_amnt_rId TMP_tmp36 = new PTypes.PTuple_src_accnt_amnt_rId();
-            int TMP_tmp37 = 0;
-            int TMP_tmp38 = 0;
+            long TMP_tmp37 = 0L;
+            long TMP_tmp38 = 0L;
             boolean TMP_tmp39 = false;
-            int TMP_tmp40 = 0;
+            long TMP_tmp40 = 0L;
             PTypes.PTuple_src_accnt_amnt_rId TMP_tmp41 = new PTypes.PTuple_src_accnt_amnt_rId();
-            int TMP_tmp42 = 0;
-            int TMP_tmp43 = 0;
-            int TMP_tmp44 = 0;
+            long TMP_tmp42 = 0L;
+            long TMP_tmp43 = 0L;
+            long TMP_tmp44 = 0L;
             String TMP_tmp45 = "";
-            int TMP_tmp46 = 0;
-            int TMP_tmp47 = 0;
-            int TMP_tmp48 = 0;
+            long TMP_tmp46 = 0L;
+            long TMP_tmp47 = 0L;
+            long TMP_tmp48 = 0L;
             boolean TMP_tmp49 = false;
-            int TMP_tmp50 = 0;
-            int TMP_tmp51 = 0;
-            int TMP_tmp52 = 0;
+            long TMP_tmp50 = 0L;
+            long TMP_tmp51 = 0L;
+            long TMP_tmp52 = 0L;
             String TMP_tmp53 = "";
 
             TMP_tmp0_1 = resp.accountId;
@@ -132,7 +129,7 @@ public class PMachines {
             TMP_tmp7 = java.text.MessageFormat.format("Unknown rId {0} in the withdraw response!", TMP_tmp6);
             tryAssert(TMP_tmp5_1, TMP_tmp7);
             TMP_tmp8 = resp.balance;
-            TMP_tmp9 = TMP_tmp8 >= 10;
+            TMP_tmp9 = TMP_tmp8 >= 10L;
             TMP_tmp10 = "Bank balance in all accounts must always be greater than or equal to 10!!";
             tryAssert(TMP_tmp9, TMP_tmp10);
             TMP_tmp11 = resp.status;
@@ -169,7 +166,7 @@ public class PMachines {
                 TMP_tmp36 = pendingWithDraws.get(TMP_tmp35);
                 TMP_tmp37 = TMP_tmp36.amount;
                 TMP_tmp38 = TMP_tmp34 - TMP_tmp37;
-                TMP_tmp39 = TMP_tmp38 < 10;
+                TMP_tmp39 = TMP_tmp38 < 10L;
                 TMP_tmp40 = resp.rId;
                 TMP_tmp41 = pendingWithDraws.get(TMP_tmp40);
                 TMP_tmp42 = TMP_tmp41.amount;
@@ -191,25 +188,24 @@ public class PMachines {
 
     } // BankBalanceIsAlwaysCorrect monitor definition
     public static class GuaranteedWithDrawProgress extends prt.Monitor {
-        private LinkedHashSet<Integer> pendingWDReqs = new LinkedHashSet<Integer>();
-        public LinkedHashSet<Integer> get_pendingWDReqs() { return this.pendingWDReqs; };
+        private LinkedHashSet<Long> pendingWDReqs = new LinkedHashSet<Long>();
+        public LinkedHashSet<Long> get_pendingWDReqs() { return this.pendingWDReqs; };
 
 
-        private enum States {
-            NOPENDINGREQUESTS_STATE,
-            PENDINGREQS_STATE
+        public enum PrtStates {
+            NopendingRequests,
+            PendingReqs
         }
 
         public GuaranteedWithDrawProgress() {
             super();
-            addState(prt.State.keyedOn(States.NOPENDINGREQUESTS_STATE)
+            addState(prt.State.keyedOn(PrtStates.NopendingRequests)
                     .isInitialState(true)
-                    .withEvent(PEvents.eWithDrawReq.class, p -> { Anon_3(p); gotoState(States.PENDINGREQS_STATE); })
+                    .withEvent(PEvents.eWithDrawReq.class, p -> { Anon_3(p); gotoState(PrtStates.PendingReqs); })
                     .build());
-            addState(prt.State.keyedOn(States.PENDINGREQS_STATE)
-                    .isInitialState(false)
+            addState(prt.State.keyedOn(PrtStates.PendingReqs)
                     .withEvent(PEvents.eWithDrawResp.class, this::Anon_4)
-                    .withEvent(PEvents.eWithDrawReq.class, p -> { Anon_5(p); gotoState(States.PENDINGREQS_STATE); })
+                    .withEvent(PEvents.eWithDrawReq.class, p -> { Anon_5(p); gotoState(PrtStates.PendingReqs); })
                     .build());
         } // constructor
 
@@ -218,38 +214,38 @@ public class PMachines {
         }
 
         private void Anon_3(PTypes.PTuple_src_accnt_amnt_rId req_1) {
-            int TMP_tmp0_2 = 0;
+            long TMP_tmp0_2 = 0L;
 
             TMP_tmp0_2 = req_1.rId;
             pendingWDReqs.add(TMP_tmp0_2);
         }
-        private void Anon_4(PTypes.PTuple_stts_accnt_blnc_rId resp_1)throws TransitionException {
-            int TMP_tmp0_3 = 0;
+        private void Anon_4(PTypes.PTuple_stts_accnt_blnc_rId resp_1) throws prt.exceptions.TransitionException {
+            long TMP_tmp0_3 = 0L;
             boolean TMP_tmp1_2 = false;
-            int TMP_tmp2_2 = 0;
-            LinkedHashSet<Integer> TMP_tmp3_2 = new LinkedHashSet<Integer>();
+            long TMP_tmp2_2 = 0L;
+            LinkedHashSet<Long> TMP_tmp3_2 = new LinkedHashSet<Long>();
             String TMP_tmp4_2 = "";
-            int TMP_tmp5_2 = 0;
-            int TMP_tmp6_1 = 0;
+            long TMP_tmp5_2 = 0L;
+            long TMP_tmp6_1 = 0L;
             boolean TMP_tmp7_1 = false;
 
             TMP_tmp0_3 = resp_1.rId;
             TMP_tmp1_2 = pendingWDReqs.contains(TMP_tmp0_3);
             TMP_tmp2_2 = resp_1.rId;
-            TMP_tmp3_2 = (LinkedHashSet<Integer>)prt.values.Clone.deepClone(pendingWDReqs);
+            TMP_tmp3_2 = (LinkedHashSet<Long>)prt.values.Clone.deepClone(pendingWDReqs);
             TMP_tmp4_2 = java.text.MessageFormat.format("unexpected rId: {0} received, expected one of {1}", TMP_tmp2_2, TMP_tmp3_2);
             tryAssert(TMP_tmp1_2, TMP_tmp4_2);
             TMP_tmp5_2 = resp_1.rId;
             pendingWDReqs.remove(TMP_tmp5_2);
             TMP_tmp6_1 = pendingWDReqs.size();
-            TMP_tmp7_1 = TMP_tmp6_1 == 0;
+            TMP_tmp7_1 = TMP_tmp6_1 == 0L;
             if (TMP_tmp7_1) {
-                gotoState(States.NOPENDINGREQUESTS_STATE);
+                gotoState(PrtStates.NopendingRequests);
                 return;
             }
         }
         private void Anon_5(PTypes.PTuple_src_accnt_amnt_rId req_2) {
-            int TMP_tmp0_4 = 0;
+            long TMP_tmp0_4 = 0L;
 
             TMP_tmp0_4 = req_2.rId;
             pendingWDReqs.add(TMP_tmp0_4);

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PTypes.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PTypes.java
@@ -1,12 +1,15 @@
 package testmonitors.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Thursday, 30 June 2022 at 14:23:48.
+ * This file was auto-generated on Wednesday, 20 July 2022 at 14:24:31.
  * Please do not edit manually!
  **************************************************************************/
 
+import java.util.*;
+
 public class PTypes {
     /* Enums */
+
     public enum tWithDrawRespStatus {
         WITHDRAW_SUCCESS(0),
         WITHDRAW_ERROR(1);
@@ -15,17 +18,18 @@ public class PTypes {
     }
 
     /* Tuples */
+
     // (accountId:int,balance:int)
     public static class PTuple_accnt_blnc implements prt.values.PValue<PTuple_accnt_blnc> {
-        public final int accountId;
-        public final int balance;
+        public long accountId;
+        public long balance;
 
         public PTuple_accnt_blnc() {
-            this.accountId = 0;
-            this.balance = 0;
+            this.accountId = 0L;
+            this.balance = 0L;
         }
 
-        public PTuple_accnt_blnc(int accountId, int balance) {
+        public PTuple_accnt_blnc(long accountId, long balance) {
             this.accountId = accountId;
             this.balance = balance;
         }
@@ -59,13 +63,13 @@ public class PTypes {
 
     // (accountId:int)
     public static class PTuple_accnt implements prt.values.PValue<PTuple_accnt> {
-        public final int accountId;
+        public long accountId;
 
         public PTuple_accnt() {
-            this.accountId = 0;
+            this.accountId = 0L;
         }
 
-        public PTuple_accnt(int accountId) {
+        public PTuple_accnt(long accountId) {
             this.accountId = accountId;
         }
 
@@ -96,19 +100,19 @@ public class PTypes {
 
     // (source:Client,accountId:int,amount:int,rId:int)
     public static class PTuple_src_accnt_amnt_rId implements prt.values.PValue<PTuple_src_accnt_amnt_rId> {
-        public final long source;
-        public final int accountId;
-        public final int amount;
-        public final int rId;
+        public long source;
+        public long accountId;
+        public long amount;
+        public long rId;
 
         public PTuple_src_accnt_amnt_rId() {
             this.source = 0L;
-            this.accountId = 0;
-            this.amount = 0;
-            this.rId = 0;
+            this.accountId = 0L;
+            this.amount = 0L;
+            this.rId = 0L;
         }
 
-        public PTuple_src_accnt_amnt_rId(long source, int accountId, int amount, int rId) {
+        public PTuple_src_accnt_amnt_rId(long source, long accountId, long amount, long rId) {
             this.source = source;
             this.accountId = accountId;
             this.amount = amount;
@@ -149,18 +153,18 @@ public class PTypes {
     // (status:tWithDrawRespStatus,accountId:int,balance:int,rId:int)
     public static class PTuple_stts_accnt_blnc_rId implements prt.values.PValue<PTuple_stts_accnt_blnc_rId> {
         public PTypes.tWithDrawRespStatus status;
-        public final int accountId;
-        public final int balance;
-        public final int rId;
+        public long accountId;
+        public long balance;
+        public long rId;
 
         public PTuple_stts_accnt_blnc_rId() {
             this.status = PTypes.tWithDrawRespStatus.WITHDRAW_SUCCESS;
-            this.accountId = 0;
-            this.balance = 0;
-            this.rId = 0;
+            this.accountId = 0L;
+            this.balance = 0L;
+            this.rId = 0L;
         }
 
-        public PTuple_stts_accnt_blnc_rId(PTypes.tWithDrawRespStatus status, int accountId, int balance, int rId) {
+        public PTuple_stts_accnt_blnc_rId(PTypes.tWithDrawRespStatus status, long accountId, long balance, long rId) {
             this.status = status;
             this.accountId = accountId;
             this.balance = balance;
@@ -197,6 +201,95 @@ public class PTypes {
             return sb.toString();
         } // toString()
     } //PTuple_stts_accnt_blnc_rId class definition
+
+    // (server:BankServer,initialBalance:map[int,int])
+    public static class PTuple_srvr_intlb implements prt.values.PValue<PTuple_srvr_intlb> {
+        public long server;
+        public HashMap<Long, Long> initialBalance;
+
+        public PTuple_srvr_intlb() {
+            this.server = 0L;
+            this.initialBalance = new HashMap<Long, Long>();
+        }
+
+        public PTuple_srvr_intlb(long server, HashMap<Long, Long> initialBalance) {
+            this.server = server;
+            this.initialBalance = initialBalance;
+        }
+
+        public PTuple_srvr_intlb deepClone() {
+            return new PTuple_srvr_intlb(server, (HashMap<Long, Long>)prt.values.Clone.deepClone(initialBalance));
+        } // deepClone()
+
+        public boolean equals(Object other) {
+            return (this.getClass() == other.getClass() &&
+                    this.deepEquals((PTuple_srvr_intlb)other)
+            );
+        } // equals()
+
+        public boolean deepEquals(PTuple_srvr_intlb other) {
+            return (true
+                    && this.server == other.server
+                    && prt.values.Equality.deepEquals(this.initialBalance, other.initialBalance)
+            );
+        } // deepEquals()
+
+        public String toString() {
+            StringBuilder sb = new StringBuilder("PTuple_srvr_intlb");
+            sb.append("[");
+            sb.append("server=" + server);
+            sb.append(", initialBalance=" + initialBalance);
+            sb.append("]");
+            return sb.toString();
+        } // toString()
+    } //PTuple_srvr_intlb class definition
+
+    // (serv:BankServer,accountId:int,balance:int)
+    public static class PTuple_serv_accnt_blnc implements prt.values.PValue<PTuple_serv_accnt_blnc> {
+        public long serv;
+        public long accountId;
+        public long balance;
+
+        public PTuple_serv_accnt_blnc() {
+            this.serv = 0L;
+            this.accountId = 0L;
+            this.balance = 0L;
+        }
+
+        public PTuple_serv_accnt_blnc(long serv, long accountId, long balance) {
+            this.serv = serv;
+            this.accountId = accountId;
+            this.balance = balance;
+        }
+
+        public PTuple_serv_accnt_blnc deepClone() {
+            return new PTuple_serv_accnt_blnc(serv, accountId, balance);
+        } // deepClone()
+
+        public boolean equals(Object other) {
+            return (this.getClass() == other.getClass() &&
+                    this.deepEquals((PTuple_serv_accnt_blnc)other)
+            );
+        } // equals()
+
+        public boolean deepEquals(PTuple_serv_accnt_blnc other) {
+            return (true
+                    && this.serv == other.serv
+                    && this.accountId == other.accountId
+                    && this.balance == other.balance
+            );
+        } // deepEquals()
+
+        public String toString() {
+            StringBuilder sb = new StringBuilder("PTuple_serv_accnt_blnc");
+            sb.append("[");
+            sb.append("serv=" + serv);
+            sb.append(", accountId=" + accountId);
+            sb.append(", balance=" + balance);
+            sb.append("]");
+            return sb.toString();
+        } // toString()
+    } //PTuple_serv_accnt_blnc class definition
 
 
 }


### PR DESCRIPTION
Other backends use the widest integral types available on the system.