### PR TITLE
[Docs] Minor: Update java installation for AL2

### DIFF
--- a/Docs/docs/getstarted/install.md
+++ b/Docs/docs/getstarted/install.md
@@ -90,7 +90,7 @@ The P compiler also requires Java (`java` version 11 or higher).
     Installing Java 11 on Amazon Linux (you can use any version of java >= 11)
 
     ```shell
-    sudo yum install -y java-11-amazon-corretto-devel
+    sudo yum install -y java-11-amazon-corretto
     ```
 
 === "Windows"


### PR DESCRIPTION
Updates java installation instructions for AL2 to use `java-11-amazon-corretto` instead of `java-11-amazon-corretto-devel`.

`java-11-amazon-corretto-devel` seems to be no longer available on AL2.