### PR TITLE
[CLI] Updates commandline options

### DIFF
--- a/Src/PChecker/CheckerCore/CheckerConfiguration.cs
+++ b/Src/PChecker/CheckerCore/CheckerConfiguration.cs
@@ -35,6 +35,12 @@ namespace PChecker
         public string AssemblyToBeAnalyzed;
 
         /// <summary>
+        /// Checking mode
+        /// </summary>
+        [DataMember]
+        public string CheckerMode;
+
+        /// <summary>
         /// Test case to be used.
         /// </summary>
         [DataMember]
@@ -240,6 +246,7 @@ namespace PChecker
             Timeout = 0;
 
             AssemblyToBeAnalyzed = string.Empty;
+            CheckerMode = "bugfinding";
             TestCaseName = string.Empty;
 
             SchedulingStrategy = "random";

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -278,7 +278,8 @@ You can provide one or two unsigned integer values", typeof(uint)).IsMultiValue 
                 if (checkerConfiguration.AssemblyToBeAnalyzed == string.Empty)
                 {
                     CommandLineOutput.WriteInfo(
-                        $".. Could not find any P project file {filePattern} in the current directory: {Directory.GetCurrentDirectory()}");
+                        $".. Could not find any P compiled file {filePattern} in the current folder: {Directory.GetCurrentDirectory()}");
+                    Error.ReportAndExit($"Provide at least one P compiled file {filePattern}");
                 }
             }
         }

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -88,12 +88,12 @@ namespace Plang.Options
         {
             if (result.Count == 0)
             {
-                CommandLineOutput.WriteInfo(".. Searching for a pproj file locally in the current folder");
+                CommandLineOutput.WriteInfo(".. Searching for a P project file *.pproj locally in the current folder");
                 var files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.pproj");
                 if (files.Length == 0)
                 {
                     CommandLineOutput.WriteInfo(
-                        $".. Could not find any P project file in the current directory: {Directory.GetCurrentDirectory()}");
+                        $".. Could not find any P project file *.pproj in the current folder: {Directory.GetCurrentDirectory()}");
                 }
                 else
                 {
@@ -101,7 +101,7 @@ namespace Plang.Options
                     commandlineArg.Value = files.First();
                     commandlineArg.LongName = "pproj";
                     commandlineArg.ShortName = "pp";
-                    CommandLineOutput.WriteInfo($".. Found project file: {commandlineArg.Value}");
+                    CommandLineOutput.WriteInfo($".. Found P project file: {commandlineArg.Value}");
                     result.Add(commandlineArg);
                 }
             }
@@ -186,7 +186,7 @@ namespace Plang.Options
             FindLocalPFiles(compilerConfiguration);
             if (compilerConfiguration.InputFiles.Count == 0)
             {
-                Error.ReportAndExit("Provide at least one input p file");
+                Error.ReportAndExit("Provide at least one input *.p file in *.pproj file or through --pfiles option");
             }
 
             foreach (var pfile in compilerConfiguration.InputFiles)

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -27,15 +27,15 @@ namespace Plang.Options
             
             var projectGroup = Parser.GetOrCreateGroup("project", "P Project: Compiling using `.pproj` file");
             projectGroup.AddArgument("pproj", "pp", "P project file to compile (*.pproj)." +
-                                                    " If this option is not passed, the compiler searches for a `*.pproj` in the current folder");
+                                                    " If this option is not passed, the compiler searches for a *.pproj in the current folder");
 
             var pfilesGroup = Parser.GetOrCreateGroup("commandline", "Compiling P files through commandline");
             pfilesGroup.AddArgument("pfiles", "pf", "List of P files to compile").IsMultiValue = true;
-            pfilesGroup.AddArgument("generate", "g",
-                    "Generate output :: (csharp, symbolic, java, c). (default: csharp)").AllowedValues =
-                new List<string>() { "csharp", "symbolic", "c", "java" };
-            pfilesGroup.AddArgument("target", "t", "Target or name of the compiled output");
+            pfilesGroup.AddArgument("projname", "pn", "Project name for the compiled output");
             pfilesGroup.AddArgument("outdir", "o", "Dump output to directory (absolute or relative path)");
+
+            Parser.AddArgument("mode", "m", "Compilation mode :: (bugfinding, pobserve). (default: bugfinding)").AllowedValues =
+                new List<string>() { "bugfinding", "verify", "cover", "pobserve" };
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Plang.Options
                     commandlineArg.Value = files.First();
                     commandlineArg.LongName = "pproj";
                     commandlineArg.ShortName = "pp";
-                    CommandLineOutput.WriteInfo($"Compiling project: {commandlineArg.Value}");
+                    CommandLineOutput.WriteInfo($".. Found project file: {commandlineArg.Value}");
                     result.Add(commandlineArg);
                 }
             }
@@ -138,17 +138,17 @@ namespace Plang.Options
                     compilerConfiguration.OutputDirectory = Directory.CreateDirectory((string)option.Value);
                     compilerConfiguration.Output = new DefaultCompilerOutput(compilerConfiguration.OutputDirectory);
                     break;
-                case "target":
+                case "projname":
                     compilerConfiguration.ProjectName = (string)option.Value;
                     break;
-                case "generate":
+                case "mode":
                     {
                         compilerConfiguration.OutputLanguage = (string)option.Value switch
                         {
-                            "csharp" => CompilerOutput.CSharp,
-                            "c" => CompilerOutput.C,
-                            "symbolic" => CompilerOutput.Symbolic,
-                            "java" => CompilerOutput.Java,
+                            "bugfinding" => CompilerOutput.CSharp,
+                            "verify" => CompilerOutput.Symbolic,
+                            "cover" => CompilerOutput.Symbolic,
+                            "pobserve" => CompilerOutput.Java,
                             _ => compilerConfiguration.OutputLanguage
                         };
                         compilerConfiguration.Backend = TargetLanguage.GetCodeGenerator(compilerConfiguration.OutputLanguage);
@@ -183,6 +183,7 @@ namespace Plang.Options
         /// </summary>
         private static void SanitizeConfiguration(CompilerConfiguration compilerConfiguration)
         {
+            FindLocalPFiles(compilerConfiguration);
             if (compilerConfiguration.InputFiles.Count == 0)
             {
                 Error.ReportAndExit("Provide at least one input p file");
@@ -201,5 +202,23 @@ namespace Plang.Options
                 Error.ReportAndExit($"{compilerConfiguration.ProjectName} is not a legal project name");
             }
         }
+        
+
+        private static void FindLocalPFiles(CompilerConfiguration compilerConfiguration)
+        {
+            if (compilerConfiguration.InputFiles.Count == 0)
+            {
+                CommandLineOutput.WriteInfo(".. Searching for P files locally in the current folder");
+                
+                var files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.p", SearchOption.AllDirectories);
+
+                foreach (var fileName in files)
+                {
+                    CommandLineOutput.WriteInfo($".. Adding P file: {fileName}");
+                    compilerConfiguration.InputFiles.Add(fileName);
+                }
+            }
+        }
+        
     }
 }

--- a/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
+++ b/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
@@ -52,9 +52,6 @@ namespace Plang.Parser
                 // get output directory
                 var outputDirectory = GetOutputDirectory(projectFilePath);
 
-                // get target language
-                GetTargetLanguage(projectFilePath, ref outputLanguage, ref generateSourceMaps);
-
                 job = new CompilerConfiguration(output: new DefaultCompilerOutput(outputDirectory), outputDir: outputDirectory,
                     outputLanguage: outputLanguage, inputFiles: inputFiles.ToList(), projectName: projectName, projectRoot: projectFilePath.Directory, projectDependencies: projectDependencies.ToList());
 


### PR DESCRIPTION
Updates include:
- Updates CLI options to remove `--target` and `--generate` options. Instead, `--target` is renamed to `--projname` and `--mode` is used to configure the compiler/checker backend (default: `bugfinding`). Currently available modes include: `bugfinding`, `pobserve`.
- Adds support for searching for `*.dll` in the current directory with `p check` command when path is not given
- Adds fallback support for searching for and adding local P files in the current directory with `p compile` command when no P file is given through `*.pproj` and `--pfiles` options.
- Improves error messages in commandline configuration