### PR TITLE
Fix typo in 2PC TestDriver.p

### DIFF
--- a/Tutorial/2_TwoPhaseCommit/PTst/TestDriver.p
+++ b/Tutorial/2_TwoPhaseCommit/PTst/TestDriver.p
@@ -65,7 +65,7 @@ machine SingleClientNoFailure {
 }
 
 /*
-This machine creates the 3 participants, 1 coordinator, and 1 clients
+This machine creates the 3 participants, 1 coordinator, and 2 clients
 */
 machine MultipleClientsNoFailure {
   start state Init {


### PR DESCRIPTION
I was following along in the 2PC tutorial and noticed this. Very minor but figured I'd send it along.