### PR TITLE
[PCompiler] Fix stale version mismatch

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/CSharp/CSharpCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/CSharp/CSharpCodeGenerator.cs
@@ -65,7 +65,7 @@ namespace Plang.Compiler.Backend.CSharp
             }
 
             // compile the csproj file
-            var args = new[] { "build -c Release", csprojName };
+            var args = new[] { "build --no-incremental -c Release", csprojName };
 
             var exitCode = Compiler.RunWithOutput(job.OutputDirectory.FullName, out stdout, out stderr, "dotnet", args);
             if (exitCode != 0)


### PR DESCRIPTION
Force non-incremental flag when building C# generated code to avoid stale version mismatch from different versions of P. 

Before the fix, running `p compile` followed by `pl compile` should throw a compile error (like https://github.com/p-org/peasy-ide-vscode/issues/23) if local P version (i.e., `pl`) does not match official (i.e., `p`). Similar issue can happen when updating P and using latest P release version on project previously built with an old release.

After the fix, the error should go away, since `--no-incremental` forces the C# generated code to perform `clean and build` instead of just `build`, thus ignoring previous dotnet object files that can trigger such error due to P .dll version mismatch.
