### PR TITLE
Fix the name of the coffee machine testcase

### DIFF
--- a/Tutorial/3_EspressoMachine/PTst/TestScripts.p
+++ b/Tutorial/3_EspressoMachine/PTst/TestScripts.p
@@ -1,4 +1,4 @@
-test tcSaneUser_UsingCoffeeMachine [main=TestWithSaneUser]:
+test tcSaneUserUsingCoffeeMachine [main=TestWithSaneUser]:
   assert EspressoMachineModesOfOperation in (union { TestWithSaneUser }, EspressoMachine, Users);
 
 test tcCrazyUserUsingCoffeeMachine [main=TestWithCrazyUser]:


### PR DESCRIPTION
Sorry for bothering you with such a trivial fix, but it should match the checking command in the tutorial.