### PR TITLE
[Java] minor fixes to the FFI stub generator

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -66,7 +66,9 @@ in the body of each function definition as necessary for your project's business
         internal static readonly string FFIStubFileName = "FFIStubs.txt";
 
         internal static readonly string FFIPackage = "PForeign";
-        internal static readonly string GlobalFFIPackage = $"{FFIPackage}.globals";
+        internal static readonly string FFITypesPackage = $"{FFIPackage}.types";
+        internal static readonly string FFIGlobalScopeCname = $"P_TopScope";
+
 
         // Something that is clearly not valid Java.
         private static readonly string FFICommentToken = "%";

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -67,7 +67,7 @@ namespace Plang.Compiler.Backend.Java {
 
         private void WriteForeignType(ForeignType ft)
         {
-            WriteLine($"import PForeign.globals.{ft.CanonicalRepresentation};");
+            WriteLine($"import {Constants.FFITypesPackage}.{ft.CanonicalRepresentation};");
         }
 
 
@@ -581,12 +581,20 @@ namespace Plang.Compiler.Backend.Java {
                 throw new NotImplementedException("StaticFunCallExpr is not implemented.");
             }
 
-            string ffiBridge = (f.IsForeign && !isStatic)
-                ? Names.FFIBridgeForMachine(_currentMachine.Name) + "."
-                : "";
             string fname = Names.GetNameForDecl(f);
+            if (f.IsForeign)
+            {
+                string ffiBridge = Names.FFIBridgeForMachine(
+                    isStatic
+                    ? Constants.FFIGlobalScopeCname
+                    : _currentMachine.Name);
+                Write($"{ffiBridge}.{fname}(");
+            }
+            else
+            {
+                Write($"{fname}(");
+            }
 
-            Write($"{ffiBridge}{fname}(");
             foreach (var (sep, expr) in args.WithPrefixSep(", "))
             {
                 Write(sep);


### PR DESCRIPTION
This patch includes some minor fixes to the FFI stub generator that @beyazit-yalcinkaya found.  

The big one is that we couldn't generate code for foreign functions at the top P scope, as there was no associated Monitor proxy class (since there's no monitor!).  There are also a bunch of tiny fixes around FFI stub quality-of-life stuff like automatically importing the right foreign types.

An example of a P project and the new FFI-generated stubs can be see [here](https://github.com/dijkstracula/pprojexample/tree/nathan/fixes_example) for those inclined.

One attribute to this patch that might warrant some conversation is that now foreign types have a stub for `hashCode()`, and `equals()` which just defers to `deepEquals()`.  I did this because I forgot about hashCode the other day and didn't want Future Me to fall into the same trap, but I wonder if we are better off not doing this?  (I did contemplate adding `equals()` to the base type since it will only ever defer to deepEquals(), but I wonder whether that's actually _more_ opaque...)