### PR TITLE
[PUnit] do not build as part of build.sh

### DIFF
--- a/Bld/build.sh
+++ b/Bld/build.sh
@@ -11,10 +11,7 @@ pushd ..
 git submodule update --init --recursive
 
 echo -e "${ORANGE} ---- Building the Java P runtime ----${NOCOLOR}"
-mvn clean compile -f ./Src/PRuntimes/PJavaRuntime/pom.xml
-
-echo -e "${ORANGE} ---- Building PUnit ----${NOCOLOR}"
-mvn clean compile -f ./Tst/PUnit/pom.xml
+mvn compile -q -f ./Src/PRuntimes/PJavaRuntime/pom.xml
 
 echo -e "${ORANGE} ---- Building the PCompiler ----${NOCOLOR}"
 # Run the build!

--- a/Bld/build.sh
+++ b/Bld/build.sh
@@ -5,8 +5,11 @@ GREEN='\033[0;32m'
 ORANGE='\033[0;33m'
 set -e
 
+BLD_PATH=$(dirname $0)
+pushd $BLD_PATH/..
+
 echo -e "${ORANGE} ---- Fetching git submodules ----${NOCOLOR}"
-pushd ..
+
 # Initialize submodules
 git submodule update --init --recursive
 

--- a/Tst/PUnit/README.md
+++ b/Tst/PUnit/README.md
@@ -2,6 +2,19 @@
 
 PUnit is a library that extends JUnit test suites with P specifications.
 
+## Dependencies
+
+The P Java runtime (PRT) is required on your classpath.  You likely already
+have it installed by virtue of executing P monitors extracted to Java; but, to
+install it from this repo into your local Maven repository,
+
+```
+$ cd Src/PRuntimes/PJavaRuntime
+$ mvn install
+```
+
+All other dependencies will be pulled from remote repositories.
+
 ## Overview and Tutorial
 
 Imagine I have an implementation of an algebraic ring (I can add and multiply

--- a/Tst/PUnit/pom.xml
+++ b/Tst/PUnit/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
-    <artifactId>prtsandbox</artifactId>
+    <groupId>com.amazon.p</groupId>
+    <artifactId>punit</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
The previous patch configured the build script to also build PUnit.  However, I realised this morning that this implicitly required that the PRT is installed in the user's local Maven repository; from a clean ~/.m2 directory, I get:

```
$ ./build.sh
...
[ERROR] Failed to execute goal on project punit: Could not resolve dependencies for project org.example:prts
andbox:jar:1.0-SNAPSHOT: Could not find artifact p.runtime:PJavaRuntime:jar:1.0-SNAPSHOT -> [Help 1]
```

One simple change would be to, at build time, install that dependency - we're building it anyway, so we just need to do a `mvn install` rather than `mvn compile`.  However, I worry about implicitly installing dependencies in a build script: in particular, if a user is actively working on the PRT and also re-building P, I'm not exactly sure which version will get stomped over unless the version is bumped explicitly.

So, given that PUnit is not a critical part of the P project, just don't build it.  If it becomes important later, it's easy to fix.