### PR TITLE
json verbose logs output

### DIFF
--- a/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
+++ b/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
@@ -2,10 +2,8 @@
 using System;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 using System.Collections.Generic;
 using System.Security.Cryptography;
-using System.Text.Json.Serialization;
 
 namespace PChecker.Actors.Logging
 {
@@ -497,6 +495,11 @@ namespace PChecker.Actors.Logging
         /// Getter for accessing log entry details.
         /// </summary>
         public LogDetails LogDetails => _log.Details;
+        
+        /// <summary>
+        /// Getter for accessing logs.
+        /// </summary>
+        public List<LogEntry> Logs => _logs;
 
         /// <summary>
         /// Initializes the Writer. Create empty _logs, _log, and _details objects.
@@ -663,16 +666,5 @@ namespace PChecker.Actors.Logging
             _logs.Add(_log);
             _log = new LogEntry();
         }
-
-        /// <summary>
-        /// Serializes the _logs to be exported as a JSON file. 
-        /// </summary>
-        /// <returns></returns>
-        public string ToJsonString() => JsonSerializer.Serialize(_logs,
-            new JsonSerializerOptions
-            {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true
-            });
     }
 }


### PR DESCRIPTION
\+ JSON verbose logs output file when running verbose mode

> Structure is a list of list of logs. i.e. `[iter 1 logs, iter 2 logs, iter 3 logs, ...]`

\+ modified emit trace for JSON formatter to stream to file while serializing at the same time