### PR TITLE
PCheckerOptions fix file path search

### DIFF
--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -296,6 +296,7 @@ namespace Plang.Options
             if (checkerConfiguration.AssemblyToBeAnalyzed == string.Empty)
             {
                 CommandLineOutput.WriteInfo(".. Searching for a P compiled file locally in the current folder");
+                var pathSep = Path.DirectorySeparatorChar;
                 
                 string filePattern =  checkerConfiguration.Mode switch
                 {
@@ -320,22 +321,22 @@ namespace Plang.Options
                 {
                     if (checkerConfiguration.Mode == CheckerMode.BugFinding)
                     {
-                        if (!fileName.Contains("CSharp/"))
+                        if (!fileName.Contains($"CSharp{pathSep}"))
                             continue;
                         if (fileName.EndsWith("PCheckerCore.dll") 
                             || fileName.EndsWith("PCSharpRuntime.dll")
-                            || fileName.EndsWith("/P.dll")
-                            || fileName.EndsWith("/p.dll"))
+                            || fileName.EndsWith($"{pathSep}P.dll")
+                            || fileName.EndsWith($"{pathSep}p.dll"))
                             continue;
                     }
                     else if (checkerConfiguration.Mode == CheckerMode.Verification || checkerConfiguration.Mode == CheckerMode.Coverage)
                     {
-                        if (!fileName.Contains("Symbolic/"))
+                        if (!fileName.Contains($"Symbolic{pathSep}"))
                             continue;
                     }
                     else
                     {
-                        if (!fileName.Contains("Java/"))
+                        if (!fileName.Contains($"Java{pathSep}"))
                             continue;
                     }
                     checkerConfiguration.AssemblyToBeAnalyzed = fileName;


### PR DESCRIPTION
Everything seems to work fine on Windows except for actually running the spec once compiled. I noticed the checker options were hard coded with `/` so I swapped it to use the character from `Path`.

I can run specs on Windows now!

Would you be open to another PR that adds a "Developing P" section to the readme? I had to look up how to install local versions of `dotnet` tools which took longer than coding up this fix. You might also assume that this is relatively common knowledge and not want to duplicate it in your repository though.