### PR TITLE
[Java] Linear time sequential iteration for P sets

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -183,7 +183,7 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         public static readonly string PrtCompareMethodName = "prt.values.Equality.compare";
 
         /// <summary>
-        /// The fully-qualified name of the static `eleemntAt(LinkedHashSet, int)` method
+        /// The fully-qualified name of the static `elementAt(LinkedHashSet, long)` method
         /// exposed by the Java PRT runtime.
         /// </summary>
         public static readonly string PrtSetElementAtMethodName = "prt.values.SetIndexing.elementAt";

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -404,9 +404,8 @@ namespace Plang.Compiler.Backend.Java {
                     Write($"gotoState({Names.IdentForState(gotoStmt.State)}");
                     if (gotoStmt.Payload != null)
                     {
-                        Write(", Optional.of(");
+                        Write(", ");
                         WriteExpr(gotoStmt.Payload);
-                        Write(")");
                     }
                     WriteLine(");");
                     WriteLine("return;");

--- a/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/SetIndexing.java
+++ b/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/SetIndexing.java
@@ -1,23 +1,181 @@
 package prt.values;
 
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.NoSuchElementException;
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Handles producing the `ith` element of a LinkedHashSet in as efficient a manner as possible.
+ * This is implemented outside the collection type itself, since in contrast to C#'s `HashSet::elementAt()`,
+ * Java's `java.util.LinkedHashSet` has no built-in way to iterate to the ith element in the set.
+ */
 public class SetIndexing {
-    // A helper that walks a LinkedHashSet's iterator to get the `i`th value in the set.  This is
-    // implemented here as J.u.LinkedHashSet has no equivalent of C# HashSet::elementAt() method.
-    public static <T> T elementAt(LinkedHashSet<T> s, int i) throws NoSuchElementException
+
+
+    /**
+     * Cached iteration state: we store the most recently-used set and its iterator, and the index
+     * that the iterator last read from.  The set and iterator are stored as weak references,
+     * meaning that the garbage collector may choose to evict them during collection.  In this case,
+     * we will have to recompute the state from scratch, but we aren't going to retain a reference to a Set
+     * that is no longer reachable from P code.
+     */
+    private static class CachedState {
+        private WeakReference<LinkedHashSet<?>> cached_set;
+        private WeakReference<Iterator<?>> cached_it;
+        private long it_idx;
+
+        public LinkedHashSet<?> getCachedSet() {
+            if (cached_set == null) {
+                return null;
+            }
+            return cached_set.get();
+        }
+        public Iterator<?> getIterator() {
+            if (cached_it == null) {
+                return null;
+            }
+            return cached_it.get();
+        }
+        public long getIdx() {
+            return it_idx;
+        }
+
+        public void setState(LinkedHashSet<?> s, Iterator<?> it, long idx) {
+            if (it.hasNext()) {
+                cached_set = new WeakReference<>(s);
+                cached_it = new WeakReference<>(it);
+                it_idx = idx;
+            } else {
+                // If the state points past the end of the set (i.e. we accessed the
+                // final element), save us some steps and just zap out the whole state.
+                cached_set = null;
+                cached_it = null;
+                it_idx = -1;
+            }
+        }
+    }
+
+    private static final ThreadLocal<CachedState> state = ThreadLocal.withInitial(() -> new CachedState());
+
+    private static final AtomicLong slowPathHits = new AtomicLong();
+    private static final AtomicLong fastPathHits = new AtomicLong();
+
+    /**
+     * Returns the proportion of set accesses that were able to use the cached iterator.
+     * @return
+     */
+    public static double GetIteratorCacheHitRate() {
+        return fastPathHits.get() / (double)(slowPathHits.get() + fastPathHits.get());
+    }
+
+    /**
+     * Sets with elements smaller than this bypass the cache, since the overhead of caching exceeds the small O(n)
+     * cost of traversing from the beginning.
+     */
+    public static final int MIN_SETSIZE = 15;
+
+    /**
+     * Returns the `i`th element in the set.
+     * @param s The set to iterate through.
+     * @param i The index of the element.
+     * @return The ith element.
+     * @throws NoSuchElementException on out-of-bounds accesses.
+     */
+    public static <T> T elementAt(LinkedHashSet<T> s, long i) throws NoSuchElementException
     {
-        if (i < 0) throw new NoSuchElementException();
+        /* If the index is sufficiently close to the start of the set, the overhead of manipulating
+         * the thread-local cache state is greater than just walking the linked list.
+         * TODO: MIN_SETSIZE was estimated from benchmarking on a Mac.  Doing this on prod hardware would be better.
+         */
+        if (i <= MIN_SETSIZE) {
+            return elementAtSlowIter(s, s.iterator(), i);
+        }
+
+        CachedState c = state.get();
+        LinkedHashSet<?> cached_set = c.getCachedSet();
+        Iterator<?> cached_it = c.getIterator();
+        long cached_i = c.getIdx();
+
+        /* If our cache is not fully populated, defer to the slow path. */
+        if (cached_set == null || cached_it == null) {
+            return elementAtSlow(s, i);
+        }
+
+        /* Even if our cache is fully populated, we still defer to the slow path if... */
+
+        /* ... the supplied set is pointer-unequal from the previously-cached one. */
+        if (cached_set != s) {
+            return elementAtSlow(s, i);
+        }
+
+        /* ... the index that the P program wants isn't reachable from the iterator. */
+        if (cached_i >= i) {
+            return elementAtSlow(s, i);
+        }
+
+        /* Fast path: we can reuse the cached state safely! */
+        try {
+            // We now know the type of the cached state, since the caller's Set is pointer-equal to the cached Set,
+            // and we never set the iterator state without also setting the Set that backs it, so this upcast is safe.
+            Iterator<T> it = (Iterator<T>) cached_it;
+
+            return elementAtFast(s, it, cached_i, i);
+        } catch (ConcurrentModificationException e) {
+            /* As P collections are immutable, we should never see a modified set from generated code.  However, there
+             * is always a chance that a Set could be modified in foreign code, so we still need to handle it. */
+            return elementAtSlow(s, i);
+        }
+    }
+
+    /**
+     * Returns the `ith` element given the current iterator, already pointing to some particular index.
+     * As a side-effect, additionally caches the given set, index, and derived iterator to amortize
+     * subsequent accesses.
+     *
+     * This method can, additionally, throw a ConcurrentModificationException if, in between previous element
+     * accesses, the underlying state of the set has been changed.
+     */
+    private static <T> T elementAtFast(LinkedHashSet<T> s, Iterator<T> it, long current_idx, long i)
+            throws ConcurrentModificationException, NoSuchElementException
+    {
+        assert(current_idx < i); // Should be checked by the caller.
+        fastPathHits.getAndIncrement();
+
+        T ret = null;
+        while (current_idx < i) {
+            ret = it.next();
+            current_idx++;
+        }
+
+        state.get().setState(s, it, i);
+        return ret;
+    }
+
+    /**
+     * Returns the `i`th element in `s` by constructing a new iterator and advancing it `i` times
+     * to the desired element.  As a side-effect, additionally caches the given set, index, and
+     * derived iterator to amortize subsequent accesses.
+     */
+    private static <T> T elementAtSlow(LinkedHashSet<T> s, long i) throws NoSuchElementException
+    {
         Iterator<T> it = s.iterator();
+        T ret = elementAtSlowIter(s, it, i);
+
+        state.get().setState(s, it, i);
+        return ret;
+    }
+
+
+    private static <T> T elementAtSlowIter(LinkedHashSet<T> s, Iterator<T> it, long i) throws NoSuchElementException {
+        if (i < 0 || i >= s.size()) throw new NoSuchElementException(Long.toString(i));
+        slowPathHits.getAndIncrement();
+
         T ret = it.next();
 
         while (i > 0) {
             ret = it.next();
             i--;
         }
-
         return ret;
     }
 }


### PR DESCRIPTION

In P, iteration through a `set[T]` is done by an integral index iterating from 0 to the size of the set.  In both the [C#](https://github.com/p-org/P/blob/1c3fb7e8190c0f50cb38afe3905e72f56a950ee9/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs#L139-L143) and [Java](https://github.com/p-org/P/blob/a1e547d4319de862f6d110b302497f06f8feddd2/Src/PRuntimes/PJavaRuntime/src/main/java/prt/values/SetIndexing.java#L8-L21) backends, to access the `i`th element requires `i` iterations through a linked list; as a result, iterating through every element in a set is [accidentally quadratic](https://accidentallyquadratic.tumblr.com/).

## Current performance numbers

Here's a benchmark of a P event handler that simply iterates through a `set[int]` of `n` elements in sequential order; essentially, 

```
  3 spec m observes e {
  4   var numbers : set[int];
...
 16     on e do {
...
 20       i = 0;
 21       while (i < sizeof(numbers)) {
 22         n = numbers[i];
 23         assert n == i;
 24         i = i + 1;
 25       }
...
```

as well as a variation on this that accesses `n` random elements from the set; essentially,


```
...
 22         n = PForeign.globals.randElement(numbers)];
...
```

```
Benchmark                  (n)  Mode  Cnt        Score       Error  Units
RandomBenchmark.doit        10  avgt   15      272.633 ±    17.920  ns/op
RandomBenchmark.doit        15  avgt   15      523.929 ±    57.207  ns/op
RandomBenchmark.doit        20  avgt   15      724.393 ±    14.306  ns/op
RandomBenchmark.doit        25  avgt   15     1240.286 ±    31.795  ns/op
RandomBenchmark.doit        50  avgt   15     3204.898 ±    38.667  ns/op
RandomBenchmark.doit       100  avgt   15    12148.208 ±   211.702  ns/op
RandomBenchmark.doit       150  avgt   15    25772.830 ±   235.244  ns/op
RandomBenchmark.doit       300  avgt   15   103857.769 ±   433.593  ns/op
RandomBenchmark.doit       500  avgt   15   297407.914 ±  7872.003  ns/op
RandomBenchmark.doit       750  avgt   15   615708.748 ± 11206.153  ns/op
RandomBenchmark.doit      1000  avgt   15  1052700.827 ±  8960.433  ns/op
SequentialBenchmark.doit    10  avgt   15      237.211 ±     6.354  ns/op
SequentialBenchmark.doit    15  avgt   15      319.286 ±     4.925  ns/op
SequentialBenchmark.doit    20  avgt   15      422.568 ±     6.201  ns/op
SequentialBenchmark.doit    25  avgt   15      628.675 ±   128.025  ns/op
SequentialBenchmark.doit    50  avgt   15     1971.279 ±    26.287  ns/op
SequentialBenchmark.doit   100  avgt   15     8674.546 ±    56.491  ns/op
SequentialBenchmark.doit   150  avgt   15    20788.436 ±   165.259  ns/op
SequentialBenchmark.doit   300  avgt   15    91951.012 ±  1559.262  ns/op
SequentialBenchmark.doit   500  avgt   15   257768.387 ±   632.963  ns/op
SequentialBenchmark.doit   750  avgt   15   590815.003 ±  1201.745  ns/op
SequentialBenchmark.doit  1000  avgt   15  1063151.578 ±  5757.310  ns/op
```

Fitting the performance to a curve, we can see that the quadratic term (index 0 of the polyfit array) for the sequential benchmark is close to 1:  

```
>>> xs = [10,15,20,25,50,100,150,300,500,750,1000]
>>> ys = [237.211, 319.286, 422.568, 628.675, 1971.279, 8674.546, 20788.436, 91951.012, 257768.387, 590815.003, 1063151.578]
>>> numpy.polyfit(xs, ys, 2)
array([  1.0923918 , -30.77778851, 783.20809902])
>>>
```

We would like it to be close to 0; that is, iterating through a set should be O(n).

## The fix, and present benchmarks

This fix caches the previously-iterated set and iterator - if the same set is iterated through a second time, _and_ if the desired index is reachable from the previous iterator (i.e. the current `i` is greater than the previous one) then we avoid walking all `i-1` previous elements.

The cost of this caching is nonzero because each mutator thread requires its own local copy of the set state - notice it's wrapped in a `ThreadLocal<T>`, which is morally accessing a `T` through a `ConcurrentHashMap<pthread_t, T>`.  For small sets, this overhead exceeds actually just iterating through the set in the first place.  So, for set accesses that are not too expensive (ie. a small index value, so only a small number of elements need to be traversed), we avoid the cache altogether.  

An alternative would have been to share an `AtomicReference<CacheState>` across all threads.  This performs better since there's no intermediary `ConcurrentHashMap`; however, if two mutator threads are in parallel iterating through distinct sets, then a ping-pong cache-update effect will be observed and each thread's update will trash the state of the other, so this could present issues when we run monitors in parallel down the road.  A more invasive solution that avoids the concurrency issue would have been to store the cache in the calling Monitor, but I'm confident that this change is sufficient.

For sequential iteration, we see linear speedup, now.  Note that the cache hit rate is nearly 100% (we only have to reset the cache state when a new set is loaded in when the test changes.)

```
Benchmark                  (n)  Mode  Cnt       Score       Error  Units
SequentialBenchmark.doit    10  avgt   15     216.031 ±     5.407  ns/op
SequentialBenchmark.doit    15  avgt   15     327.776 ±     4.290  ns/op
SequentialBenchmark.doit    20  avgt   15     558.184 ±    17.173  ns/op
SequentialBenchmark.doit    25  avgt   15     742.731 ±    17.478  ns/op
SequentialBenchmark.doit    50  avgt   15    1806.386 ±   124.997  ns/op
SequentialBenchmark.doit   100  avgt   15    4220.894 ±   379.450  ns/op
SequentialBenchmark.doit   150  avgt   15    6844.797 ±   490.108  ns/op
SequentialBenchmark.doit   300  avgt   15   15529.279 ±  1026.500  ns/op
SequentialBenchmark.doit   500  avgt   15   28237.317 ±  2473.446  ns/op
SequentialBenchmark.doit   750  avgt   15   36714.523 ±  4915.789  ns/op
SequentialBenchmark.doit  1000  avgt   15   50924.735 ±  3050.903  ns/op

Fast path hit rate: 0.999000

>>> numpy.polyfit(xs, ys, 2)
array([-5.26892822e-03,  5.63964087e+01, -7.58108985e+02])
>>>
```

We can't avoid the quadratic term altogether for random access, since the expected previous index is `n/2`, and so there's a 50/50 chance that the currently-desired index is behind where the iterator can reach.  The measured cache hit rate confirms this intuition.  Nonetheless, though, random access (which isn't a common pattern from what I've seen anyway) still performs better now.

```
Benchmark                  (n)  Mode  Cnt       Score       Error  Units
RandomBenchmark.doit        10  avgt   15     297.049 ±     4.334  ns/op
RandomBenchmark.doit        15  avgt   15     549.493 ±    22.147  ns/op
RandomBenchmark.doit        20  avgt   15     764.102 ±    12.385  ns/op
RandomBenchmark.doit        25  avgt   15    2079.356 ±   163.918  ns/op
RandomBenchmark.doit        50  avgt   15    5234.513 ±    50.335  ns/op
RandomBenchmark.doit       100  avgt   15   16048.639 ±   872.522  ns/op
RandomBenchmark.doit       150  avgt   15   29705.166 ±  2118.038  ns/op
RandomBenchmark.doit       300  avgt   15  100701.370 ±  6579.890  ns/op
RandomBenchmark.doit       500  avgt   15  247975.669 ±  3213.003  ns/op
RandomBenchmark.doit       750  avgt   15  502248.985 ± 10517.799  ns/op
RandomBenchmark.doit      1000  avgt   15  896770.482 ±  9040.733  ns/op

Fast path hit rate: 0.502000

>>> numpy.polyfit(xs, ys, 2)
array([ 0.81579153, 75.47217746, 27.15074285])
>>>
```

