### PR TITLE
[PSym] Update examples on fp branch

### DIFF
--- a/Src/PRuntimes/PSymbolicRuntime/Examples/I4/lockserver/FilteredStyle.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/I4/lockserver/FilteredStyle.p
@@ -121,6 +121,8 @@ machine Main {
   var clients : seq[int];
   var servers : seq[int];
   var global  : machine;
+  var maxNumRequests : int;
+  var numRequests : int;
   start state Init {
     entry {
       var i : int;
@@ -129,6 +131,7 @@ machine Main {
       var numServers : int;
       numClients = 5;
       numServers = 2;
+      maxNumRequests = 10;
       i = 0;
       while (i < numClients) {
         clients += (i, i);
@@ -144,6 +147,10 @@ machine Main {
     }
 
     on eNext do {
+      numRequests = numRequests + 1;
+      if (numRequests >= maxNumRequests) {
+          raise halt;
+      }
       if (choose()) {
           send global, eConnect;
       }

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/I4/lockserver/IvyStyle.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/I4/lockserver/IvyStyle.p
@@ -84,6 +84,8 @@ machine Main {
   var clients : seq[int];
   var servers : seq[int];
   var global  : machine;
+  var maxNumRequests : int;
+  var numRequests : int;
   start state Init {
     entry {
       var i : int;
@@ -92,6 +94,7 @@ machine Main {
       var numServers : int;
       numClients = 5;
       numServers = 2;
+      maxNumRequests = 10;
       i = 0;
       while (i < numClients) {
         clients += (i, i);
@@ -109,6 +112,10 @@ machine Main {
     on eNext do {
       var client : int;
       var server : int;
+      numRequests = numRequests + 1;
+      if (numRequests >= maxNumRequests) {
+          raise halt;
+      }
       client = choose(clients);
       server = choose(servers);
       send global, eEvent, (client=client, server=server);

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/I4/lockserver/Symmetry.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/I4/lockserver/Symmetry.p
@@ -147,6 +147,8 @@ machine Main {
   var clients : seq[int];
   var servers : seq[int];
   var global  : machine;
+  var maxNumRequests : int;
+  var numRequests : int;
   start state Init {
     entry {
       var i : int;
@@ -155,6 +157,7 @@ machine Main {
       var numServers : int;
       numClients = 5;
       numServers = 2;
+      maxNumRequests = 10;
       i = 0;
       while (i < numClients) {
         clients += (i, i);
@@ -170,6 +173,10 @@ machine Main {
     }
 
     on eNext do {
+      numRequests = numRequests + 1;
+      if (numRequests >= maxNumRequests) {
+          raise halt;
+      }
       if (choose()) {
           send global, eConnect;
       }

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/HybridClock/HLC.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/HybridClock/HLC.p
@@ -106,6 +106,7 @@ machine HLC {
         }
         i = i + 1;
       }
+      assert(sizeof(choices) != 0);
       i = choose(sizeof(choices));
       msg[choices[i]] = ((l = L[j], c = C[j]));
       pcL[j] = 0;

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/Paxos.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/Paxos.p
@@ -295,6 +295,7 @@ machine Global {
         }
         i = i + 1;
       }
+      assert(sizeof(choices) != 0);
       choice = choices[choose(sizeof(choices))];
       hVal[pld.acceptor] += (choice); //(sizeof(hVal[pld.acceptor]), choice.2);
       SentP2B[pld.b] += (choice.2);

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/Paxos_map.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/Paxos_map.p
@@ -334,6 +334,7 @@ machine Global {
         }
         i = i + 1;
       }
+      assert(sizeof(choices) != 0);
       choice = choices[choose(sizeof(choices))];
       hVal[pld.acceptor][choice.0][choice.1][choice.2] = true;
       SentP2B[pld.b][choice.2] = true;

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/Paxos_seq.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/Paxos_seq.p
@@ -298,6 +298,7 @@ machine Global {
         }
         i = i + 1;
       }
+      assert(sizeof(choices) != 0);
       choice = choices[choose(sizeof(choices))];
       if (!(choice in hVal[pld.acceptor])) {
         hVal[pld.acceptor] += (sizeof(hVal[pld.acceptor]), choice);

--- a/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/VoldemortKV/VoldChain.p
+++ b/Src/PRuntimes/PSymbolicRuntime/Examples/TLA/VoldemortKV/VoldChain.p
@@ -301,12 +301,19 @@ machine Voldchain {
 
 machine Main {
   var voldchain : machine;
+  var maxNumRequests : int;
+  var numRequests : int;
   start state Init {
     entry {
+      maxNumRequests = 10;
       voldchain = new Voldchain((driver=this, N=2, C=1, STOP=1, FAILNUM=1));
       send voldchain, eNext;
     }
     on eNext do {
+      numRequests = numRequests + 1;
+      if (numRequests >= maxNumRequests) {
+          raise halt;
+      }
       send voldchain, eNext;
     }
   }


### PR DESCRIPTION
Hi @lmpick,

I was trying the latest PSym on examples in the fp branch.
I found a few issues with the examples, dealing with few examples having infinite length executions, and ones where choose(*) might be triggered on an empty list.

I have updated these examples to:
- Bounds examples with infinite/large execution lengths to fixed length
- Adds few assertions to ensure we aren't choose(*) from empty list

Please let me know if these changes make sense and if we can add them to the fp branch.

Requested reviews from: @lmpick, @ankushdesai 

--
Aman