### PR TITLE
[Java] nit: invert inverted conditionals

### DIFF
--- a/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
+++ b/Src/PRuntimes/PJavaRuntime/src/test/java/testcases/clientserver/PMachines.java
@@ -2,7 +2,7 @@ package testcases.clientserver;
 
 
 /***************************************************************************
- * This file was auto-generated on Monday, 08 August 2022 at 17:03:57.
+ * This file was auto-generated on Wednesday, 10 August 2022 at 14:54:34.
  * Please do not edit manually!
  **************************************************************************/
 


### PR DESCRIPTION
This is not a correctness or performance issue but I've been staring at some awkward generated code today and this has been driving me nuts!

Here are two event handlers:

```
  7     on e1 do {
  8       var i: int;
  9       i = 0;
 10       while (i < sizeof(numbers)) {
 11         i = i + 1;
 12       }
 13     }
 14     on e2 do {
 15       if (true) {} else {}
 16     }
```

Currently, the loop in `e1` and "useless if" in e2 is emitted in a correct but awkward way:

```java
 49             while ((true)) {
 50                 TMP_tmp0 = numbers.size();
 51                 TMP_tmp1 = i < TMP_tmp0;
 52                 TMP_tmp2 = TMP_tmp1;
 53                 if (TMP_tmp2) {} else
 54                 {
 55                     break;
 56                 }
 57                 TMP_tmp3 = i + 1L;
 58                 i = TMP_tmp3;
 59             }
...
 62         private void Anon_1() {
 63             if ((true)) {}}
```

For the first case, we rearrange the conditional to its negation if the "then" body is empty but the "else" is not.  (The useless parens around the boolean literal are also removed.)

```java
 49             while (true) {
 50                 TMP_tmp0 = numbers.size();
 51                 TMP_tmp1 = i < TMP_tmp0;
 52                 TMP_tmp2 = TMP_tmp1;
 53                 if (!(TMP_tmp2)) {
 54                     break;
 55                 }
 56                 TMP_tmp3 = i + 1L;
 57                 i = TMP_tmp3;
 58             }
```

For the latter case, where both branches are empty, we can elide the statement altogether.

```java
 61         private void Anon_1() {
 62         }
```