### PR TITLE
Correctly emit downcasts for covariant datatypes

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -94,20 +94,21 @@ namespace Plang.Compiler.Backend.Java
                     writeTermToBeCloned();
                     break;
 
-                /* Non-boxable reference types must be cloned explicitly and then
-                 * cast to their expected type (since clone() is Object-producing). */
+                /* Collections and `any` types must be explicitly cloned with the Java P runtime's `deepClone` method;
+                 * there is one override for each of these. */
                 case TypeManager.JType.JAny _:
                 case TypeManager.JType.JMap _:
                 case TypeManager.JType.JList _:
                 case TypeManager.JType.JSet _:
-                case TypeManager.JType.JForeign _: //TODO: is this right?
-                    Write($"({t.TypeName})");
                     Write($"{Constants.PrtDeepCloneMethodName}(");
                     writeTermToBeCloned();
                     Write(")");
                     break;
 
-                /* JNamedTuples have a copy constructor. */
+                /* JNamedTuples and foreign types extend prt.values.PValue, and thus have an explicit `.deepEquals()`
+                 * method.  (We could have just as easily passed these to the runtime's `deepClone` method, but this
+                 * saves us a type dispatch). */
+                case TypeManager.JType.JForeign _:
                 case TypeManager.JType.JNamedTuple _:
                     writeTermToBeCloned();
                     Write(".deepClone()");
@@ -128,7 +129,7 @@ namespace Plang.Compiler.Backend.Java
         }
     }
 
-    static class IEnumerableExtensions
+    static class EnumerableExtensions
     {
 
         /// <summary>

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -562,7 +562,6 @@ namespace Plang.Compiler.Backend.Java {
                     break;
 
                 case SeqAccessExpr seqAccessExpr:
-                    // TODO: do we need to think about handling out of bounds exceptions?
                     WriteExpr(seqAccessExpr.SeqExpr);
                     Write($".{t.MutatorMethodName}(");
                     WriteExpr(seqAccessExpr.IndexExpr);

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -113,7 +113,7 @@ namespace Plang.Compiler.Backend.Java
                 /// be implemented.
                 internal JAny()
                 {
-                    _unboxedType = "PValue";
+                    _unboxedType = "Object";
                 }
 
                 internal override bool IsPrimitive => false;

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Clone.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Clone.java
@@ -15,51 +15,56 @@ public class Clone {
      * they are included.
      */
 
-    private static Boolean cloneBoolean(Boolean b) {
+    public static Boolean deepClone(Boolean b) {
         return b; //already immutable!  No cloning necessary.
     }
 
-    private static Long cloneLong(Long l) {
-        // NB: Actor IDs are stored as Longs.
+    public static Long deepClone(Long l) {
         return l; //already immutable!  No cloning necessary.
     }
 
-    private static Float cloneFloat(Float f) {
+    public static Float deepClone(Float f) {
         return f; //already immutable!  No cloning necessary.
     }
 
-    private static String cloneString(String s) {
+    public static String deepClone(String s) {
         return s; //already immutable!  No cloning necessary.
     }
 
-    private static Enum cloneEnum(Enum e) {
+    public static Enum<?> deepClone(Enum<?> e) {
         return e; //already immutable!  No cloning necessary.
     }
 
-    private static ArrayList<Object> cloneList(ArrayList<?> a) {
-        ArrayList<Object> cloned = new ArrayList<>();
+    public static <T> ArrayList<T> deepClone(ArrayList<T> a) {
+        if (a == null) return null;
+
+        ArrayList<T> cloned = new ArrayList<>();
         cloned.ensureCapacity(a.size());
-        for (Object val : a) {
+        for (T val : a) {
             cloned.add(deepClone(val));
         }
         return cloned;
     }
 
-    private static LinkedHashSet<Object> cloneSet(LinkedHashSet<?> s)
+    public static <T> LinkedHashSet<T> deepClone(LinkedHashSet<T> s)
     {
-        LinkedHashSet<Object> cloned = new LinkedHashSet<>();
-        for (Object val : s) {
+        if (s == null) return null;
+
+        LinkedHashSet<T> cloned = new LinkedHashSet<>();
+        for (T val : s) {
             cloned.add(deepClone(val));
         }
         return cloned;
     }
 
-    private static HashMap<Object, Object> cloneMap(HashMap<?, ?> m)
+    public static <T,U> HashMap<T, U> deepClone(HashMap<T, U> m)
     {
-        HashMap<Object, Object> cloned = new HashMap<>();
-        for (Map.Entry<?,?> e : m.entrySet()) {
-            Object k = deepClone(e.getKey());
-            Object v = deepClone(e.getValue());
+        if (m == null) return null;
+
+        HashMap<T, U> cloned = new HashMap<>();
+        for (Map.Entry<T,U> e : m.entrySet()) {
+            T k = deepClone(e.getKey());
+            U v = deepClone(e.getValue());
             cloned.put(k, v);
         }
         return cloned;
@@ -75,32 +80,32 @@ public class Clone {
      * @return a structurally-equivalent version of `o` but such that mutations of
      * one object are not visible within the other.
      */
-    public static Object deepClone(Object o) {
+    public static <T> T deepClone(T o) {
         if (o == null) {
             return null;
         }
+
         if (o instanceof PValue<?>) {
-            return ((PValue<?>)o).deepClone();
+            return (T) ((PValue<?>)o).deepClone();
         }
 
         Class<?> clazz = o.getClass();
         if (clazz == Boolean.class)
-            return cloneBoolean((Boolean)o);
+            return (T) deepClone((Boolean)o);
         if (clazz == Long.class)
-            return cloneLong((Long)o);
+            return (T) deepClone((Long)o);
         if (clazz == Float.class)
-            return cloneFloat((Float)o);
+            return (T) deepClone((Float)o);
         if (clazz == String.class)
-            return cloneString((String)o);
+            return (T) deepClone((String)o);
         if (clazz == ArrayList.class)
-            return cloneList((ArrayList<?>) o);
+            return (T) deepClone((ArrayList<?>) o);
         if (clazz == HashMap.class)
-            return cloneMap((HashMap<?, ?>) o);
+            return (T) deepClone((HashMap<?, ?>) o);
         if (clazz == LinkedHashSet.class)
-            return cloneSet((LinkedHashSet<?>) o);
+            return (T) deepClone((LinkedHashSet<?>) o);
         if (Enum.class.isAssignableFrom(clazz))
-            return cloneEnum((Enum) o);
-
+            return (T) deepClone((Enum<?>) o);
 
         throw new UncloneableValueException(clazz);
     }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ClientServerTraceParser/ClientServerTraceParser.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ClientServerTraceParser/ClientServerTraceParser.java
@@ -11,8 +11,8 @@ import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
-import static testmonitors.clientserver.PEvents.*;
-import static testmonitors.clientserver.PTypes.*;
+import static testcases.clientserver.PEvents.*;
+import static testcases.clientserver.PTypes.*;
 
 /**
  * Here is an example of a P parser that makes use of the PTraceParserUtils` helper class to

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ClientServerTraceParser/ClientServerTraceParserTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ClientServerTraceParser/ClientServerTraceParserTest.java
@@ -2,8 +2,8 @@ package ClientServerTraceParser;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import testmonitors.clientserver.PEvents;
-import testmonitors.clientserver.PTypes;
+import testcases.clientserver.PEvents;
+import testcases.clientserver.PTypes;
 
 import java.util.Arrays;
 import java.util.Iterator;

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCompareTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ValueCompareTest.java
@@ -2,8 +2,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import prt.exceptions.IncomparableValuesException;
 import prt.values.*;
-import testmonitors.clientserver.PEvents;
-import testmonitors.clientserver.PTypes;
+import testcases.clientserver.PEvents;
+import testcases.clientserver.PTypes;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/UnboundedNat.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/UnboundedNat.java
@@ -1,0 +1,29 @@
+package testcases;
+
+import prt.values.PValue;
+
+import java.math.BigInteger;
+
+// A simple foreign type that wraps a BigInteger.
+public class UnboundedNat implements PValue<UnboundedNat> {
+    private BigInteger i = BigInteger.ZERO;
+    public BigInteger getI() {
+        return i;
+    }
+
+    public void add(long l) {
+        i = i.add(BigInteger.valueOf(l));
+    }
+
+    @Override
+    public UnboundedNat deepClone() {
+        UnboundedNat n = new UnboundedNat();
+        n.i = i;
+        return n;
+    }
+
+    @Override
+    public boolean deepEquals(UnboundedNat o2) {
+        return o2 != null && this.i.equals(o2.i);
+    }
+}

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/ClientServerTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/ClientServerTest.java
@@ -1,4 +1,4 @@
-package testmonitors.clientserver;
+package testcases.clientserver;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,9 +15,9 @@ import prt.exceptions.UnhandledEventException;
 import static org.junit.jupiter.api.Assertions.*;
 
 import static prt.values.Equality.deepEquals;
-import static testmonitors.clientserver.PMachines.*;
-import static testmonitors.clientserver.PEvents.*;
-import static testmonitors.clientserver.PTypes.*;
+import static testcases.clientserver.PMachines.*;
+import static testcases.clientserver.PEvents.*;
+import static testcases.clientserver.PTypes.*;
 
 public class ClientServerTest {
     private BankBalanceIsAlwaysCorrect initedBankBalanceIsAlwaysCorrect() {

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PEvents.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PEvents.java
@@ -1,4 +1,4 @@
-package testmonitors.clientserver;
+package testcases.clientserver;
 
 /***************************************************************************
  * This file was auto-generated on Wednesday, 20 July 2022 at 14:12:46.

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
@@ -1,7 +1,7 @@
-package testmonitors.clientserver;
+package testcases.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Friday, 22 July 2022 at 08:49:45.
+ * This file was auto-generated on Monday, 01 August 2022 at 11:28:45.
  * Please do not edit manually!
  **************************************************************************/
 
@@ -52,7 +52,7 @@ public class PMachines {
         }
 
         private void Anon(HashMap<Long, Long> balance) {
-            bankBalance = (HashMap<Long, Long>)prt.values.Clone.deepClone(balance);
+            bankBalance = prt.values.Clone.deepClone(balance);
         }
         private void Anon_1(PTypes.PTuple_src_accnt_amnt_rId req) {
             long TMP_tmp0 = 0L;
@@ -250,7 +250,7 @@ public class PMachines {
             TMP_tmp0_3 = resp_1.rId;
             TMP_tmp1_2 = pendingWDReqs.contains(TMP_tmp0_3);
             TMP_tmp2_2 = resp_1.rId;
-            TMP_tmp3_2 = (LinkedHashSet<Long>)prt.values.Clone.deepClone(pendingWDReqs);
+            TMP_tmp3_2 = prt.values.Clone.deepClone(pendingWDReqs);
             TMP_tmp4_2 = java.text.MessageFormat.format("unexpected rId: {0} received, expected one of {1}", TMP_tmp2_2, TMP_tmp3_2);
             tryAssert(TMP_tmp1_2, TMP_tmp4_2);
             TMP_tmp5_2 = resp_1.rId;

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PTypes.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PTypes.java
@@ -1,4 +1,4 @@
-package testmonitors.clientserver;
+package testcases.clientserver;
 
 /***************************************************************************
  * This file was auto-generated on Thursday, 21 July 2022 at 13:40:36.

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/espressomachine/EspressoMachine.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/espressomachine/EspressoMachine.java
@@ -1,4 +1,4 @@
-package testmonitors.espressomachine;
+package testcases.espressomachine;
 
 /***************************************************************************
  * This file was auto-generated on Wednesday, 22 June 2022 at 11:28:46.

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/espressomachine/EspressoMachineTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/espressomachine/EspressoMachineTest.java
@@ -1,10 +1,10 @@
-package testmonitors.espressomachine;
+package testcases.espressomachine;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
-import static testmonitors.espressomachine.EspressoMachine.*;
+import static testcases.espressomachine.EspressoMachine.*;
 
 public class EspressoMachineTest {
     @Test

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/failuredetector/FailureDetector.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/failuredetector/FailureDetector.java
@@ -1,4 +1,4 @@
-package testmonitors.failuredetector;
+package testcases.failuredetector;
 
 /***************************************************************************
  * This file was auto-generated on Wednesday, 22 June 2022 at 11:29:15.

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/failuredetector/FailureDetectorTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/failuredetector/FailureDetectorTest.java
@@ -1,4 +1,4 @@
-package testmonitors.failuredetector;
+package testcases.failuredetector;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import static testmonitors.failuredetector.FailureDetector.*;
+import static testcases.failuredetector.FailureDetector.*;
 
 public class FailureDetectorTest {
     @Test

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/twophasecommit/TwoPhaseCommit.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/twophasecommit/TwoPhaseCommit.java
@@ -1,4 +1,4 @@
-package testmonitors.twophasecommit;
+package testcases.twophasecommit;
 
 /***************************************************************************
  * This file was auto-generated on Wednesday, 22 June 2022 at 11:28:16.

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/twophasecommit/TwoPhaseCommitTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/twophasecommit/TwoPhaseCommitTest.java
@@ -1,4 +1,4 @@
-package testmonitors.twophasecommit;
+package testcases.twophasecommit;
 
 import java.util.List;
 
@@ -8,7 +8,7 @@ import prt.exceptions.PAssertionFailureException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import static testmonitors.twophasecommit.TwoPhaseCommit.*;
+import static testcases.twophasecommit.TwoPhaseCommit.*;
 
 public class TwoPhaseCommitTest {
     private AtomicityInvariant initedMonitor() {


### PR DESCRIPTION
Per [this TODO comment block](https://github.com/p-org/P/blob/1b69964fb0d64ca7acaf6f8d5be190703cb86940/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs#L867-L875): Collections in P are covariant.  This means that because `int` is a subclass of `any`, `seq[int]` is a subclass of `seq[any]`.  We were not emitting correct Java code for cases where a downcast is expected during an assignment statement.  This patch fixes it along with some minor adjustments to extracted Java casting behaviour.

## Background

(If you are familiar with the problem with covariant collections you can skip this part)

In languages with mutable references, covariant collections are problematic:

```
jshell> String ss[] = new String[] { "Java", "Arrays", "Are", "Covariant" }
ss ==> String[4] { "Java", "Arrays", "Are", "Covariant" }

jshell> Object os[] = ss;
os ==> String[4] { "Java", "Arrays", "Are", "Covariant" }
```

This violates type safety if we decided to overwrite values in `os` (and hence in `ss`).  As far as the type system knows any Object can be stored in `os`, but of course this isn't the case, because `os == ss`.

```
jshell> os == ss;
$10 ==> true

jshell> os[1] = Long.valueOf(42)
|  Exception java.lang.ArrayStoreException: java.lang.Long
|        at (#11:1)

jshell>
```

## The bug

However, in P-land we are safer because the assignment to `os` would be from a cloned collection: the following P code will get compiled down to the following Java code:

```
  9 spec monitorA observes eIncr {
 10   var os: seq[any];
 11   start state Init {
 12     entry {
 13       var is: seq[int];
 14       os = is;
 15     }
 16   }
 17 }
```

```java
 10 public class PMachines {
 11     public static class monitorA extends prt.Monitor<monitorA.PrtStates> {
...
 21         private ArrayList<Object> os = new ArrayList<Object>();
...
 41         private void Anon() {
 42             ArrayList<Long> is = new ArrayList<Long>();
 43
 44             os = (ArrayList<Long>)prt.values.Clone.deepClone(is);
 45         }
```

Unfortunately, this isn't precisely the right code that we want to have genearted:  The Java language designers realized that because of the above issue with covariant arrays, the Collections API would be _invariant_ in its type.  Therefore, even though `j.l.Long` extends `j.l.Object`, there's no inheritance relationship between `ArrayList<Long>` and `ArrayList<Object>`.  Therefore, the above code actually fails to compile.

```
[ERROR] /private/tmp/PMachines.java:[44,18] incompatible types: java.util.ArrayList<java.lang.Long> cannot be converted to java.util.ArrayList<java.lang.Object>
```

We have "good news", though - because we lose type information at runtime, [deepClone() has no choice but to clone an `ArrayList<Long>` as an `ArrayList<Object>`](https://github.com/p-org/P/blob/master/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Clone.java#L39-L46)!  So, the problem with the above Java code is only that we are casting it to the rval type of the assignment as opposed to the lval.

```
jshell> ArrayList<Long> is = new ArrayList<>(List.of(1L, 2L, 3L))
is ==> [1, 2, 3]

jshell> ArrayList<Object> os = (ArrayList<Object>)prt.values.Clone.deepClone(is); // deepClone returns an Object
|  Warning:
|  unchecked cast
|    required: java.util.ArrayList<java.lang.Object>
|    found:    java.lang.Object
|  ArrayList<Object> os = (ArrayList<Object>)prt.values.Clone.deepClone(is);
|                                            ^----------------------------^
os ==> [1, 2, 3]

jshell> os.add("No runtime exception here, as we are backed by an Object[] !")
$14 ==> true

jshell> os
os ==> [1, 2, 3, No runtime exception here, as we are backed by an Object[] !]

jshell>
```

The problem is that the rval `CloneExpr` has no idea that it's being used in a larger context, so there isn't a "local" way to to see that line 44 of the example program should be emitted as 

```
 44             os = (ArrayList<Object>)prt.values.Clone.deepClone(is); // Only ArrayList<Object> because that's the LHS type
```

## Solution

This issue gave me the change to rethink some parts of how deepClone() works, and I think we're in a better place in general.

### A better deepClone code emitter

The current implementation of `prt.values.Clone.deepClone` consumes and returns a plain old `Object` in all cases.  This is not necessarily incorrect, but, this means _all returned values need to be upcast to their correct type_ even if the Java type system could have known what type it is supposed to be.  You can see this in [the current generated code](https://github.com/p-org/P/blob/1b69964fb0d64ca7acaf6f8d5be190703cb86940/Src/PRuntimes/PJavaRuntime/src/test/java/testmonitors/clientserver/PMachines.java#L55) - we basically "forget" the type when we pass it to `deepClone`, and then coerce the returned type back to what we already knew it to be.

Changes to the PRT have been made such that `deepClone` now consumes an arbitrary type `T` and returns that same `T`.  In this way, we don't need to "forget and then upcast" in this way.  This lets us better leverage the Java-level typechecking to ensure we're not spuriously cloning and casting values to wildly disparate types.  And unlike before, where we just emit casts in an ad-hoc manner, here we're actually producing new AST nodes to take advantage of existing code generation mechanisms.

Note that because of type erasure, the return type of, say, the [ArrayList clone method](https://github.com/p-org/P/blob/nathan/covariant_schmovariant/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/Clone.java#L38-L47) ends up _still_ being an `ArrayList<Object>`.

Overall, this makes the Java generated code more readable - it's less noisy because the unnecessary casts are gone, and the reader will now know that when a cast is present it's because it _has_ to be there, not because the code generator was naive or silly.

Which brings us to...

### The solution to the "clone into an any" problem:

The core of this patch fixes the immediate problem described above: Line 44 is now cast to the value of `os` during assignment.

```
...
 21         private ArrayList<Object> os = new ArrayList<Object>();
...
 42             ArrayList<Long> is = new ArrayList<Long>();
 43
 44             os = ((ArrayList<Object>)((Object)prt.values.Clone.deepClone(is)));
```

Eagle-eyed reviewers will notice that this now has _two_ casts: one that downcasts the return value of deepClone to an Object, and then _upcasts_ it to an ArrayList<Object>.  This is a Java type system implementation detail: Java won't let us cast an `ArrayList<T>` to an `ArrayList<U>` for some `T extends U` for the reasons described above, so we have to be wildly unsafe (or at least rely on P's typechecker!) in the subtyping case by downcasting entirely to throw away the type parameter.  Alas.  

But, on the balance, I think if you look at the generated ClientServer code, in addition to being safer in the presence of `any`s the generated code is improved overall.