### PR TITLE
Java FFI: Functions to consume the current Machine

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -30,6 +30,7 @@ namespace Plang.Compiler.Backend.Java
             return classes.Select(pkg => $"import {pkg};");
         }
 
+        public static readonly string PGeneratedNamespaceName = "PGenerated";
 
         public static readonly string MachineNamespaceName = "PMachines";
         public static readonly string MachineDefnFileName = $"{MachineNamespaceName}.java";

--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -58,7 +58,7 @@ namespace Plang.Compiler.Backend.Java
         private static readonly string rawFFIBanner = $@"
 P <-> Java Foreign Function Interface Stubs
 
-This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.  
+This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.
 
 Please separate each generated class into its own .java file (detailed throughout the file), filling
 in the body of each function definition as necessary for your project's business logic.
@@ -92,7 +92,7 @@ in the body of each function definition as necessary for your project's business
 
         internal static string DoNotEditWarning => $@"
 /***************************************************************************
- * This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.  
+ * This file was auto-generated on {DateTime.Now.ToLongDateString()} at {DateTime.Now.ToLongTimeString()}.
  * Please do not edit manually!
  **************************************************************************/";
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -214,6 +214,9 @@ namespace Plang.Compiler.Backend.Java
             WriteLine($"package {Constants.FFIPackage};");
             WriteLine();
 
+            WriteLine("import prt.exceptions.*;");
+            WriteLine($"import {Constants.PGeneratedNamespaceName}.*;");
+
             // The foreign types we need to import are the ones occuring in the signature of
             // a top-level foreign function.
             IEnumerable<Function> ffs = GlobalScope.Functions.Where(f => f.IsForeign);
@@ -222,7 +225,6 @@ namespace Plang.Compiler.Backend.Java
                 JType toImport = Types.JavaTypeFor(t);
                 WriteLine($"import {Constants.FFITypesPackage}.{toImport.TypeName};");
             }
-
             WriteLine();
 
             // Unlike Machine-scoped functions, top-level scoped ones need to go in a special
@@ -259,6 +261,10 @@ namespace Plang.Compiler.Backend.Java
             WriteLine($"package {Constants.FFIPackage};");
             WriteLine();
 
+            WriteLine("import prt.exceptions.*;");
+            WriteLine($"import {Constants.PGeneratedNamespaceName}.*;");
+            WriteLine($"import {Constants.PGeneratedNamespaceName}.{Constants.MachineNamespaceName}.{m.Name}.PrtStates;");
+
             // Import dependencies for a FFI bridge for a monitor are whatever foreign types are used
             // by foreign functions in this monitor.
             foreach (ForeignType t in ffs.SelectMany(ExtractForeignTypesFrom))
@@ -266,7 +272,6 @@ namespace Plang.Compiler.Backend.Java
                 JType toImport = Types.JavaTypeFor(t);
                 WriteLine($"import {Constants.FFITypesPackage}.{toImport.TypeName};");
             }
-
             WriteLine();
 
             // Class definition: By convention, this "para-class" has the same name as
@@ -301,8 +306,8 @@ namespace Plang.Compiler.Backend.Java
             // type the enclosing machine's state enum type is (it's always the `PrtStates`
             // enum inner class) so we can be as precise as we need to be.
             string monitorType = (m == null
-                ? "prt.Monitor<? extends Enum<?>>"
-                : $"{Constants.PGeneratedNamespaceName}.{Constants.MachineNamespaceName}.{m.Name}");
+                ? "prt.Monitor<?>"
+                : $"{Constants.MachineNamespaceName}.{m.Name}");
             Write($"{monitorType} machine");
 
             foreach (var param in f.Signature.Parameters)
@@ -314,7 +319,9 @@ namespace Plang.Compiler.Backend.Java
                 Write($"{ptype.TypeName} {pname}");
             }
 
-            WriteLine(") {");
+            WriteLine(")");
+            WriteLine(" /* throws RaiseEventException, TransitionException */ {");
+
             if (ret is JType.JVoid _)
             {
                 WriteLine($"// TODO");

--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -226,7 +226,7 @@ namespace Plang.Compiler.Backend.Java
             WriteLine();
 
             // Unlike Machine-scoped functions, top-level scoped ones need to go in a special
-            // class, `PForeign.Globals`.
+            // class, `PForeign.P_TopScope`.
             WriteLine($"public class {Constants.FFIGlobalScopeCname} {{");
             foreach (Function f in GlobalScope.Functions.Where(f => f.IsForeign))
             {
@@ -300,10 +300,10 @@ namespace Plang.Compiler.Backend.Java
             // have to wildcard it.  Within a Machine scope, though, we know exactly what
             // type the enclosing machine's state enum type is (it's always the `PrtStates`
             // enum inner class) so we can be as precise as we need to be.
-            string stateEnumType = (m == null
-                ? "? extends Enum<?>"
-                : $"{Constants.PGeneratedNamespaceName}.{Constants.MachineNamespaceName}.{m.Name}.{Constants.StateEnumName}");
-            Write($"prt.Monitor<{stateEnumType}> machine");
+            string monitorType = (m == null
+                ? "prt.Monitor<? extends Enum<?>>"
+                : $"{Constants.PGeneratedNamespaceName}.{Constants.MachineNamespaceName}.{m.Name}");
+            Write($"{monitorType} machine");
 
             foreach (var param in f.Signature.Parameters)
             {

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -31,7 +31,7 @@ namespace Plang.Compiler.Backend.Java
 
         protected virtual void WriteFileHeader()
         {
-            WriteLine("package PGenerated;");
+            WriteLine($"package {Constants.PGeneratedNamespaceName};");
 
             WriteLine(Constants.DoNotEditWarning);
             WriteLine();
@@ -84,13 +84,13 @@ namespace Plang.Compiler.Backend.Java
                 case TypeManager.JType.JBool _:
                 case TypeManager.JType.JInt _:
                 case TypeManager.JType.JFloat _:
+                case TypeManager.JType.JMachine _:
                     writeTermToBeCloned();
                     break;
 
                 /* Same with immutable types. */
                 case TypeManager.JType.JString _:
                 case TypeManager.JType.JEnum _:
-                case TypeManager.JType.JMachine _:
                     writeTermToBeCloned();
                     break;
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -78,7 +78,7 @@ namespace Plang.Compiler.Backend.Java {
         {
             string cname = Names.GetNameForDecl(_currentMachine);
 
-            WriteLine($"public static class {cname} extends prt.Monitor {{");
+            WriteLine($"public static class {cname} extends prt.Monitor<{cname}.{Constants.StateEnumName}> {{");
 
             WriteLine();
             WriteSupplierCDef(cname);

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -615,6 +615,9 @@ namespace Plang.Compiler.Backend.Java {
                     ? Constants.FFIGlobalScopeCname
                     : _currentMachine.Name);
                 Write($"{ffiBridge}.{fname}(");
+
+                // All foreign functions have an implicit first argument to the current machine
+                args = args.Prepend(new ThisRefExpr(f.SourceLocation, _currentMachine));
             }
             else
             {
@@ -751,7 +754,8 @@ namespace Plang.Compiler.Backend.Java {
                     break;
                 }
                 case ThisRefExpr _:
-                    goto default;
+                    Write("this");
+                    break;
                 case UnaryOpExpr ue:
                     switch (ue.Operation)
                     {

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -38,8 +38,7 @@ namespace Plang.Compiler.Backend.Java
                         throw new Exception($"TypeName not implemented for {this.GetType()}");
                     }
 
-                    string prefix = (isUserDefined ? Constants.TypesNamespaceName + "." : "");
-                    return prefix + _unboxedType;
+                    return _unboxedType;
                 }
             }
 
@@ -57,8 +56,7 @@ namespace Plang.Compiler.Backend.Java
                     {
                         return TypeName;
                     }
-                    string prefix = (isUserDefined ? Constants.MachineNamespaceName + "." : "");
-                    return prefix + _refType;
+                    return _refType;
                 }
             }
 
@@ -100,12 +98,6 @@ namespace Plang.Compiler.Backend.Java
             /// </summary>
             internal virtual string RemoveMethodName =>
                 throw new Exception($"RemoveMethodName not implemented for {this.TypeName}");
-
-            /// <summary>
-            /// Returns whether this type is defined by user P code (i.e. a tuple) or if it's a built-in
-            /// type (i.e. a seq or a map).  This is used to qualify type identifiers.
-            /// </summary>
-            internal virtual bool isUserDefined => false;
 
             internal class JAny : JType
             {
@@ -275,11 +267,10 @@ namespace Plang.Compiler.Backend.Java
             {
                 internal JNamedTuple(string jClassName, IEnumerable<(string, JType)> fields)
                 {
-                    _unboxedType = jClassName;
+                    _unboxedType = $"{Constants.TypesNamespaceName}.{jClassName}";
                 }
 
                 internal override bool IsPrimitive => false;
-                internal override bool isUserDefined => true;
             }
 
             internal class JForeign : JType
@@ -307,13 +298,12 @@ namespace Plang.Compiler.Backend.Java
 
                 internal JEnum(EnumType e)
                 {
-                    _unboxedType = e.CanonicalRepresentation;
+                    _unboxedType = Constants.TypesNamespaceName + "." + e.CanonicalRepresentation;
                     _defaultValue = e.EnumDecl.Values.First().Name; // An arbitrary enum value is fine.
                 }
 
-                internal override bool isUserDefined => true;
 
-                internal override string DefaultValue => $"{Constants.TypesNamespaceName}.{_unboxedType}.{_defaultValue}";
+                internal override string DefaultValue => $"{_unboxedType}.{_defaultValue}";
             }
 
             //TODO: not sure about this one.  Is the base class sufficient?
@@ -322,7 +312,7 @@ namespace Plang.Compiler.Backend.Java
             {
                 internal JEvent()
                 {
-                    _unboxedType = "PEvent";
+                    _unboxedType = $"{Constants.EventNamespaceName}.PEvent";
                 }
                 internal override bool IsPrimitive => false;
             }

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/Monitor.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/Monitor.java
@@ -75,7 +75,7 @@ public abstract class Monitor<StateKey extends Enum<StateKey>> implements Consum
      * @param cond The predicate to assert on.
      * @param msg The message to deliver if the predicate is false.
      */
-    protected void tryAssert(boolean cond, String msg)
+    public void tryAssert(boolean cond, String msg)
     {
         if (!cond) throw new PAssertionFailureException(msg);
     }
@@ -86,7 +86,7 @@ public abstract class Monitor<StateKey extends Enum<StateKey>> implements Consum
      * @throws RaiseEventException to context-switch back into the runtime.
      */
     @SuppressWarnings(value = "unchecked")
-    protected <P> void tryRaiseEvent(PEvent<P> ev) throws RaiseEventException
+    public <P> void tryRaiseEvent(PEvent<P> ev) throws RaiseEventException
     {
         throw new RaiseEventException((PEvent<Object>) ev);
     }
@@ -98,7 +98,7 @@ public abstract class Monitor<StateKey extends Enum<StateKey>> implements Consum
      *
      * @throws RuntimeException if `k` is not a state in the state machine.
      */
-    protected void gotoState(StateKey k) throws TransitionException {
+    public void gotoState(StateKey k) throws TransitionException {
         Objects.requireNonNull(k);
 
         if (!states.containsKey(k)) {
@@ -115,7 +115,7 @@ public abstract class Monitor<StateKey extends Enum<StateKey>> implements Consum
      *
      * @throws RuntimeException if `k` is not a state in the state machine.
      */
-    protected <P> void gotoState(StateKey k, P payload) throws TransitionException {
+    public <P> void gotoState(StateKey k, P payload) throws TransitionException {
         Objects.requireNonNull(k);
         Objects.requireNonNull(payload);
 

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Equality.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Equality.java
@@ -60,11 +60,11 @@ public class Equality {
         return true;
     }
 
-    private static <P1 extends PValue<P1>, P2 extends PValue<P2>> boolean deepPValueEquals(P1 t1, P2 t2) {
+    private static <T extends PValue<T>, U extends PValue<U>> boolean deepPValueEquals(PValue<T> t1, PValue<U> t2) {
         if (t1.getClass() != t2.getClass()) {
             return false;
         }
-        return t1.deepEquals((P1)t2);
+        return t1.deepEquals((T)t2);
     }
 
 
@@ -81,10 +81,10 @@ public class Equality {
             // For PValues, defer to their `deepEquals()` method (which may recursively call
             // back into `Values.deepEquals()`.
             if (o1 instanceof PValue<?> && o2 instanceof PValue<?>) {
-                return deepPValueEquals((PValue) o1, (PValue) o2);
+                return deepPValueEquals((PValue<?>) o1, (PValue<?>) o2);
             }
 
-            if (o1 instanceof PEvent && o2 instanceof PEvent<?>) {
+            if (o1 instanceof PEvent<?> && o2 instanceof PEvent<?>) {
                 return o1.equals(o2);
             }
 

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/PValue.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/PValue.java
@@ -1,6 +1,6 @@
 package prt.values;
 
-public interface PValue<P extends PValue<?>> {
+public interface PValue<P extends PValue<P>> {
     /**
      * Performs a deep copy of a P tuple by
      * (The performance difference between a hand-rolled deep copy and using serializers


### PR DESCRIPTION
Noticed that this was a missing part of the FFI for Java.

For functions defined within the scope of a Machine, the FFI generator now emits a call typed to [that exact Monitor type](https://github.com/dijkstracula/pprojexample/blob/nathan/fixes_example/PForeign/Monitor.java#L9).  

For top-level function definitions, we don't know for sure which Monitor is calling the function, [so we unfortunately can't be quite as precise at the type level](https://github.com/dijkstracula/pprojexample/blob/nathan/fixes_example/PForeign/P_TopScope.java#L9), so we just emit the base Monitor type instead.

This patch also makes certain state transition and assert methods that were previously protected within the Monitor type public, [so they can be called on the monitor](https://github.com/dijkstracula/pprojexample/blob/nathan/fixes_example/PForeign/Monitor.java#L12).  See [this commit message](https://github.com/p-org/P/pull/487/commits/8443e2231d2f90106f5a932f39ca6179af0d0f6e) for more details.