### PR TITLE
Update FFI file to remove machien as first param

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -315,14 +315,12 @@ namespace Plang.Compiler.Backend.Java
             string monitorType = (m == null
                 ? "prt.Monitor<?>"
                 : $"{Constants.MachineNamespaceName}.{m.Name}");
-            Write($"{monitorType} machine");
 
             foreach (var param in f.Signature.Parameters)
             {
                 string pname = Names.GetNameForDecl(param);
                 TypeManager.JType ptype = Types.JavaTypeFor(param.Type);
 
-                WriteLine(",");
                 Write($"{ptype.TypeName} {pname}");
             }
 


### PR DESCRIPTION
Removed the monitorType machine line the writes machine as the first parameter in FFIStubGenerator.cs. 