### PR TITLE
[CI] Fix Tutorial GitHub Action

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -18,11 +18,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build P from source
-      run: dotnet build --configuration Release
+    - name: Install P as a tool
+      run: dotnet tool install --global p
     - name: Compile Tutorials
-      run: ./Src/Scripts/TutorialsChecker/compile.sh ${GITHUB_WORKSPACE}/Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
+      run: ./Src/Scripts/TutorialsChecker/compile.sh ./Tutorial
     - name: Check Tutorials
-      run: ./Src/Scripts/TutorialsChecker/check.sh ${GITHUB_WORKSPACE}/Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
-
-
+      run: ./Src/Scripts/TutorialsChecker/check.sh ./Tutorial

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -18,9 +18,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Install P as a tool
-      run: dotnet tool install --global p 
+    - name: Build P from source
+      run: dotnet build --configuration Release
     - name: Compile Tutorials
-      run: ./Src/Scripts/TutorialsChecker/compile.sh ./Tutorial
+      run: ./Src/Scripts/TutorialsChecker/compile.sh ./Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
     - name: Check Tutorials
-      run: ./Src/Scripts/TutorialsChecker/check.sh ./Tutorial
+      run: ./Src/Scripts/TutorialsChecker/check.sh ./Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
+
+

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Build P from source
       run: dotnet build --configuration Release
     - name: Compile Tutorials
-      run: ./Src/Scripts/TutorialsChecker/compile.sh ./Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
+      run: ./Src/Scripts/TutorialsChecker/compile.sh ${GITHUB_WORKSPACE}/Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
     - name: Check Tutorials
-      run: ./Src/Scripts/TutorialsChecker/check.sh ./Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
+      run: ./Src/Scripts/TutorialsChecker/check.sh ${GITHUB_WORKSPACE}/Bld/Drops/Release/Binaries/net6.0/p.dll ./Tutorial
 
 

--- a/Src/Scripts/TutorialsChecker/check.sh
+++ b/Src/Scripts/TutorialsChecker/check.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-cd $1
+PBIN=$(realpath $1)
+ITERATIONS=10000
+
+cd $2
 
 # Get list of subfolders  
 folders=$(ls -d */)   
@@ -20,7 +23,7 @@ for folder in $folders; do
     echo "------------------------------------------------------"
 
     checkLog="check.log"
-    p check -i 100 2>&1 | tee ${checkLog}
+    dotnet ${PBIN} check -i ${ITERATIONS} 2>&1 | tee ${checkLog}
     if grep -q "Possible options are:" ${checkLog}; then
       beginFlag=false
       while IFS=" " read firstWord _; do
@@ -31,7 +34,7 @@ for folder in $folders; do
             break;
           fi
           echo "Smoke testing for test case ${firstWord}";
-          p check -i 10000 -tc ${firstWord}
+          dotnet ${PBIN} check -i ${ITERATIONS} -tc ${firstWord}
           if [ $? -ne 0 ]; then  
             let "errorCount=errorCount + 1"
           fi  

--- a/Src/Scripts/TutorialsChecker/check.sh
+++ b/Src/Scripts/TutorialsChecker/check.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-PBIN=$1
 ITERATIONS=10000
 
-cd $2
+cd $1
 
 # Get list of subfolders  
 folders=$(ls -d */)   
@@ -23,7 +22,7 @@ for folder in $folders; do
     echo "------------------------------------------------------"
 
     checkLog="check.log"
-    dotnet ${PBIN} check -i ${ITERATIONS} 2>&1 | tee ${checkLog}
+    p check -i ${ITERATIONS} 2>&1 | tee ${checkLog}
     if grep -q "Possible options are:" ${checkLog}; then
       beginFlag=false
       while IFS=" " read firstWord _; do
@@ -34,7 +33,7 @@ for folder in $folders; do
             break;
           fi
           echo "Smoke testing for test case ${firstWord}";
-          dotnet ${PBIN} check -i ${ITERATIONS} -tc ${firstWord}
+          p check -i ${ITERATIONS} -tc ${firstWord}
           if [ $? -ne 0 ]; then  
             let "errorCount=errorCount + 1"
           fi  

--- a/Src/Scripts/TutorialsChecker/check.sh
+++ b/Src/Scripts/TutorialsChecker/check.sh
@@ -27,7 +27,7 @@ for folder in $folders; do
         if  [[ "${beginFlag}" = false ]] && [[ ${firstWord} == "Possible" ]]; then
           beginFlag=true
         elif [[ "${beginFlag}" = true ]] && [[ ${firstWord} ]]; then
-          if [[ "${firstWord}" = "[PTool]:" ]]; then
+          if [[ "${firstWord}" = "~~" ]]; then
             break;
           fi
           echo "Smoke testing for test case ${firstWord}";

--- a/Src/Scripts/TutorialsChecker/check.sh
+++ b/Src/Scripts/TutorialsChecker/check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PBIN=$(realpath $1)
+PBIN=$1
 ITERATIONS=10000
 
 cd $2

--- a/Src/Scripts/TutorialsChecker/compile.sh
+++ b/Src/Scripts/TutorialsChecker/compile.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-PBIN=$1
-cd $2
+cd $1
 
 # Get list of subfolders  
 folders=$(ls -d */)   
@@ -20,7 +19,7 @@ for folder in $folders; do
     echo "Compiling $folder!"
     echo "------------------------------------------------------"
 
-    dotnet ${PBIN} compile
+    p compile
     
     # Check and print any errors
     if [ $? -ne 0 ]; then  

--- a/Src/Scripts/TutorialsChecker/compile.sh
+++ b/Src/Scripts/TutorialsChecker/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PBIN=$(realpath $1)
+PBIN=$1
 cd $2
 
 # Get list of subfolders  

--- a/Src/Scripts/TutorialsChecker/compile.sh
+++ b/Src/Scripts/TutorialsChecker/compile.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-cd $1
+PBIN=$(realpath $1)
+cd $2
 
 # Get list of subfolders  
 folders=$(ls -d */)   
@@ -13,12 +14,13 @@ for folder in $folders; do
   # If so, change into folder and compile
   if [ -n "$pprojFiles" ]; then 
     cd $folder
+    rm -rf PGenerated
 
     echo "------------------------------------------------------"
     echo "Compiling $folder!"
     echo "------------------------------------------------------"
 
-    p compile  
+    dotnet ${PBIN} compile
     
     # Check and print any errors
     if [ $? -ne 0 ]; then  


### PR DESCRIPTION
GitHub action for Tutorials was picking up the latest P version on NuGet and using it to run the GitHub action.
What we instead need in our CI is that P is built from the current code commit (like all other GitHub actions).
This PR adds support for this.

Also, the shell script [check.sh](https://github.com/p-org/P/blob/master/Src/Scripts/TutorialsChecker/check.sh#L30) was incorrectly parsing the test cases (due to the recent P change "[PTool]" became "~~ [PTool]"). Corrected.