### PR TITLE
fixed vector clock for ReceiveEvent, fixed naming consistency

### DIFF
--- a/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
+++ b/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
@@ -216,9 +216,10 @@ namespace PChecker.Actors.Logging
                     _unhandledSendRequests.Add(hashedSendReqId, CopyVcMap(_contextVcMap[machine]));
                     break;
 
-                // On dequeue event, has the string containing information about the current machine that dequeued (i.e. received the event),
+                // On dequeue OR receive event, has the string containing information about the current machine that dequeued (i.e. received the event),
                 // the event name, and payload. This is used to find the corresponding SendReqId from the machine that sent it in order to retrieve
                 // the vector clock of the sender machine during that time when it was sent.
+                case "ReceiveEvent":
                 case "DequeueEvent":
                     var correspondingSendReqId = GetSendReceiveId(machine, logDetails.Event, logDetails.Payload);
                     var hashedGeneralCorrespondingSendReqId = HashString(correspondingSendReqId);

--- a/Src/PRuntimes/PCSharpRuntime/PJsonFormatter.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PJsonFormatter.cs
@@ -186,7 +186,7 @@ namespace Plang.CSharpRuntime
             Writer.AddLogType(JsonWriter.LogType.CreateStateMachine);
             Writer.LogDetails.Id = id.ToString();
             Writer.LogDetails.CreatorName = creatorName;
-            Writer.LogDetails.CreatorType = creatorType;
+            Writer.LogDetails.CreatorType = GetShortName(creatorType);
             Writer.AddLog(log);
             Writer.AddToLogs(updateVcMap: true);
         }
@@ -532,8 +532,9 @@ namespace Plang.CSharpRuntime
         public override void OnMonitorRaiseEvent(string monitorType, string stateName, Event e)
         {
             stateName = GetShortName(stateName);
+            monitorType = GetShortName(monitorType);
             string eventName = GetEventNameWithPayload(e);
-            var log = $"Monitor '{GetShortName(monitorType)}' raised event '{eventName}' in state '{stateName}'.";
+            var log = $"Monitor '{monitorType}' raised event '{eventName}' in state '{stateName}'.";
 
             Writer.AddLogType(JsonWriter.LogType.MonitorRaiseEvent);
             Writer.LogDetails.Monitor = monitorType;


### PR DESCRIPTION
\+ Previous vector clock generation didn't handle ReceiveEvent properly, fixed now
\+ Fixed some machine naming inconsistencies