### PR TITLE
[Java] emit correct accessors for unnamed tuples

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -62,6 +62,8 @@ namespace Plang.Compiler.Backend.Java
         public static readonly string TypesNamespaceName = "PTypes";
         public static readonly string TypesDefnFileName = $"{TypesNamespaceName}.java";
 
+        public static readonly string UnnamedTupleFieldPrefix = "arg_";
+
         #endregion
 
         #region FFI generation

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -566,9 +566,10 @@ namespace Plang.Compiler.Backend.Java {
 
                 case TupleAccessExpr tupleAccessExpr:
                     WriteExpr(tupleAccessExpr.SubExpr);
-                    Write($".put({tupleAccessExpr.FieldNo.ToString()}, ");
+                    Write($".{Constants.UnnamedTupleFieldPrefix + tupleAccessExpr.FieldNo}");
+                    Write(" = ");
                     WriteExpr(rval);
-                    WriteLine(");");
+                    WriteLine(";");
                     break;
 
                 case VariableAccessExpr variableAccessExpr:
@@ -916,7 +917,7 @@ namespace Plang.Compiler.Backend.Java {
 
                 case TupleAccessExpr tupleAccessExpr:
                     WriteExpr(tupleAccessExpr.SubExpr);
-                    Write($".{tupleAccessExpr.FieldNo.ToString()}");
+                    Write($".{Constants.UnnamedTupleFieldPrefix + tupleAccessExpr.FieldNo}");
                     break;
 
             }

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/TupleType.cs
@@ -2,6 +2,7 @@ using Plang.Compiler.TypeChecker.AST.Declarations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Plang.Compiler.Backend.Java;
 
 namespace Plang.Compiler.TypeChecker.Types
 {
@@ -24,7 +25,7 @@ namespace Plang.Compiler.TypeChecker.Types
             List<NamedTupleEntry> fields = Types.Select((t, i) =>
             {
                 NamedTupleEntry e = new NamedTupleEntry();
-                e.Name = "arg_" + i;
+                e.Name = Constants.UnnamedTupleFieldPrefix + i;
                 e.FieldNo = i;
                 e.Type = t;
                 return e;


### PR DESCRIPTION
Unnamed tuple code generation has a few issues, which I noticed while splunking in some old code during benchmarking.  Here's a sample program:

```
nathta@bcd0741cf59d /tmp % cat -n foo.p
     1  type t = (int, int, seq[int]);
     2  event e: t;
     3
     4  spec M observes e {
     5    start state S {
     6      on e do (a: t) {
     7        a.0 = a.1;
     8      }
     9    }
    10  }
nathta@bcd0741cf59d /tmp %
```

For context: unnamed tuples are treated by the Java type generator as if they were NamedTuples with field names "arg_0", "arg_1", and so on.


```
 13     public static class PTuple_arg_0_arg_1_arg_2 implements prt.values.PValue<PTuple_arg_0_arg_1_arg_2> {
 14         // (arg_0:int,arg_1:int,arg_2:seq[int])
 15         public long arg_0;
 16         public long arg_1;
 17         public ArrayList<Long> arg_2;
...
```

However, we were generating wildly-incorrect code to access such types (probably because we haven't actually had a use of unnamed tuples from a customer yet, and the implementation of unnamed tuples changed since this was written):

```
 38         private void Anon(PTypes.PTuple_arg_0_arg_1_arg_2 a) {
 39             long TMP_tmp0;
 40             long TMP_tmp1;
 41
 42             TMP_tmp0 = a.1;
 43             TMP_tmp1 = TMP_tmp0;
 44             a.put(0, TMP_tmp1);
 45         }
```

This patch makes the code generator do the right thing.

```
 38         private void Anon(PTypes.PTuple_arg_0_arg_1_arg_2 a) {
 39             long TMP_tmp0;
 40             long TMP_tmp1;
 41
 42             TMP_tmp0 = a.arg_1;
 43             TMP_tmp1 = TMP_tmp0;
 44             a.arg_0 = TMP_tmp1;
 45         }
```