### PR TITLE
[PSym/PCover] Updates

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Symbolic/SymbolicCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Symbolic/SymbolicCodeGenerator.cs
@@ -2136,7 +2136,7 @@ namespace Plang.Compiler.Backend.Symbolic
                         WriteExpr(context, output, pcScope, binOpExpr.Lhs);
                         context.Write(output, ").apply(");
                         if (binOpExpr.Rhs is NullLiteralExpr)
-                            context.Write(output, $"{GetDefaultValueNoGuard(context, binOpExpr.Lhs.Type)}.restrict(Guard.constFalse())");
+                            context.Write(output, $"{GetDefaultValue(context, pcScope, binOpExpr.Lhs.Type)}.");
                         else WriteExpr(context, output, pcScope, binOpExpr.Rhs);
                         string lambda;
                         if (binOpExpr.Operation == BinOpType.Eq)

--- a/Src/PCompiler/CompilerCore/Backend/Symbolic/SymbolicCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Symbolic/SymbolicCodeGenerator.cs
@@ -953,7 +953,7 @@ namespace Plang.Compiler.Backend.Symbolic
                             var expr = UnnestCloneExpr(assignStmt.Value);
                             if (expr is NullLiteralExpr)
                             {
-                                context.WriteLine(output, $"{locationTemp} = {GetDefaultValueNoGuard(context, assignStmt.Location.Type)}.restrict(Guard.constFalse());");
+                                context.WriteLine(output, $"{locationTemp} = {GetDefaultValue(context, flowContext.pcScope, assignStmt.Location.Type)};");
                             } else
                             {
                                 var inlineCastPrefix = GetInlineCastPrefix(assignStmt.Value.Type, assignStmt.Location.Type, context, flowContext.pcScope);

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
@@ -55,7 +55,7 @@ public class PSymConfiguration implements Serializable {
   // whether or not to allow sync events
   @Getter @Setter boolean allowSyncEvents = true;
   // mode of state hashing
-  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.Symbolic;
+  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.None;
   // symmetry mode
   @Getter @Setter SymmetryMode symmetryMode = SymmetryMode.None;
   // use backtracking
@@ -102,7 +102,7 @@ public class PSymConfiguration implements Serializable {
 
   public void setToSymbolic() {
     this.setStrategy("symbolic");
-    this.setStateCachingMode(StateCachingMode.Symbolic);
+    this.setStateCachingMode(StateCachingMode.None);
     this.setUseBacktrack(false);
     this.setChoiceOrchestration(ChoiceOrchestrationMode.None);
     this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
@@ -55,7 +55,7 @@ public class PSymConfiguration implements Serializable {
   // whether or not to allow sync events
   @Getter @Setter boolean allowSyncEvents = true;
   // mode of state hashing
-  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.None;
+  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.Symbolic;
   // symmetry mode
   @Getter @Setter SymmetryMode symmetryMode = SymmetryMode.None;
   // use backtracking
@@ -102,7 +102,7 @@ public class PSymConfiguration implements Serializable {
 
   public void setToSymbolic() {
     this.setStrategy("symbolic");
-    this.setStateCachingMode(StateCachingMode.None);
+    this.setStateCachingMode(StateCachingMode.Symbolic);
     this.setUseBacktrack(false);
     this.setChoiceOrchestration(ChoiceOrchestrationMode.None);
     this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);
@@ -111,7 +111,7 @@ public class PSymConfiguration implements Serializable {
   private void setToExplicit() {
     this.setSchChoiceBound(1);
     this.setDataChoiceBound(1);
-    this.setStateCachingMode(StateCachingMode.Fast);
+    this.setStateCachingMode(StateCachingMode.ExplicitFast);
     this.setUseBacktrack(true);
   }
 

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymOptions.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymOptions.java
@@ -214,7 +214,7 @@ public class PSymOptions {
     Option stateCaching =
         Option.builder()
             .longOpt("state-caching")
-            .desc("State caching mode: none, symbolic, exact, fast (default: symbolic/fast)")
+            .desc("State caching mode: none, symbolic, exact, fast (default: auto)")
             .numberOfArgs(1)
             .hasArg()
             .argName("Caching Mode (string)")

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymOptions.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymOptions.java
@@ -214,7 +214,7 @@ public class PSymOptions {
     Option stateCaching =
         Option.builder()
             .longOpt("state-caching")
-            .desc("State caching mode: none, exact, fast (default: none)")
+            .desc("State caching mode: none, symbolic, exact, fast (default: symbolic/fast)")
             .numberOfArgs(1)
             .hasArg()
             .argName("Caching Mode (string)")
@@ -522,11 +522,15 @@ public class PSymOptions {
             case "none":
               config.setStateCachingMode(StateCachingMode.None);
               break;
+            case "sym":
+            case "symbolic":
+              config.setStateCachingMode(StateCachingMode.Symbolic);
+              break;
             case "exact":
-              config.setStateCachingMode(StateCachingMode.Exact);
+              config.setStateCachingMode(StateCachingMode.ExplicitExact);
               break;
             case "fast":
-              config.setStateCachingMode(StateCachingMode.Fast);
+              config.setStateCachingMode(StateCachingMode.ExplicitFast);
               break;
             default:
               optionError(

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/machine/events/Message.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/machine/events/Message.java
@@ -295,11 +295,11 @@ public class Message implements ValueSummary<Message> {
     StringBuilder out = new StringBuilder();
     out.append("{");
     int i = 0;
+    out.append(getTarget()).append(" -> ");
     for (GuardedValue<Event> event : getEvent().getGuardedValues()) {
       out.append(event.getValue());
       out.append(" @ ");
       out.append(event.getGuard());
-      // str += " -> " + getMachine().guard(name.guard);
       if (payload.size() > 0 && payload.containsKey(event.getValue())) {
         out.append(": ");
         out.append(payload.get(event.getValue()));

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/replay/ReplayScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/replay/ReplayScheduler.java
@@ -77,9 +77,13 @@ public class ReplayScheduler extends Scheduler {
           "Maximum allowed depth " + PSymGlobal.getConfiguration().getMaxStepBound() + " exceeded",
           schedule.getLengthCond(schedule.size()));
       step();
-      checkLiveness(allMachinesHalted);
+      if (Assert.getFailureType().equals("liveness")) {
+        checkLiveness(allMachinesHalted);
+      }
     }
-    checkLiveness(Guard.constTrue());
+    if (Assert.getFailureType().equals("liveness")) {
+      checkLiveness(Guard.constTrue());
+    }
     if (Assert.getFailureType().equals("cycle")) {
       throw new LivenessException(Assert.getFailureMsg(), Guard.constTrue());
     }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/explicit/ExplicitSearchScheduler.java
@@ -581,7 +581,7 @@ public class ExplicitSearchScheduler extends SearchScheduler {
       List<Object> machineStateConcrete = new ArrayList<>();
       for (int j = 0; j < machineStateSymbolic.size(); j++) {
         Object varValue = null;
-        if (mode == StateCachingMode.Fast) {
+        if (mode == StateCachingMode.ExplicitFast) {
           varValue = machineStateSymbolic.get(j).getConcreteHash();
         } else {
           GuardedValue<?> guardedValue = Concretizer.concretize(machineStateSymbolic.get(j));

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/explicit/StateCachingMode.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/explicit/StateCachingMode.java
@@ -2,6 +2,7 @@ package psym.runtime.scheduler.search.explicit;
 
 public enum StateCachingMode {
     None,
-    Exact,
-    Fast
+    Symbolic,
+    ExplicitExact,
+    ExplicitFast
 }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSearchScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSearchScheduler.java
@@ -54,7 +54,7 @@ public class SymbolicSearchScheduler extends SearchScheduler {
     int numMessagesExplored = 0;
     int numStates = 0;
 
-    if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Exact) {
+    if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Symbolic) {
       ProtocolState srcProtocolState = new ProtocolState(currentMachines);
       for (int i = depth; i >= 0; i--) {
         ProtocolState cachedProtocolState = depthToCachedProtocolState.get(i);
@@ -138,7 +138,7 @@ public class SymbolicSearchScheduler extends SearchScheduler {
       depth++;
     }
 
-    if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Exact) {
+    if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Symbolic) {
       Message effectNew = effect.restrict(done.not());
       if (effectNew.isEmptyVS()) {
         return;

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSearchScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSearchScheduler.java
@@ -29,7 +29,7 @@ import psym.valuesummary.ValueSummary;
 import psym.valuesummary.solvers.SolverEngine;
 
 public class SymbolicSearchScheduler extends SearchScheduler {
-  private transient final TreeMap<Integer, ProtocolState> depthToProtocolState = new TreeMap<>();
+  private transient final TreeMap<Integer, ProtocolState> depthToCachedProtocolState = new TreeMap<>();
 
   public SymbolicSearchScheduler(Program p) {
     super(p);
@@ -53,6 +53,22 @@ public class SymbolicSearchScheduler extends SearchScheduler {
     int numMessagesMerged = 0;
     int numMessagesExplored = 0;
     int numStates = 0;
+
+    if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Exact) {
+      ProtocolState srcProtocolState = new ProtocolState(currentMachines);
+      for (int i = depth; i >= 0; i--) {
+        ProtocolState cachedProtocolState = depthToCachedProtocolState.get(i);
+        if (cachedProtocolState != null) {
+          Guard areEqual = srcProtocolState.symbolicEquals(cachedProtocolState);
+          if (!areEqual.isFalse()) {
+            done = done.or(areEqual);
+            allMachinesHalted = allMachinesHalted.or(done);
+//            break;
+          }
+        }
+      }
+      depthToCachedProtocolState.put(depth, srcProtocolState);
+    }
 
     if (PSymGlobal.getConfiguration().getSymmetryMode() != SymmetryMode.None) {
       PSymGlobal.getSymmetryTracker().mergeAllSymmetryClasses();
@@ -117,28 +133,23 @@ public class SymbolicSearchScheduler extends SearchScheduler {
         stickyStep = true;
       }
     }
+
     if (!stickyStep) {
-      if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Exact) {
-        effect = effect.restrict(done.not());
-      }
       depth++;
+    }
+
+    if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Exact) {
+      Message effectNew = effect.restrict(done.not());
+      if (effectNew.isEmptyVS()) {
+        return;
+      }
+      effect = effectNew;
     }
 
     TraceLogger.schedule(depth, effect);
 
     performEffect(effect);
 
-    if (!stickyStep) {
-      if (PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Exact) {
-        ProtocolState destProtocolState = new ProtocolState(currentMachines);
-        for (ProtocolState srcProtocolState : depthToProtocolState.values()) {
-          Guard areEqual = destProtocolState.symbolicEquals(srcProtocolState);
-          done = done.or(areEqual);
-          allMachinesHalted = allMachinesHalted.or(done);
-        }
-        depthToProtocolState.put(depth, destProtocolState);
-      }
-    }
 
     // simplify engine
     //        SolverEngine.simplifyEngineAuto();
@@ -393,13 +404,13 @@ public class SymbolicSearchScheduler extends SearchScheduler {
   /** Reset scheduler state */
   @Override protected void reset() {
     super.reset();
-    depthToProtocolState.clear();
+    depthToCachedProtocolState.clear();
   }
 
   /** Restore scheduler state */
   @Override protected void restore(int d, int cd) {
     super.restore(d, cd);
-    depthToProtocolState.clear();
+    depthToCachedProtocolState.clear();
   }
 
   public static class ProtocolState {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
@@ -235,7 +235,10 @@ public class MapVS<K, T extends ValueSummary<T>, V extends ValueSummary<V>>
       }
     }
 
-    return new MapVS<>(newKeys, newEntries);
+    MapVS<K, T, V> result = new MapVS<>(newKeys, newEntries);
+    assert result.containsKey(keySummary).getGuardFor(true).equals(keySummary.getUniverse());
+    assert (result.get(keySummary).symbolicEquals(valSummary, Guard.constTrue()).getGuardFor(true).equals(valSummary.getUniverse()));
+    return result;
   }
 
   /**

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
@@ -231,8 +231,8 @@ public class MapVS<K, T extends ValueSummary<T>, V extends ValueSummary<V>>
     }
 
     MapVS<K, T, V> result = new MapVS<>(newKeys, newEntries);
-    assert result.containsKey(keySummary).getGuardFor(true).equals(keySummary.getUniverse());
-    assert (result.get(keySummary).symbolicEquals(valSummary, Guard.constTrue()).getGuardFor(true).equals(valSummary.getUniverse()));
+//    assert result.containsKey(keySummary).getGuardFor(true).equals(keySummary.getUniverse());
+//    assert (result.get(keySummary).symbolicEquals(valSummary, Guard.constTrue()).getGuardFor(true).equals(valSummary.getUniverse()));
     return result;
   }
 

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
@@ -124,12 +124,17 @@ public class MapVS<K, T extends ValueSummary<T>, V extends ValueSummary<V>>
     final SetVS<T> newKeys = keys.restrict(guard);
     final Map<K, V> newEntries = new HashMap<>();
 
-    if (!newKeys.isEmptyVS()) {
-      for (Map.Entry<K, V> entry : entries.entrySet()) {
-        final V newValue = entry.getValue().restrict(guard);
-        newEntries.put(entry.getKey(), newValue);
+    for (T keySummary : newKeys.getElements().getItems()) {
+      for (GuardedValue<?> guardedKey : ValueSummary.getGuardedValues(keySummary)) {
+        K key = (K) guardedKey.getValue();
+        V val = entries.get(key);
+        if (val != null) {
+          val = val.restrict(guard);
+        }
+        newEntries.put(key, val);
       }
     }
+
     return new MapVS<>(newKeys, newEntries);
   }
 

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
@@ -379,10 +379,12 @@ public class MapVS<K, T extends ValueSummary<T>, V extends ValueSummary<V>>
   @Override
   public int computeConcreteHash() {
     int hashCode = 1;
-    for (Map.Entry<K, V> entry : entries.entrySet()) {
-      hashCode = 31 * hashCode + (entry.getKey() == null ? 0 : entry.getKey().hashCode());
+    List<K> sortedKeys = new ArrayList<>(this.entries.keySet());
+    sortedKeys.sort(Comparator.comparing(Objects::hashCode));
+    for (K key : sortedKeys) {
+      hashCode = 31 * hashCode + (key == null ? 0 : key.hashCode());
       hashCode =
-          31 * hashCode + (entry.getValue() == null ? 0 : entry.getValue().getConcreteHash());
+          31 * hashCode + (entries.get(key) == null ? 0 : entries.get(key).getConcreteHash());
     }
     return hashCode;
   }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/NamedTupleVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/NamedTupleVS.java
@@ -201,6 +201,9 @@ public class NamedTupleVS implements ValueSummary<NamedTupleVS> {
     final List<TupleVS> tuples = new ArrayList<TupleVS>();
 
     for (NamedTupleVS summary : summaries) {
+      if (summary == null) {
+        continue;
+      }
       if (!Arrays.equals(getNames(), summary.getNames())) {
         throw new RuntimeException("Merging named tuples with different fields is unsupported.");
       }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/TupleVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/TupleVS.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Getter;
 import psym.runtime.machine.Machine;
+import psym.utils.exception.BugFoundException;
 
 /** Represents a tuple value summaries */
 @SuppressWarnings("unchecked")
@@ -216,7 +217,10 @@ public class TupleVS implements ValueSummary<TupleVS> {
   public Guard getUniverse() {
     // Optimization: Tuples should always be nonempty,
     // and all fields should exist under the same conditions
-    return fields[0].getUniverse();
+    Guard result = fields[0].getUniverse();
+    assert IntStream.range(0, fields.length).allMatch(i -> fields[i].getUniverse().equals(result)):
+          "Error: all tuple fields should have same universe";
+    return result;
   }
 
   @Override

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/UnionVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/UnionVS.java
@@ -36,7 +36,7 @@ public class UnionVS implements ValueSummary<UnionVS> {
     UnionVStype type = UnionVStype.getUnionVStype(PrimitiveVS.class, null);
     this.type = new PrimitiveVS<>(type);
     this.value = new HashMap<>();
-    this.value.put(type, null);
+    this.value.put(type, new PrimitiveVS(null, Guard.constTrue()));
     this.concreteHash = computeConcreteHash();
   }
 
@@ -191,7 +191,10 @@ public class UnionVS implements ValueSummary<UnionVS> {
       List<ValueSummary> value = entry.getValue();
       ValueSummary newValue = null;
       if (value.size() > 0) {
-        newValue = value.get(0).merge(value.subList(1, entry.getValue().size()));
+        newValue = value.get(0);
+        if (value.size() > 1) {
+          newValue = newValue.merge(value.subList(1, entry.getValue().size()));
+        }
       }
       mergedValue.put(type, newValue);
     }

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
@@ -71,6 +71,7 @@ public class TestSymbolicRegression {
 
     // TODO Unsupported: nested type casting in tuple fields with any type
     excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/Correct/nonAtomicDataTypes");
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast3");
 
     // TODO Unsupported: null events
     excluded.add("../../../Tst/RegressionTests/Integration/Correct/openwsn1");


### PR DESCRIPTION
[PSym]
- Corrects symbolic comparison with nested null values in tuples casted as any
- Codegen: correct default null value guards
- Correct Map value summary get operation with any or null values
- Correct tuple value summary merging with null or any sub fields
- New improved symbolic state caching mode with support for incremental pruning and fixpoint detection (WIP)

[PCover]
- Support dependent fields during symmetry detection (WIP)
- Make Map type hashing to be key-order independent