### PR TITLE
[Java] do not initialise temporary variables

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -157,11 +157,13 @@ namespace Plang.Compiler.Backend.Java {
                 {
                     TypeManager.JType t = Types.JavaTypeFor(decl.Type);
 
-                    if (decl.Role.HasFlag(VariableRole.Temp) && !t.IsPrimitive)
+                    if (decl.Role.HasFlag(VariableRole.Temp))
                     {
                         /* Temporary values are only emitted as part of the frontend's SSA algorithm, and therefore
-                         * will never be read but only overwritten.  Save us allocating a dummy rval in such cases. */
-                        WriteLine($"{t.TypeName} {Names.GetNameForDecl(decl)} = null;");
+                         * will never be read but only overwritten.  There's no need to initialise this variable,
+                         * especially if it's a reference type (resulting in a GC allocation that will be thrown
+                         * away immediately). */
+                        WriteLine($"{t.TypeName} {Names.GetNameForDecl(decl)};");
                     }
                     else
                     {

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -155,9 +155,18 @@ namespace Plang.Compiler.Backend.Java {
             {
                 foreach (var decl in f.LocalVariables)
                 {
-                    //TODO: for reference types the default value can simply be null; it will be reassigned later.
                     TypeManager.JType t = Types.JavaTypeFor(decl.Type);
-                    WriteLine($"{t.TypeName} {Names.GetNameForDecl(decl)} = {t.DefaultValue};");
+
+                    if (decl.Role.HasFlag(VariableRole.Temp) && !t.IsPrimitive)
+                    {
+                        /* Temporary values are only emitted as part of the frontend's SSA algorithm, and therefore
+                         * will never be read but only overwritten.  Save us allocating a dummy rval in such cases. */
+                        WriteLine($"{t.TypeName} {Names.GetNameForDecl(decl)} = null;");
+                    }
+                    else
+                    {
+                        WriteLine($"{t.TypeName} {Names.GetNameForDecl(decl)} = {t.DefaultValue};");
+                    }
                 }
                 WriteLine();
             }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/ValueSetElementAtTest.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/ValueSetElementAtTest.java
@@ -58,8 +58,8 @@ public class ValueSetElementAtTest {
                         .collect(Collectors.toList()));
 
         // Arbitrary iteration
-        Random r = new Random();
-        for (int i = 0; i < 2000; i++) {
+        Random r = new Random(System.currentTimeMillis());
+        for (int i = 0; i < 500; i++) {
             int idx = r.nextInt(s.size());
             assertEquals(prt.values.SetIndexing.elementAt(s, idx), idx+1);
 

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
@@ -1,7 +1,7 @@
 package testcases.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Monday, 01 August 2022 at 11:28:45.
+ * This file was auto-generated on Friday, 05 August 2022 at 09:21:39.
  * Please do not edit manually!
  **************************************************************************/
 
@@ -13,7 +13,7 @@ public class PMachines {
     // PMachine Database elided
     // PMachine Client elided
     // PMachine AbstractBankServer elided
-    public static class BankBalanceIsAlwaysCorrect extends prt.Monitor {
+    public static class BankBalanceIsAlwaysCorrect extends prt.Monitor<BankBalanceIsAlwaysCorrect.PrtStates> {
 
         public static class Supplier implements java.util.function.Supplier<BankBalanceIsAlwaysCorrect> {
             public BankBalanceIsAlwaysCorrect get() {
@@ -58,8 +58,8 @@ public class PMachines {
             long TMP_tmp0 = 0L;
             boolean TMP_tmp1 = false;
             long TMP_tmp2 = 0L;
-            ArrayList<Long> TMP_tmp3 = new ArrayList<Long>();
-            String TMP_tmp4 = "";
+            ArrayList<Long> TMP_tmp3 = null;
+            String TMP_tmp4 = null;
             long TMP_tmp5 = 0L;
 
             TMP_tmp0 = req.accountId;
@@ -75,21 +75,21 @@ public class PMachines {
             long TMP_tmp0_1 = 0L;
             boolean TMP_tmp1_1 = false;
             long TMP_tmp2_1 = 0L;
-            String TMP_tmp3_1 = "";
+            String TMP_tmp3_1 = null;
             long TMP_tmp4_1 = 0L;
             boolean TMP_tmp5_1 = false;
             long TMP_tmp6 = 0L;
-            String TMP_tmp7 = "";
+            String TMP_tmp7 = null;
             long TMP_tmp8 = 0L;
             boolean TMP_tmp9 = false;
-            String TMP_tmp10 = "";
+            String TMP_tmp10 = null;
             PTypes.tWithDrawRespStatus TMP_tmp11 = PTypes.tWithDrawRespStatus.WITHDRAW_SUCCESS;
             boolean TMP_tmp12 = false;
             long TMP_tmp13 = 0L;
             long TMP_tmp14 = 0L;
             long TMP_tmp15 = 0L;
             long TMP_tmp16 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp17 = new PTypes.PTuple_src_accnt_amnt_rId();
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp17 = null;
             long TMP_tmp18 = 0L;
             long TMP_tmp19 = 0L;
             boolean TMP_tmp20 = false;
@@ -98,26 +98,26 @@ public class PMachines {
             long TMP_tmp23 = 0L;
             long TMP_tmp24 = 0L;
             long TMP_tmp25 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp26 = new PTypes.PTuple_src_accnt_amnt_rId();
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp26 = null;
             long TMP_tmp27 = 0L;
             long TMP_tmp28 = 0L;
-            String TMP_tmp29 = "";
+            String TMP_tmp29 = null;
             long TMP_tmp30 = 0L;
             long TMP_tmp31 = 0L;
             long TMP_tmp32 = 0L;
             long TMP_tmp33 = 0L;
             long TMP_tmp34 = 0L;
             long TMP_tmp35 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp36 = new PTypes.PTuple_src_accnt_amnt_rId();
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp36 = null;
             long TMP_tmp37 = 0L;
             long TMP_tmp38 = 0L;
             boolean TMP_tmp39 = false;
             long TMP_tmp40 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp41 = new PTypes.PTuple_src_accnt_amnt_rId();
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp41 = null;
             long TMP_tmp42 = 0L;
             long TMP_tmp43 = 0L;
             long TMP_tmp44 = 0L;
-            String TMP_tmp45 = "";
+            String TMP_tmp45 = null;
             long TMP_tmp46 = 0L;
             long TMP_tmp47 = 0L;
             long TMP_tmp48 = 0L;
@@ -125,7 +125,7 @@ public class PMachines {
             long TMP_tmp50 = 0L;
             long TMP_tmp51 = 0L;
             long TMP_tmp52 = 0L;
-            String TMP_tmp53 = "";
+            String TMP_tmp53 = null;
 
             TMP_tmp0_1 = resp.accountId;
             TMP_tmp1_1 = bankBalance.containsKey(TMP_tmp0_1);
@@ -196,7 +196,7 @@ public class PMachines {
         }
 
     } // BankBalanceIsAlwaysCorrect monitor definition
-    public static class GuaranteedWithDrawProgress extends prt.Monitor {
+    public static class GuaranteedWithDrawProgress extends prt.Monitor<GuaranteedWithDrawProgress.PrtStates> {
 
         public static class Supplier implements java.util.function.Supplier<GuaranteedWithDrawProgress> {
             public GuaranteedWithDrawProgress get() {
@@ -241,8 +241,8 @@ public class PMachines {
             long TMP_tmp0_3 = 0L;
             boolean TMP_tmp1_2 = false;
             long TMP_tmp2_2 = 0L;
-            LinkedHashSet<Long> TMP_tmp3_2 = new LinkedHashSet<Long>();
-            String TMP_tmp4_2 = "";
+            LinkedHashSet<Long> TMP_tmp3_2 = null;
+            String TMP_tmp4_2 = null;
             long TMP_tmp5_2 = 0L;
             long TMP_tmp6_1 = 0L;
             boolean TMP_tmp7_1 = false;

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
@@ -1,7 +1,7 @@
 package testcases.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Friday, 05 August 2022 at 09:21:39.
+ * This file was auto-generated on Friday, 05 August 2022 at 10:00:12.
  * Please do not edit manually!
  **************************************************************************/
 
@@ -55,12 +55,12 @@ public class PMachines {
             bankBalance = prt.values.Clone.deepClone(balance);
         }
         private void Anon_1(PTypes.PTuple_src_accnt_amnt_rId req) {
-            long TMP_tmp0 = 0L;
-            boolean TMP_tmp1 = false;
-            long TMP_tmp2 = 0L;
-            ArrayList<Long> TMP_tmp3 = null;
-            String TMP_tmp4 = null;
-            long TMP_tmp5 = 0L;
+            long TMP_tmp0;
+            boolean TMP_tmp1;
+            long TMP_tmp2;
+            ArrayList<Long> TMP_tmp3;
+            String TMP_tmp4;
+            long TMP_tmp5;
 
             TMP_tmp0 = req.accountId;
             TMP_tmp1 = bankBalance.containsKey(TMP_tmp0);
@@ -72,60 +72,60 @@ public class PMachines {
             pendingWithDraws.put(TMP_tmp5,req.deepClone());
         }
         private void Anon_2(PTypes.PTuple_stts_accnt_blnc_rId resp) {
-            long TMP_tmp0_1 = 0L;
-            boolean TMP_tmp1_1 = false;
-            long TMP_tmp2_1 = 0L;
-            String TMP_tmp3_1 = null;
-            long TMP_tmp4_1 = 0L;
-            boolean TMP_tmp5_1 = false;
-            long TMP_tmp6 = 0L;
-            String TMP_tmp7 = null;
-            long TMP_tmp8 = 0L;
-            boolean TMP_tmp9 = false;
-            String TMP_tmp10 = null;
-            PTypes.tWithDrawRespStatus TMP_tmp11 = PTypes.tWithDrawRespStatus.WITHDRAW_SUCCESS;
-            boolean TMP_tmp12 = false;
-            long TMP_tmp13 = 0L;
-            long TMP_tmp14 = 0L;
-            long TMP_tmp15 = 0L;
-            long TMP_tmp16 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp17 = null;
-            long TMP_tmp18 = 0L;
-            long TMP_tmp19 = 0L;
-            boolean TMP_tmp20 = false;
-            long TMP_tmp21 = 0L;
-            long TMP_tmp22 = 0L;
-            long TMP_tmp23 = 0L;
-            long TMP_tmp24 = 0L;
-            long TMP_tmp25 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp26 = null;
-            long TMP_tmp27 = 0L;
-            long TMP_tmp28 = 0L;
-            String TMP_tmp29 = null;
-            long TMP_tmp30 = 0L;
-            long TMP_tmp31 = 0L;
-            long TMP_tmp32 = 0L;
-            long TMP_tmp33 = 0L;
-            long TMP_tmp34 = 0L;
-            long TMP_tmp35 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp36 = null;
-            long TMP_tmp37 = 0L;
-            long TMP_tmp38 = 0L;
-            boolean TMP_tmp39 = false;
-            long TMP_tmp40 = 0L;
-            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp41 = null;
-            long TMP_tmp42 = 0L;
-            long TMP_tmp43 = 0L;
-            long TMP_tmp44 = 0L;
-            String TMP_tmp45 = null;
-            long TMP_tmp46 = 0L;
-            long TMP_tmp47 = 0L;
-            long TMP_tmp48 = 0L;
-            boolean TMP_tmp49 = false;
-            long TMP_tmp50 = 0L;
-            long TMP_tmp51 = 0L;
-            long TMP_tmp52 = 0L;
-            String TMP_tmp53 = null;
+            long TMP_tmp0_1;
+            boolean TMP_tmp1_1;
+            long TMP_tmp2_1;
+            String TMP_tmp3_1;
+            long TMP_tmp4_1;
+            boolean TMP_tmp5_1;
+            long TMP_tmp6;
+            String TMP_tmp7;
+            long TMP_tmp8;
+            boolean TMP_tmp9;
+            String TMP_tmp10;
+            PTypes.tWithDrawRespStatus TMP_tmp11;
+            boolean TMP_tmp12;
+            long TMP_tmp13;
+            long TMP_tmp14;
+            long TMP_tmp15;
+            long TMP_tmp16;
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp17;
+            long TMP_tmp18;
+            long TMP_tmp19;
+            boolean TMP_tmp20;
+            long TMP_tmp21;
+            long TMP_tmp22;
+            long TMP_tmp23;
+            long TMP_tmp24;
+            long TMP_tmp25;
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp26;
+            long TMP_tmp27;
+            long TMP_tmp28;
+            String TMP_tmp29;
+            long TMP_tmp30;
+            long TMP_tmp31;
+            long TMP_tmp32;
+            long TMP_tmp33;
+            long TMP_tmp34;
+            long TMP_tmp35;
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp36;
+            long TMP_tmp37;
+            long TMP_tmp38;
+            boolean TMP_tmp39;
+            long TMP_tmp40;
+            PTypes.PTuple_src_accnt_amnt_rId TMP_tmp41;
+            long TMP_tmp42;
+            long TMP_tmp43;
+            long TMP_tmp44;
+            String TMP_tmp45;
+            long TMP_tmp46;
+            long TMP_tmp47;
+            long TMP_tmp48;
+            boolean TMP_tmp49;
+            long TMP_tmp50;
+            long TMP_tmp51;
+            long TMP_tmp52;
+            String TMP_tmp53;
 
             TMP_tmp0_1 = resp.accountId;
             TMP_tmp1_1 = bankBalance.containsKey(TMP_tmp0_1);
@@ -232,20 +232,20 @@ public class PMachines {
         }
 
         private void Anon_3(PTypes.PTuple_src_accnt_amnt_rId req_1) {
-            long TMP_tmp0_2 = 0L;
+            long TMP_tmp0_2;
 
             TMP_tmp0_2 = req_1.rId;
             pendingWDReqs.add(TMP_tmp0_2);
         }
         private void Anon_4(PTypes.PTuple_stts_accnt_blnc_rId resp_1) throws prt.exceptions.TransitionException {
-            long TMP_tmp0_3 = 0L;
-            boolean TMP_tmp1_2 = false;
-            long TMP_tmp2_2 = 0L;
-            LinkedHashSet<Long> TMP_tmp3_2 = null;
-            String TMP_tmp4_2 = null;
-            long TMP_tmp5_2 = 0L;
-            long TMP_tmp6_1 = 0L;
-            boolean TMP_tmp7_1 = false;
+            long TMP_tmp0_3;
+            boolean TMP_tmp1_2;
+            long TMP_tmp2_2;
+            LinkedHashSet<Long> TMP_tmp3_2;
+            String TMP_tmp4_2;
+            long TMP_tmp5_2;
+            long TMP_tmp6_1;
+            boolean TMP_tmp7_1;
 
             TMP_tmp0_3 = resp_1.rId;
             TMP_tmp1_2 = pendingWDReqs.contains(TMP_tmp0_3);
@@ -263,7 +263,7 @@ public class PMachines {
             }
         }
         private void Anon_5(PTypes.PTuple_src_accnt_amnt_rId req_2) {
-            long TMP_tmp0_4 = 0L;
+            long TMP_tmp0_4;
 
             TMP_tmp0_4 = req_2.rId;
             pendingWDReqs.add(TMP_tmp0_4);


### PR DESCRIPTION
Currently, all local variables in an extracted function are properly declared and defined with a valid initial value.  Here's a snippet from the local variable definition of a non-trivial function:

```java
...
PTypes.a_b_c TMP_tmp7_1 = new PTypes.a_b_c();
LinkedHashSet<PTypes.PTuple_foo_bar_baz_quz> TMP_tmp8 = new LinkedHashSet<PTypes.PTuple_foo_bar_baz_quz>();
PTypes.PTuple_foo_bar_baz_quz TMP_tmp9 = new PTypes.PTuple_foo_bar_baz_quz();
String TMP_tmp10 = "";
long TMP_tmp11 = 0L;
PTypes.a_b_c TMP_tmp12 = new PTypes.a_b_c();
PTypes.a_b_c TMP_tmp13 = new PTypes.a_b_c();
PTypes.PTuple_foo_bar_baz_quz TMP_tmp14 = new PTypes.PTuple_foo_bar_baz_quz();
String TMP_tmp15 = "";
String TMP_tmp16 = "";
...
```

These are all prefaced with `TMP_`, indicating that they're emitted only as part of the compiler frontend's SSA algorithm.  As a result, these initial values will never actaully be read prior to being overwritten by something else (as they're temporaries!), so, all these allocations are useless.

As I measured [here](https://github.com/p-org/P/issues/437#issuecomment-1150322398), only C2, the most optimizing JIT compiler, will do enough dataflow analysis to remove such allocations (though I don't know if it'll be able to in all cases, and I don't know how likely it is that in a full runtime monitoring system, a given spec is likely to be hot enough to get recompiled with that optimising JIT).