### PR TITLE
[Java] fully qualify foreign types

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -32,18 +32,6 @@ namespace Plang.Compiler.Backend.Java {
         /// <exception cref="Exception"></exception>
         protected override void GenerateCodeImpl()
         {
-            if (GlobalScope.Typedefs.Any())
-            {
-                foreach (var t in GlobalScope.Typedefs)
-                {
-                    if (t.Type is ForeignType foreignType)
-                    {
-                        WriteForeignType(foreignType);
-                    }
-                }
-                WriteLine();
-            }
-
             WriteLine($"public class {Constants.MachineNamespaceName} {{");
 
             foreach (var m in GlobalScope.Machines)
@@ -60,12 +48,6 @@ namespace Plang.Compiler.Backend.Java {
                 _currentMachine = null;
             }
             WriteLine("}");
-        }
-
-
-        private void WriteForeignType(ForeignType ft)
-        {
-            WriteLine($"import {Constants.FFITypesPackage}.{ft.CanonicalRepresentation};");
         }
 
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/NameManager.cs
@@ -43,7 +43,7 @@ namespace Plang.Compiler.Backend.Java
             if (!_namedTupleJTypes.TryGetValue(t, out var val))
             {
                 IEnumerable<string> names = t.Names;
-                names = names.Select(AbbreviateTupleName).ToArray();
+                names = names.Select(AbbreviateTupleName);
                 val = UniquifyName("PTuple_" + string.Join("_", names));
                 _namedTupleJTypes.Add(t, val);
             }

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PEvents.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PEvents.java
@@ -1,7 +1,7 @@
 package testcases.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Wednesday, 20 July 2022 at 14:12:46.
+ * This file was auto-generated on Monday, 08 August 2022 at 17:03:57.
  * Please do not edit manually!
  **************************************************************************/
 

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
@@ -1,12 +1,12 @@
 package testcases.clientserver;
 
+
 /***************************************************************************
- * This file was auto-generated on Friday, 05 August 2022 at 10:00:12.
+ * This file was auto-generated on Monday, 08 August 2022 at 17:03:57.
  * Please do not edit manually!
  **************************************************************************/
 
 import java.util.*;
-
 
 public class PMachines {
     // PMachine BankServer elided

--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PTypes.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PTypes.java
@@ -1,7 +1,7 @@
 package testcases.clientserver;
 
 /***************************************************************************
- * This file was auto-generated on Thursday, 21 July 2022 at 13:40:36.
+ * This file was auto-generated on Monday, 08 August 2022 at 17:03:57.
  * Please do not edit manually!
  **************************************************************************/
 
@@ -246,7 +246,7 @@ public class PTypes {
         }
 
         public PTuple_srvr_intlb deepClone() {
-            return new PTuple_srvr_intlb(server, (HashMap<Long, Long>)prt.values.Clone.deepClone(initialBalance));
+            return new PTuple_srvr_intlb(server, prt.values.Clone.deepClone(initialBalance));
         } // deepClone()
 
 


### PR DESCRIPTION
Previously we were only importing foreign type names when generating
Monitors, but not Events - this inconsistency lead to compilation
errors in complicated specs.  This patch makes us consistent in
that we always have to fully qualify the type, obviating the need for
the import.