### PR TITLE
[Java] generate a hashcode() implentation for named tuples

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Plang.Compiler.TypeChecker;
 using Plang.Compiler.TypeChecker.Types;
+using static Plang.Compiler.Backend.Java.TypeManager;
 
 namespace Plang.Compiler.Backend.Java
 {
@@ -86,9 +87,9 @@ namespace Plang.Compiler.Backend.Java
 
         private void WriteNamedTupleDecl(NamedTupleType t)
         {
-            // This is a sequence of <type, stringName> pairs.
-            List<(TypeManager.JType, string)> fields =
-                new List<(TypeManager.JType, string)>();
+            // This is a sequence of <type, field name> pairs.
+            List<(JType, string)> fields =
+                new List<(JType, string)>();
 
             // Build up our list of fields.
             foreach (var e in t.Fields)
@@ -103,22 +104,42 @@ namespace Plang.Compiler.Backend.Java
                     type = tdef.TypeDefDecl.Type;
                 }
 
-                TypeManager.JType jType = Types.JavaTypeFor(type);
+                JType jType = Types.JavaTypeFor(type);
 
                 fields.Add((jType, name));
             }
 
             string tname = Names.NameForNamedTuple(t);
-            WriteLine($"// {t.CanonicalRepresentation}");
             WriteLine($"public static class {tname} implements {Constants.PValueClass}<{tname}> {{");
+            WriteLine($"// {t.CanonicalRepresentation}");
 
-            // Write the fields.
+            WriteNamedTupleFields(fields);
+            WriteLine();
+
+            WriteNamedTupleConstructors(tname, fields);
+            WriteLine();
+
+            WriteNamedTupleEqualityMethods(tname, fields);
+            WriteLine();
+
+            WriteNamedTupleToString(tname, fields);
+            WriteLine();
+
+            WriteLine($"}} //{tname} class definition");
+
+            WriteLine();
+        }
+
+        private void WriteNamedTupleFields(List<(JType, string)> fields)
+        {
             foreach (var (jType, fieldName) in fields)
             {
                 WriteLine($"public {jType.TypeName} {fieldName};");
             }
-            WriteLine();
+        }
 
+        private void WriteNamedTupleConstructors(string tname, List<(JType, string)> fields)
+        {
             // Write the default constructor.
             WriteLine($"public {tname}() {{");
             foreach (var (jtype, fieldName) in fields)
@@ -154,7 +175,10 @@ namespace Plang.Compiler.Backend.Java
             WriteLine(");");
             WriteLine("} // deepClone()");
             WriteLine();
+        }
 
+        private void WriteNamedTupleEqualityMethods(string tname, List<(JType, string)> fields)
+        {
             // .equals() implementation: this simply defers to deepEquals() but explicitly overriding it is useful
             // for calling assertEquals() in unit tests, for example.
             WriteLine($"public boolean equals(Object other) {{");
@@ -189,23 +213,24 @@ namespace Plang.Compiler.Backend.Java
             WriteLine(");");
             WriteLine("} // deepEquals()");
             WriteLine();
+        }
 
+        private void WriteNamedTupleToString(string tname, List<(JType, string)> fields)
+        {
             // Write toString() in the same output style as a Java record.
             WriteLine("public String toString() {");
             WriteLine($"StringBuilder sb = new StringBuilder(\"{tname}\");");
+            
             WriteLine("sb.append(\"[\");");
             foreach (var (sep, (_, fieldName)) in fields.WithPrefixSep(", "))
             {
                 WriteLine($"sb.append(\"{sep}{fieldName}=\" + {fieldName});");
             }
             WriteLine("sb.append(\"]\");");
+
             WriteLine("return sb.toString();");
             WriteLine("} // toString()");
-
-            WriteLine($"}} //{tname} class definition");
-
-            WriteLine();
-       }
+        }
 
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
@@ -164,6 +164,18 @@ namespace Plang.Compiler.Backend.Java
             WriteLine("} // equals()");
             WriteLine();
 
+            // hashCode() implementation.
+            WriteLine($"public int hashCode() {{");
+            Write($"return Objects.hash(");
+            foreach (var (sep, (_, fieldName)) in fields.WithPrefixSep(", "))
+            {
+                Write($"{sep}{fieldName}");
+            }
+            WriteLine(");");
+            WriteLine("} // hashCode()");
+            WriteLine();
+
+
             // Deep equality predicate.
             WriteLine($"public boolean deepEquals({tname} other) {{");
             WriteLine("return (true");

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCompareTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCompareTest.java
@@ -2,6 +2,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import prt.exceptions.IncomparableValuesException;
 import prt.values.*;
+import testmonitors.clientserver.PEvents;
+import testmonitors.clientserver.PTypes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -98,5 +100,26 @@ public class ValueCompareTest {
 
         assertFalse(m1.get("123") == m2.get("123")); // Ensure that the values are different references
         assertTrue(Equality.deepEquals(m1, m2));
+    }
+    @Test
+    @DisplayName("hashcode() and equals() is correctly overridden for P tuples and events.")
+    public void testPTypeHashing() {
+        // Tuples.
+        PTypes.PTuple_src_accnt_amnt_rId t1 = new PTypes.PTuple_src_accnt_amnt_rId();
+        PTypes.PTuple_src_accnt_amnt_rId t2 = new PTypes.PTuple_src_accnt_amnt_rId();
+
+        assertFalse(t1 == t2);
+        assertTrue(t1.equals(t2));
+        assertTrue(Equality.deepEquals(t1, t2));
+        assertTrue(t1.hashCode() == t2.hashCode());
+
+        // Events.
+        PEvents.eWithDrawReq e1 = new PEvents.eWithDrawReq(t1);
+        PEvents.eWithDrawReq e2 = new PEvents.eWithDrawReq(t1);
+
+        assertFalse(e1 == e2);
+        assertTrue(e1.equals(e2));
+        assertTrue(Equality.deepEquals(e1, e2));
+        assertTrue(e1.hashCode() == e2.hashCode());
     }
 }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PTypes.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PTypes.java
@@ -1,7 +1,7 @@
 package testmonitors.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Thursday, 21 July 2022 at 12:34:44.
+ * This file was auto-generated on Thursday, 21 July 2022 at 13:40:36.
  * Please do not edit manually!
  **************************************************************************/
 
@@ -19,8 +19,8 @@ public class PTypes {
 
     /* Tuples */
 
-    // (accountId:int,balance:int)
     public static class PTuple_accnt_blnc implements prt.values.PValue<PTuple_accnt_blnc> {
+        // (accountId:int,balance:int)
         public long accountId;
         public long balance;
 
@@ -38,6 +38,7 @@ public class PTypes {
             return new PTuple_accnt_blnc(accountId, balance);
         } // deepClone()
 
+
         public boolean equals(Object other) {
             return (this.getClass() == other.getClass() &&
                     this.deepEquals((PTuple_accnt_blnc)other)
@@ -47,12 +48,14 @@ public class PTypes {
         public int hashCode() {
             return Objects.hash(accountId, balance);
         } // hashCode()
+
         public boolean deepEquals(PTuple_accnt_blnc other) {
             return (true
                     && this.accountId == other.accountId
                     && this.balance == other.balance
             );
         } // deepEquals()
+
 
         public String toString() {
             StringBuilder sb = new StringBuilder("PTuple_accnt_blnc");
@@ -62,10 +65,11 @@ public class PTypes {
             sb.append("]");
             return sb.toString();
         } // toString()
+
     } //PTuple_accnt_blnc class definition
 
-    // (accountId:int)
     public static class PTuple_accnt implements prt.values.PValue<PTuple_accnt> {
+        // (accountId:int)
         public long accountId;
 
         public PTuple_accnt() {
@@ -80,6 +84,7 @@ public class PTypes {
             return new PTuple_accnt(accountId);
         } // deepClone()
 
+
         public boolean equals(Object other) {
             return (this.getClass() == other.getClass() &&
                     this.deepEquals((PTuple_accnt)other)
@@ -89,11 +94,13 @@ public class PTypes {
         public int hashCode() {
             return Objects.hash(accountId);
         } // hashCode()
+
         public boolean deepEquals(PTuple_accnt other) {
             return (true
                     && this.accountId == other.accountId
             );
         } // deepEquals()
+
 
         public String toString() {
             StringBuilder sb = new StringBuilder("PTuple_accnt");
@@ -102,10 +109,11 @@ public class PTypes {
             sb.append("]");
             return sb.toString();
         } // toString()
+
     } //PTuple_accnt class definition
 
-    // (source:Client,accountId:int,amount:int,rId:int)
     public static class PTuple_src_accnt_amnt_rId implements prt.values.PValue<PTuple_src_accnt_amnt_rId> {
+        // (source:Client,accountId:int,amount:int,rId:int)
         public long source;
         public long accountId;
         public long amount;
@@ -129,6 +137,7 @@ public class PTypes {
             return new PTuple_src_accnt_amnt_rId(source, accountId, amount, rId);
         } // deepClone()
 
+
         public boolean equals(Object other) {
             return (this.getClass() == other.getClass() &&
                     this.deepEquals((PTuple_src_accnt_amnt_rId)other)
@@ -138,6 +147,7 @@ public class PTypes {
         public int hashCode() {
             return Objects.hash(source, accountId, amount, rId);
         } // hashCode()
+
         public boolean deepEquals(PTuple_src_accnt_amnt_rId other) {
             return (true
                     && this.source == other.source
@@ -146,6 +156,7 @@ public class PTypes {
                     && this.rId == other.rId
             );
         } // deepEquals()
+
 
         public String toString() {
             StringBuilder sb = new StringBuilder("PTuple_src_accnt_amnt_rId");
@@ -157,10 +168,11 @@ public class PTypes {
             sb.append("]");
             return sb.toString();
         } // toString()
+
     } //PTuple_src_accnt_amnt_rId class definition
 
-    // (status:tWithDrawRespStatus,accountId:int,balance:int,rId:int)
     public static class PTuple_stts_accnt_blnc_rId implements prt.values.PValue<PTuple_stts_accnt_blnc_rId> {
+        // (status:tWithDrawRespStatus,accountId:int,balance:int,rId:int)
         public PTypes.tWithDrawRespStatus status;
         public long accountId;
         public long balance;
@@ -184,6 +196,7 @@ public class PTypes {
             return new PTuple_stts_accnt_blnc_rId(status, accountId, balance, rId);
         } // deepClone()
 
+
         public boolean equals(Object other) {
             return (this.getClass() == other.getClass() &&
                     this.deepEquals((PTuple_stts_accnt_blnc_rId)other)
@@ -193,6 +206,7 @@ public class PTypes {
         public int hashCode() {
             return Objects.hash(status, accountId, balance, rId);
         } // hashCode()
+
         public boolean deepEquals(PTuple_stts_accnt_blnc_rId other) {
             return (true
                     && this.status == other.status
@@ -201,6 +215,7 @@ public class PTypes {
                     && this.rId == other.rId
             );
         } // deepEquals()
+
 
         public String toString() {
             StringBuilder sb = new StringBuilder("PTuple_stts_accnt_blnc_rId");
@@ -212,10 +227,11 @@ public class PTypes {
             sb.append("]");
             return sb.toString();
         } // toString()
+
     } //PTuple_stts_accnt_blnc_rId class definition
 
-    // (server:BankServer,initialBalance:map[int,int])
     public static class PTuple_srvr_intlb implements prt.values.PValue<PTuple_srvr_intlb> {
+        // (server:BankServer,initialBalance:map[int,int])
         public long server;
         public HashMap<Long, Long> initialBalance;
 
@@ -233,6 +249,7 @@ public class PTypes {
             return new PTuple_srvr_intlb(server, (HashMap<Long, Long>)prt.values.Clone.deepClone(initialBalance));
         } // deepClone()
 
+
         public boolean equals(Object other) {
             return (this.getClass() == other.getClass() &&
                     this.deepEquals((PTuple_srvr_intlb)other)
@@ -242,12 +259,14 @@ public class PTypes {
         public int hashCode() {
             return Objects.hash(server, initialBalance);
         } // hashCode()
+
         public boolean deepEquals(PTuple_srvr_intlb other) {
             return (true
                     && this.server == other.server
                     && prt.values.Equality.deepEquals(this.initialBalance, other.initialBalance)
             );
         } // deepEquals()
+
 
         public String toString() {
             StringBuilder sb = new StringBuilder("PTuple_srvr_intlb");
@@ -257,10 +276,11 @@ public class PTypes {
             sb.append("]");
             return sb.toString();
         } // toString()
+
     } //PTuple_srvr_intlb class definition
 
-    // (serv:BankServer,accountId:int,balance:int)
     public static class PTuple_serv_accnt_blnc implements prt.values.PValue<PTuple_serv_accnt_blnc> {
+        // (serv:BankServer,accountId:int,balance:int)
         public long serv;
         public long accountId;
         public long balance;
@@ -281,6 +301,7 @@ public class PTypes {
             return new PTuple_serv_accnt_blnc(serv, accountId, balance);
         } // deepClone()
 
+
         public boolean equals(Object other) {
             return (this.getClass() == other.getClass() &&
                     this.deepEquals((PTuple_serv_accnt_blnc)other)
@@ -290,6 +311,7 @@ public class PTypes {
         public int hashCode() {
             return Objects.hash(serv, accountId, balance);
         } // hashCode()
+
         public boolean deepEquals(PTuple_serv_accnt_blnc other) {
             return (true
                     && this.serv == other.serv
@@ -297,6 +319,7 @@ public class PTypes {
                     && this.balance == other.balance
             );
         } // deepEquals()
+
 
         public String toString() {
             StringBuilder sb = new StringBuilder("PTuple_serv_accnt_blnc");
@@ -307,6 +330,7 @@ public class PTypes {
             sb.append("]");
             return sb.toString();
         } // toString()
+
     } //PTuple_serv_accnt_blnc class definition
 
 

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PTypes.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PTypes.java
@@ -1,7 +1,7 @@
 package testmonitors.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Wednesday, 20 July 2022 at 14:24:31.
+ * This file was auto-generated on Thursday, 21 July 2022 at 12:34:44.
  * Please do not edit manually!
  **************************************************************************/
 
@@ -44,6 +44,9 @@ public class PTypes {
             );
         } // equals()
 
+        public int hashCode() {
+            return Objects.hash(accountId, balance);
+        } // hashCode()
         public boolean deepEquals(PTuple_accnt_blnc other) {
             return (true
                     && this.accountId == other.accountId
@@ -83,6 +86,9 @@ public class PTypes {
             );
         } // equals()
 
+        public int hashCode() {
+            return Objects.hash(accountId);
+        } // hashCode()
         public boolean deepEquals(PTuple_accnt other) {
             return (true
                     && this.accountId == other.accountId
@@ -129,6 +135,9 @@ public class PTypes {
             );
         } // equals()
 
+        public int hashCode() {
+            return Objects.hash(source, accountId, amount, rId);
+        } // hashCode()
         public boolean deepEquals(PTuple_src_accnt_amnt_rId other) {
             return (true
                     && this.source == other.source
@@ -181,6 +190,9 @@ public class PTypes {
             );
         } // equals()
 
+        public int hashCode() {
+            return Objects.hash(status, accountId, balance, rId);
+        } // hashCode()
         public boolean deepEquals(PTuple_stts_accnt_blnc_rId other) {
             return (true
                     && this.status == other.status
@@ -227,6 +239,9 @@ public class PTypes {
             );
         } // equals()
 
+        public int hashCode() {
+            return Objects.hash(server, initialBalance);
+        } // hashCode()
         public boolean deepEquals(PTuple_srvr_intlb other) {
             return (true
                     && this.server == other.server
@@ -272,6 +287,9 @@ public class PTypes {
             );
         } // equals()
 
+        public int hashCode() {
+            return Objects.hash(serv, accountId, balance);
+        } // hashCode()
         public boolean deepEquals(PTuple_serv_accnt_blnc other) {
             return (true
                     && this.serv == other.serv


### PR DESCRIPTION
Baby's first Java gotcha and I fell into it, argh!

```
nathta@bcd0741cf59d 1_ClientServer % jshell -c POutput/ClientServer-1.0-SNAPSHOT-jar-with-dependencies.jar
|  Welcome to JShell -- Version 11.0.14
|  For an introduction type: /help intro

jshell> import PGenerated.PTypes.*;

jshell> PTuple_src_accnt_amnt_rId t1 = new PTuple_src_accnt_amnt_rId();
t1 ==> PTuple_src_accnt_amnt_rId[source=0, accountId=0, amount=0, rId=0]

jshell> PTuple_src_accnt_amnt_rId t2 = new PTuple_src_accnt_amnt_rId();
t2 ==> PTuple_src_accnt_amnt_rId[source=0, accountId=0, amount=0, rId=0]

jshell> t1.equals(t2)
$4 ==> true

jshell> t1.hashCode() == t2.hashCode()
$5 ==> true

jshell>
```