### PR TITLE
[Java] rename tokens reserved by the Java backend

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -10,7 +10,6 @@ namespace Plang.Compiler.Backend.Java
     /// </summary>
     internal static class Constants
     {
-
         #region Machine source generation
 
         private static readonly string[] JreDefaultImports =
@@ -31,6 +30,7 @@ namespace Plang.Compiler.Backend.Java
         }
 
         public static readonly string PGeneratedNamespaceName = "PGenerated";
+        public static readonly string PRTNamespaceName = "prt";
 
         public static readonly string MachineNamespaceName = "PMachines";
         public static readonly string MachineDefnFileName = $"{MachineNamespaceName}.java";
@@ -64,11 +64,11 @@ Please separate each generated class into its own .java file (detailed throughou
 in the body of each function definition as necessary for your project's business logic.
 ";
 
-        internal static readonly string FFIStubFileName = "FFIStubs.txt";
+        public static readonly string FFIStubFileName = "FFIStubs.txt";
 
-        internal static readonly string FFIPackage = "PForeign";
+        public static readonly string FFIPackage = "PForeign";
         internal static readonly string FFITypesPackage = $"{FFIPackage}.types";
-        internal static readonly string FFIGlobalScopeCname = $"P_TopScope";
+        public static readonly string FFIGlobalScopeCname = "P_TopScope";
 
 
         // Something that is clearly not valid Java.
@@ -197,6 +197,36 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         /// The fully-qualified class name of the Java P runtime's PEvent class.
         /// </summary>
         public static readonly string PEventsClass = "prt.events.PEvent";
+
+        #endregion
+
+
+        #region Reserved words
+
+        private static HashSet<string> _reservedWords = null;
+
+        /// <summary>
+        /// Reflects out all the string fields defined in this class.
+        /// </summary>
+        private static HashSet<string> ExtractReservedWords()
+        {
+            Type self = typeof(Constants);
+            return self.GetFields()
+                .Where(f => f.IsStatic && f.FieldType == typeof(string))
+                .Select(f => (string)f.GetValue(null) /* passed null b/c all our fields are static */ )
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Checks whether the given string should be considered a reserved word for the Java backend.  For our
+        /// purposes, if the string matches a static string defined in this class, then we consider it a reserved
+        /// word (since that string will be used actively in code generation)
+        /// </summary>
+        public static bool IsReserved(string token)
+        {
+            _reservedWords ??= ExtractReservedWords();
+            return _reservedWords.Contains(token);
+        }
 
         #endregion
     }

--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -6,10 +6,22 @@ using System.Text;
 namespace Plang.Compiler.Backend.Java
 {
     /// <summary>
-    /// Holds some string constants for the JavaCodeGenerator.
+    /// Holds some string constants for the JavaCodeGenerator.  Any public strings
+    /// defined in this class are additionally implicitly Java backend-specific
+    /// keywords and will be renamed if a P programmer gives an identifier a name
+    /// matching one of them.  See the `Reserved words` region for details.
     /// </summary>
     internal static class Constants
     {
+        #region P Java runtime constants
+
+        public static readonly string PRTNamespaceName = "prt";
+
+        public static readonly string TryAssertMethodName = "tryAssert";
+        public static readonly string TryRaiseEventMethodName = "tryRaiseEvent";
+
+        #endregion
+
         #region Machine source generation
 
         private static readonly string[] JreDefaultImports =
@@ -30,7 +42,6 @@ namespace Plang.Compiler.Backend.Java
         }
 
         public static readonly string PGeneratedNamespaceName = "PGenerated";
-        public static readonly string PRTNamespaceName = "prt";
 
         public static readonly string MachineNamespaceName = "PMachines";
         public static readonly string MachineDefnFileName = $"{MachineNamespaceName}.java";
@@ -74,7 +85,7 @@ in the body of each function definition as necessary for your project's business
         // Something that is clearly not valid Java.
         private static readonly string FFICommentToken = "%";
 
-        public static string FFICommentDivider = new StringBuilder(72).Insert(0, FFICommentToken, 72).ToString();
+        internal static readonly string FFICommentDivider = new StringBuilder(72).Insert(0, FFICommentToken, 72).ToString();
 
         internal static string AsFFIComment(string line)
         {
@@ -168,40 +179,97 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         /// The fully-qualified name of the static `deepClone(PrtValue)` method exposed by
         /// the Java PRT runtime.
         /// </summary>
-        public static readonly string PrtDeepCloneMethodName = "prt.values.Clone.deepClone";
+        internal static readonly string PrtDeepCloneMethodName = "prt.values.Clone.deepClone";
 
         /// <summary>
         /// The fully-qualified name of the static `deepEquality(Object, Object)` method
         /// exposed by the Java PRT runtime.
         /// </summary>
-        public static readonly string PrtDeepEqualsMethodName = "prt.values.Equality.deepEquals";
+        internal static readonly string PrtDeepEqualsMethodName = "prt.values.Equality.deepEquals";
 
         /// <summary>
         /// The fully-qualified name of the static `compare(Comparable, Comparable)` method
         /// exposed by the Java PRT runtime.
         /// </summary>
-        public static readonly string PrtCompareMethodName = "prt.values.Equality.compare";
+        internal static readonly string PrtCompareMethodName = "prt.values.Equality.compare";
 
         /// <summary>
         /// The fully-qualified name of the static `eleemntAt(LinkedHashSet, int)` method
         /// exposed by the Java PRT runtime.
         /// </summary>
-        public static readonly string PrtSetElementAtMethodName = "prt.values.SetIndexing.elementAt";
+        internal static readonly string PrtSetElementAtMethodName = "prt.values.SetIndexing.elementAt";
 
         /// <summary>
         /// The fully-qualified class name of the Java P runtime's PValue class.
         /// </summary>
-        public static readonly string PValueClass = "prt.values.PValue";
+        internal static readonly string PValueClass = "prt.values.PValue";
 
         /// <summary>
         /// The fully-qualified class name of the Java P runtime's PEvent class.
         /// </summary>
-        public static readonly string PEventsClass = "prt.events.PEvent";
+        internal static readonly string PEventsClass = "prt.events.PEvent";
 
         #endregion
 
 
         #region Reserved words
+
+        // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
+        // keywords that match P reserved words are commented out.
+        private static IEnumerable<string> _javaKeywords = new[]
+        {
+            "abstract",
+            /*"assert",*/
+            /*"boolean",*/
+            /*"break",*/
+            "byte",
+            /*"case",*/
+            "catch",
+            "char",
+            "class",
+            "const",
+            "continue",
+            "default",
+            /*"do",*/
+            /*"double",*/
+            "else",
+            "enum",
+            "extends",
+            "final",
+            "finally",
+            /*"float",*/
+            /*"for",*/
+            /*"goto",*/
+            /*"if",*/
+            "implements",
+            "import",
+            "instanceof",
+            /*"int",*/
+            "interface",
+            "java", /* not strictly a keyword but it's the top level language import */
+            "long",
+            "native",
+            /*"new",*/
+            "package",
+            "private",
+            "protected",
+            "public",
+            /*"return",*/
+            "short",
+            "static",
+            "strictfp",
+            "super",
+            "switch",
+            "synchronized",
+            /*"this",*/
+            "throw",
+            "throws",
+            "transient",
+            "try",
+            /*"void",*/
+            "volatile",
+            /*"while",*/
+        };
 
         private static HashSet<string> _reservedWords = null;
 
@@ -224,7 +292,9 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         /// </summary>
         public static bool IsReserved(string token)
         {
-            _reservedWords ??= ExtractReservedWords();
+            _reservedWords ??= ExtractReservedWords()
+                .Concat(_javaKeywords)
+                .ToHashSet();
             return _reservedWords.Contains(token);
         }
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -252,10 +252,12 @@ namespace Plang.Compiler.Backend.Java
                 return;
             }
 
+            string mname = Names.GetNameForDecl(m);
+
             WriteLine(Constants.FFICommentDivider);
 
             WriteLine();
-            WriteFFIHeader(m.Name);
+            WriteFFIHeader(mname);
             WriteLine();
 
             WriteLine($"package {Constants.FFIPackage};");
@@ -277,7 +279,7 @@ namespace Plang.Compiler.Backend.Java
             // Class definition: By convention, this "para-class" has the same name as
             // the P machine it is defined within, to mimic the C#-style partial class mixin
             // functionalty that we are not afforded in Java, unfortunately.
-            WriteLine($"public class {m.Name} {{");
+            WriteLine($"public class {mname} {{");
             foreach (Function f in ffs)
             {
                 WriteForeignFunctionStub(f, m);
@@ -296,9 +298,14 @@ namespace Plang.Compiler.Backend.Java
         /// <param name="m">The machine scope (if null, treated as the global scope)</param>
         void WriteForeignFunctionStub(Function f, Machine m = null)
         {
-            JType ret = Types.JavaTypeFor(f.Signature.ReturnType);
+            string fname = Names.GetNameForDecl(f);
+            TypeManager.JType ret = Types.JavaTypeFor(f.Signature.ReturnType);
 
-            WriteLine($"public static {ret.TypeName} {f.Name}(");
+            Write($"public static {ret.TypeName} {fname}(");
+            if (f.Signature.Parameters.Any())
+            {
+                WriteLine();
+            }
 
             // If the function is being emitted at global scope, any monitor can call it
             // and hence we can't say anything about the monitor's state enum type, so we
@@ -312,8 +319,8 @@ namespace Plang.Compiler.Backend.Java
 
             foreach (var param in f.Signature.Parameters)
             {
-                string pname = param.Name;
-                JType ptype = Types.JavaTypeFor(param.Type);
+                string pname = Names.GetNameForDecl(param);
+                TypeManager.JType ptype = Types.JavaTypeFor(param.Type);
 
                 WriteLine(",");
                 Write($"{ptype.TypeName} {pname}");

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -100,7 +100,8 @@ namespace Plang.Compiler.Backend.Java {
             WriteLine($"public enum {Constants.StateEnumName} {{");
             foreach (var (state, sep) in _currentMachine.States.WithPostfixSep(","))
             {
-                WriteLine($"{state.Name}{sep}");
+                string name = Names.GetNameForDecl(state);
+                WriteLine($"{name}{sep}");
             }
             WriteLine("}");
             WriteLine();
@@ -253,7 +254,8 @@ namespace Plang.Compiler.Backend.Java {
             Write("return java.util.Arrays.asList(");
             foreach (var (sep, ev) in _currentMachine.Observes.Events.WithPrefixSep(", "))
             {
-                Write($"{sep}{Constants.EventNamespaceName}.{ev.Name}.class");
+                string name = Names.GetNameForDecl(ev);
+                Write($"{sep}{Constants.EventNamespaceName}.{name}.class");
             }
             WriteLine(");");
             WriteLine("}");

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -250,7 +250,8 @@ namespace Plang.Compiler.Backend.Java {
 
         private void WriteEventsAccessor()
         {
-            WriteLine("public java.util.List<Class<? extends prt.events.PEvent<?>>> getEventTypes() {");
+            TypeManager.JType eventType = new TypeManager.JType.JEvent();
+            WriteLine($"public java.util.List<Class<? extends {eventType.TypeName}>> getEventTypes() {{");
             Write("return java.util.Arrays.asList(");
             foreach (var (sep, ev) in _currentMachine.Observes.Events.WithPrefixSep(", "))
             {
@@ -366,7 +367,7 @@ namespace Plang.Compiler.Backend.Java {
                     break;
 
                 case AssertStmt assertStmt:
-                    Write("tryAssert(");
+                    Write($"{Constants.TryAssertMethodName}(");
                     WriteExpr(assertStmt.Assertion);
                     Write(", ");
                     WriteExpr(assertStmt.Message);
@@ -458,7 +459,7 @@ namespace Plang.Compiler.Backend.Java {
                     break;
 
                 case RaiseStmt raiseStmt:
-                    Write("tryRaiseEvent(new ");
+                    Write($"{Constants.TryRaiseEventMethodName}(new ");
                     WriteExpr(raiseStmt.PEvent);
                     Write("(");
                     foreach (var (sep, expr) in raiseStmt.Payload.WithPrefixSep(", "))
@@ -468,7 +469,6 @@ namespace Plang.Compiler.Backend.Java {
                     }
                     Write(")");
                     WriteLine(");");
-                    WriteLine("return;");
                     break;
 
                 case ReceiveStmt _:

--- a/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
@@ -29,7 +29,8 @@ namespace Plang.Compiler.Backend.Java
         /// <returns>The identifier.</returns>
         public string IdentForState(State s)
         {
-            return Constants.StateEnumName + "." + s.Name;
+            string name = GetNameForDecl(s);
+            return Constants.StateEnumName + "." + name;
         }
 
         /// <summary>
@@ -116,13 +117,13 @@ namespace Plang.Compiler.Backend.Java
                 name = "TMP_" + name.Substring(1);
             }
 
-            // Handle the case where a declaration happens to match the name of the top level
-            // classname (which, as it isn't strictly a declaration in the grammar, doesn't
-            // pass through here)
-            if (name == TopLevelCName)
+            // If the name matches a reserved word (either a string defined in the Constants class or the top-level
+            // compilation job), pre-uniquify it so there is no collision during Java compilation.
+            if (name == TopLevelCName || Constants.IsReserved(name))
             {
-                string cname = decl.GetType().ToString().Split(".").Last();
-                name = $"{name}_{cname}";
+                //No need to use the fully-qualified typename, just grab the innermost class name for this.
+                string tname = decl.GetType().ToString().Split(".").Last();
+                name = $"{name}_{tname}";
             }
 
             return UniquifyName(name);

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -312,7 +312,7 @@ namespace Plang.Compiler.Backend.Java
             {
                 internal JEvent()
                 {
-                    _unboxedType = $"{Constants.EventNamespaceName}.PEvent";
+                    _unboxedType = $"{Constants.PEventsClass}<?>";
                 }
                 internal override bool IsPrimitive => false;
             }


### PR DESCRIPTION
The Java backend (as with all other backends) reserves certain keywords for internal use.  Examples would be `prt` (the top-level package for the P java runtime) and `PEvents` (the package where all P events are stored).  This means that P programs can't use those keywords as P-language identifiers in a safe manner.  Consider the following slightly silly program:

```
nathta@bcd0741cf59d /tmp % cat -n foo.p
     1  enum PValue {
     2    VALUE_ZERO,
     3    VALUE_ONE
     4  }
     5
     6  event PEvent : PValue;
     7
     8  spec PMachines observes PEvent {
     9    var PEvents: set[PValue];
    10    start state P_TopScope {
    11      entry {
    12      }
    13    }
    14  }
nathta@bcd0741cf59d /tmp %
```

This of course is an extreme example but there's no reason why a P programmer should believe this shouldn't compile.  (For instance, `PEvents` could reasonably be a set of events, or something.). But, unsurprisingly, this doesn't currently compile, and the Java compilation errors get pretty gnarly (all around `cyclic inheritance involving ...`), obscuring the actual issue.

Here' another one:

```
  1 event e;
  2
  3 spec m observes e {
  4   var numbers : set[int];
  5   var synchronized : bool;
  6
  7   start state Init {
  8     entry {
...
 14     }
...
 20 }
```

This looks reasonable, too - but, `synchronized` is a Java keyword, so we would end up generating a field in `PGenerated.PMachines.m` thus: `private boolean synchronized = false;`.  This will of course fail to compile in a rather spectacular manner:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /private/tmp/PMachines.java:[24,24] <identifier> expected
[ERROR] /private/tmp/PMachines.java:[24,38] illegal start of type
[ERROR] /private/tmp/PMachines.java:[25,57] <identifier> expected
[ERROR] /private/tmp/PMachines.java:[25,69] '(' expected
[ERROR] /private/tmp/PMachines.java:[28,9] illegal start of expression
[INFO] 5 errors
```


This patch renames any identifiers that the Java backend has reserved, or that are reserved by the Java language itself.  Note that for the former, this uses reflection on the Constants class in order to pull out all the reserved words (defined as public strings in that class); this means that future developers who add constants to that class don't have to ensure that their new string definition _also_ appears in a static set or anything.

```
nathta@bcd0741cf59d /tmp % pcl -generate:Java foo.p
----------------------------------------
....... includes p file: /private/tmp/foo.p
----------------------------------------
----------------------------------------
Parsing ...
Type checking ...
Code generation ...
Reusing existing pom.xml
Generated PTypes.java.
Generated PEvents.java.
Generated PMachines.java.
Generated FFIStubs.txt.
----------------------------------------
Compiling foo...
----------------------------------------
nathta@bcd0741cf59d /tmp % cat -n PMachines.java
     1  package PGenerated;
     2
     3  /***************************************************************************
     4   * This file was auto-generated on Tuesday, 02 August 2022 at 11:58:44.
     5   * Please do not edit manually!
     6   **************************************************************************/
     7
     8  import java.util.*;
     9
    10  public class PMachines {
    11      public static class PMachines_Machine extends prt.Monitor {
    12
    13          public static class Supplier implements java.util.function.Supplier<PMachines_Machine> {
    14              public PMachines_Machine get() {
    15                  PMachines_Machine ret = new PMachines_Machine();
    16                  ret.ready();
    17                  return ret;
    18              }
    19          }
    20
    21          private LinkedHashSet<PTypes.PValue> PEvents_Variable = new LinkedHashSet<PTypes.PValue>();
    22          public LinkedHashSet<PTypes.PValue> get_PEvents_Variable() { return this.PEvents_Variable; };
    23
    24
    25          public enum PrtStates {
    26              P_TopScope_State
    27          }
    28
    29          public PMachines_Machine() {
    30              super();
    31              addState(prt.State.keyedOn(PrtStates.P_TopScope_State)
    32                  .isInitialState(true)
    33                  .withEntry(this::Anon)
    34                  .build());
    35          } // constructor
    36
    37          public java.util.List<Class<? extends prt.events.PEvent<?>>> getEventTypes() {
    38              return java.util.Arrays.asList(PEvents.PEvent.class);
    39          }
    40
    41          private void Anon() {
    42          }
    43
    44      } // PMachines_Machine monitor definition
    45  }
nathta@bcd0741cf59d /tmp %
```

This patch additionally fixes a few places where `getNameForDecl()` wasn't called directly, but rather the "naked" identifier name was used in place.  

An alternative to this patch would be to throw an exception if a name collision occurs.  This would be desirable in, I think, precisely one situation: where a user of some Monitor expects a certain machine name to construct in some other P tool, only to discover that it's been renamed out from under them?