### PR TITLE
[CSharpRuntime] bounds check on named tuple access

### DIFF
--- a/Src/PRuntimes/PCSharpRuntime/Exceptions/UnknownNamedTupleFieldAccess.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Exceptions/UnknownNamedTupleFieldAccess.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Plang.CSharpRuntime.Exceptions
+{
+    public class UnknownNamedTupleFieldAccess : Exception
+    {
+        public static UnknownNamedTupleFieldAccess FromFields(string expectedField, IEnumerable<string> actualFields)
+        {
+            string msg =
+                "Field " + expectedField + " absent from NamedTuple with fields " + String.Join(",", actualFields);
+            return new UnknownNamedTupleFieldAccess(msg);
+        }
+
+        private UnknownNamedTupleFieldAccess(string msg): base(msg)
+        {
+
+        }
+    }
+}

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
@@ -104,8 +104,8 @@ namespace Plang.CSharpRuntime.Values
     [Serializable]
     public class PrtNamedTuple : IPrtValue
     {
-        private readonly List<IPrtValue> fieldValues;
-        private List<string> fieldNames;
+        public readonly List<IPrtValue> fieldValues;
+        public List<string> fieldNames;
 
         public PrtNamedTuple()
         {

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Plang.CSharpRuntime.Exceptions;
 
 namespace Plang.CSharpRuntime.Values
 {
@@ -103,8 +104,8 @@ namespace Plang.CSharpRuntime.Values
     [Serializable]
     public class PrtNamedTuple : IPrtValue
     {
-        public readonly List<IPrtValue> fieldValues;
-        public List<string> fieldNames;
+        private readonly List<IPrtValue> fieldValues;
+        private List<string> fieldNames;
 
         public PrtNamedTuple()
         {
@@ -129,8 +130,24 @@ namespace Plang.CSharpRuntime.Values
 
         public IPrtValue this[string name]
         {
-            get => fieldValues[fieldNames.IndexOf(name)];
-            set => fieldValues[fieldNames.IndexOf(name)] = value;
+            get
+            {
+                int idx = fieldNames.IndexOf(name);
+                if (idx == -1)
+                {
+                    throw UnknownNamedTupleFieldAccess.FromFields(name, fieldNames);
+                }
+                return fieldValues[fieldNames.IndexOf(name)];
+            }
+            set
+            {
+                int idx = fieldNames.IndexOf(name);
+                if (idx == -1)
+                {
+                    throw UnknownNamedTupleFieldAccess.FromFields(name, fieldNames);
+                }
+                fieldValues[fieldNames.IndexOf(name)] = value;
+            }
         }
 
         public IPrtValue Clone()


### PR DESCRIPTION
Tuples and named tuples in C# extract to, morally, association lists, meaning that field accesses require iterating through an array.  Currently, on an invalid field access, the exception that is thrown is not useful to users.

Imagine I am writing the foreign code for the 2PC tutorial and I mis-type one of the fields: 

```diff
diff --git a/Tutorial/2_TwoPhaseCommit/PForeign/ForeignCode.cs b/Tutorial/2_TwoPhaseCommit/PForeign/ForeignCode.cs
index c8b9af5a1..0bd3ad5c8 100644
--- a/Tutorial/2_TwoPhaseCommit/PForeign/ForeignCode.cs
+++ b/Tutorial/2_TwoPhaseCommit/PForeign/ForeignCode.cs
@@ -16,7 +16,7 @@ namespace PImplementation
   {
     public static PrtNamedTuple ChooseRandomTransaction(PrtInt uniqueId, PMachine pMachine)
     {
-      return (new PrtNamedTuple(new string[] { "key", "val", "transId" }, (PrtString)pMachine.TryRandomInt(10).ToString(), (PrtInt)pMachine.TryRandomInt(10), (PrtInt) uniqueId));
+      return (new PrtNamedTuple(new string[] { "key", "val", "trans_id" }, (PrtString)pMachine.TryRandomInt(10).ToString(), (PrtInt)pMachine.TryRandomInt(10), (PrtInt) uniqueId));
     }
   }
-}
\ No newline at end of file
+}
nathta@bcd0741cf59d 2_TwoPhaseCommit %
```

Of course, this will fail at runtime when a non-existent field is read from this tuple on a line like

```csharp
TMP_tmp1_8 = (PrtInt)(((PrtNamedTuple)TMP_tmp0_9)["transId"]);
```

because we will attempt to access field index -1:

```csharp
        public IPrtValue this[string name]
        {
            get => fieldValues[fieldNames.IndexOf(name)];
            set => fieldValues[fieldNames.IndexOf(name)] = value;
        }
```

So we get an `ArgumentOutOfRangeException` in the Coyote log.

```
<DequeueLog> 'Coordinator(6)' dequeued event 'eWriteTransReq with payload (<client:Client(7), trans:<key:1, val:5, trans_id:102, >, >)' in state 'WaitForTransactions'.
<ExceptionLog> Coordinator(6) running action 'Anon_1' in state 'WaitForTransactions' threw exception 'ArgumentOutOfRangeException'.
<ErrorLog> Exception 'System.ArgumentOutOfRangeException' was thrown in Coordinator(6) (state 'WaitForTransactions', action 'Anon_1'): Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
from location 'System.Private.CoreLib':
The stack trace is:
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Plang.CSharpRuntime.Values.PrtNamedTuple.get_Item(String name)
   at PImplementation.Coordinator.Anon_1(Event currentMachine_dequeuedEvent) in /Users/nathta/code/P/Tutorial/2_TwoPhaseCommit/PGenerated/TwoPhaseCommit.cs:line 495
```

But this is of course useless to the developer: they haven't, as far as they're concerned, indexed into any sort of array (the fact that a field access is O(n) is an internal implementation detail).  

This patch simply does bounds checking prior to the access, and throws an exception that actually describes the programming error instead.

```
nathta@bcd0741cf59d 2_TwoPhaseCommit % cp ~/code/P/Src/PRuntimes/PCSharpRuntime/obj/Release/netcoreapp3.1/PCSharpRuntime.dll ./POutput/netcoreapp3.1/
nathta@bcd0741cf59d 2_TwoPhaseCommit % pmc POutput/netcoreapp3.1/TwoPhaseCommit.dll \
    -m PImplementation.tcMultipleClientsWithFailure.Execute \
    -i 10000

...

<ExceptionLog> Coordinator(6) running action 'Anon_1' in state 'WaitForTransactions' threw exception 'UnknownNamedTupleFieldAccess'.
<ErrorLog> Exception 'Plang.CSharpRuntime.Exceptions.UnknownNamedTupleFieldAccess' was thrown in Coordinator(6) (state 'WaitForTransactions', action 'Anon_1'): Field transId absent from NamedTuple with fields key,val,trans_id       from location 'PCSharpRuntime':
The stack trace is:
   at Plang.CSharpRuntime.Values.PrtNamedTuple.get_Item(String name)
   at PImplementation.Coordinator.Anon_1(Event currentMachine_dequeuedEvent) in /Users/nathta/code/P/Tutorial/2_TwoPhaseCommit/PGenerated/TwoPhaseCommit.cs:line 495                                                                       at Microsoft.Coyote.Actors.Actor.InvokeActionAsync(CachedDelegate cachedAction, Event e)
<StackTrace>    at Microsoft.Coyote.SystematicTesting.OperationScheduler.NotifyAssertionFailure(String text, Boolean killTasks, Boolean cancelExecution)
```