### PR TITLE
Fixed a broken regression and a better error message

### DIFF
--- a/Src/PRuntimes/PCSharpRuntime/PMachine.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PMachine.cs
@@ -76,6 +76,7 @@ namespace Plang.CSharpRuntime
         public void TrySendEvent(PMachineValue target, Event ev, object payload = null)
         {
             Assert(ev != null, "Machine cannot send a null event");
+            Assert(target != null, "Machine in send cannot be null");
             Assert(sends.Contains(ev.GetType().Name),
                 $"Event {ev.GetType().Name} is not in the sends set of the Machine {GetType().Name}");
             Assert(target.Permissions.Contains(ev.GetType().Name),

--- a/Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_15/MonitorInvocationEventExprPayload.p
+++ b/Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_15/MonitorInvocationEventExprPayload.p
@@ -20,3 +20,5 @@ spec M observes E2 {
 		on E2 do (payload: bool) { assert (payload == true); }  //fails in Zinger
 	}
 }
+
+test DefaultImpl [main=Main]: assert M in { Main };


### PR DESCRIPTION
Fixed #510 

Also, a better error message is reported when trying to send a message and target machine is `null`