### PR TITLE
[PSym/PCover] Add fixpoint, symmetry search

### DIFF
--- a/.github/workflows/psymit.yml
+++ b/.github/workflows/psymit.yml
@@ -37,4 +37,4 @@ jobs:
       run: ./scripts/build.sh
     - name: Test PSym
       working-directory: Src/PRuntimes/PSymRuntime
-      run: mvn test -Dpsym.args="-sb 2 -db 2"
+      run: mvn test -Dpsym.args="--strategy symbolic-iterative"

--- a/.github/workflows/psymit.yml
+++ b/.github/workflows/psymit.yml
@@ -37,4 +37,4 @@ jobs:
       run: ./scripts/build.sh
     - name: Test PSym
       working-directory: Src/PRuntimes/PSymRuntime
-      run: mvn test -Dpsym.args="--strategy symbolic-iterative"
+      run: mvn test -Dpsym.args="--strategy symbolic-iterative" -Diterations="20"

--- a/.github/workflows/psymit.yml
+++ b/.github/workflows/psymit.yml
@@ -37,4 +37,4 @@ jobs:
       run: ./scripts/build.sh
     - name: Test PSym
       working-directory: Src/PRuntimes/PSymRuntime
-      run: mvn test -Dpsym.args="--strategy symbolic-iterative" -Diterations="20"
+      run: mvn test -Dpsym.args="--strategy symbolic-iterative" -Diterations="10"

--- a/.github/workflows/psymit.yml
+++ b/.github/workflows/psymit.yml
@@ -37,4 +37,4 @@ jobs:
       run: ./scripts/build.sh
     - name: Test PSym
       working-directory: Src/PRuntimes/PSymRuntime
-      run: mvn test -Dpsym.args="--strategy symbolic-iterative" -Diterations="10"
+      run: mvn test -Dpsym.args="--strategy symbolic-iterative"

--- a/Src/PRuntimes/PSymRuntime/pom.xml
+++ b/Src/PRuntimes/PSymRuntime/pom.xml
@@ -191,6 +191,9 @@
                     <systemPropertyVariables>
                         <propertyName>java.library.path</propertyName>
                         <mode/>
+                        <timeout/>
+                        <iterations/>
+                        <max.steps/>
                         <psym.args/>
                     </systemPropertyVariables>
                     <systemProperties>

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/EntryPoint.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/EntryPoint.java
@@ -80,9 +80,6 @@ public class EntryPoint {
     executor = Executors.newSingleThreadExecutor();
 
     PSymGlobal.setResult("error");
-    if (PSymGlobal.getConfiguration().getSymmetryMode() != SymmetryMode.None) {
-      SymmetryTracker.setScheduler(searchScheduler);
-    }
 
     double preSearchTime =
         TimeMonitor.getInstance().findInterval(TimeMonitor.getInstance().getStart());

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
@@ -55,7 +55,7 @@ public class PSymConfiguration implements Serializable {
   // whether or not to allow sync events
   @Getter @Setter boolean allowSyncEvents = true;
   // mode of state hashing
-  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.Symbolic;
+  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.None;
   // symmetry mode
   @Getter @Setter SymmetryMode symmetryMode = SymmetryMode.None;
   // use backtracking
@@ -102,10 +102,28 @@ public class PSymConfiguration implements Serializable {
 
   public void setToSymbolic() {
     this.setStrategy("symbolic");
+    this.setStateCachingMode(StateCachingMode.None);
+    this.setUseBacktrack(false);
+    this.setChoiceOrchestration(ChoiceOrchestrationMode.None);
+    this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);
+  }
+
+  public void setToSymbolicFixpoint() {
+    this.setStrategy("symbolic-fixpoint");
     this.setStateCachingMode(StateCachingMode.Symbolic);
     this.setUseBacktrack(false);
     this.setChoiceOrchestration(ChoiceOrchestrationMode.None);
     this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);
+  }
+
+  public void setToSymbolicIterative() {
+    this.setStrategy("symbolic-iterative");
+    this.setSchChoiceBound(2);
+    this.setDataChoiceBound(2);
+    this.setStateCachingMode(StateCachingMode.None);
+    this.setUseBacktrack(true);
+    this.setChoiceOrchestration(ChoiceOrchestrationMode.Random);
+    this.setTaskOrchestration(TaskOrchestrationMode.Random);
   }
 
   private void setToExplicit() {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
@@ -121,7 +121,7 @@ public class PSymConfiguration implements Serializable {
     this.setDataChoiceBound(2);
     this.setUseBacktrack(true);
     this.setChoiceOrchestration(ChoiceOrchestrationMode.Random);
-    this.setTaskOrchestration(TaskOrchestrationMode.Random);
+    this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);
   }
 
   private void setToExplicit() {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
@@ -84,7 +84,7 @@ public class PSymConfiguration implements Serializable {
   @Getter @Setter boolean writeToFile = false;
 
   public boolean isSymbolic() {
-    return (strategy.equals("symbolic"));
+    return (strategy.startsWith("symbolic"));
   }
 
   public boolean isExplicit() {
@@ -109,18 +109,16 @@ public class PSymConfiguration implements Serializable {
   }
 
   public void setToSymbolicFixpoint() {
+    setToSymbolic();
     this.setStrategy("symbolic-fixpoint");
     this.setStateCachingMode(StateCachingMode.Symbolic);
-    this.setUseBacktrack(false);
-    this.setChoiceOrchestration(ChoiceOrchestrationMode.None);
-    this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);
   }
 
   public void setToSymbolicIterative() {
+    setToSymbolic();
     this.setStrategy("symbolic-iterative");
     this.setSchChoiceBound(2);
     this.setDataChoiceBound(2);
-    this.setStateCachingMode(StateCachingMode.None);
     this.setUseBacktrack(true);
     this.setChoiceOrchestration(ChoiceOrchestrationMode.Random);
     this.setTaskOrchestration(TaskOrchestrationMode.Random);

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymConfiguration.java
@@ -55,7 +55,7 @@ public class PSymConfiguration implements Serializable {
   // whether or not to allow sync events
   @Getter @Setter boolean allowSyncEvents = true;
   // mode of state hashing
-  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.None;
+  @Getter @Setter StateCachingMode stateCachingMode = StateCachingMode.Symbolic;
   // symmetry mode
   @Getter @Setter SymmetryMode symmetryMode = SymmetryMode.None;
   // use backtracking
@@ -102,7 +102,7 @@ public class PSymConfiguration implements Serializable {
 
   public void setToSymbolic() {
     this.setStrategy("symbolic");
-    this.setStateCachingMode(StateCachingMode.None);
+    this.setStateCachingMode(StateCachingMode.Symbolic);
     this.setUseBacktrack(false);
     this.setChoiceOrchestration(ChoiceOrchestrationMode.None);
     this.setTaskOrchestration(TaskOrchestrationMode.DepthFirst);

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymOptions.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/commandline/PSymOptions.java
@@ -432,6 +432,12 @@ public class PSymOptions {
             case "symbolic":
               config.setToSymbolic();
               break;
+            case "symbolic-fixpoint":
+              config.setToSymbolicFixpoint();
+              break;
+            case "symbolic-iterative":
+              config.setToSymbolicIterative();
+              break;
             case "random":
               config.setToRandom();
               break;

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/machine/events/Message.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/machine/events/Message.java
@@ -157,17 +157,10 @@ public class Message implements ValueSummary<Message> {
     return new Message(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public Message swap(Machine m1, Machine m2) {
+  public Message swap(Map<Machine, Machine> mapping) {
     Map<Event, UnionVS> newPayload = new HashMap<>(this.payload);
-    newPayload.replaceAll((k, v) -> v.swap(m1, m2));
-    return new Message(this.event.swap(m1, m2), this.target.swap(m1, m2), newPayload);
+    newPayload.replaceAll((k, v) -> v.swap(mapping));
+    return new Message(this.event.swap(mapping), this.target.swap(mapping), newPayload);
   }
 
   public PrimitiveVS<Event> getEvent() {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/Schedule.java
@@ -30,12 +30,7 @@ public class Schedule implements Serializable {
     this.schedulerSymmetry = symmetryTracker;
   }
 
-  private Schedule(
-          Map<Class<? extends Machine>, ListVS<PrimitiveVS<Machine>>> createdMachines,
-          Set<Machine> machines) {
-    this.createdMachines = new HashMap<>(createdMachines);
-    this.machines = new HashSet<>(machines);
-  }
+  private Schedule() {}
 
 
   private Schedule(
@@ -285,7 +280,7 @@ public class Schedule implements Serializable {
   }
 
   public Schedule getSingleSchedule() {
-    Schedule result = new Schedule(createdMachines, machines);
+    Schedule result = new Schedule();
 
     Guard pc = Guard.constTrue();
     pc = pc.and(getFilter());
@@ -312,6 +307,15 @@ public class Schedule implements Serializable {
             pc = pc.and(intChoice.getGuardedValues().get(0).getGuard());
             result.addRepeatInt(new PrimitiveVS<>(intChoice.getGuardedValues().get(0).getValue()), dNew++);
           }
+        }
+      }
+    }
+
+    for (Map.Entry<Class<? extends Machine>, ListVS<PrimitiveVS<Machine>>> entry: createdMachines.entrySet()) {
+      ListVS<PrimitiveVS<Machine>> machineListVs = entry.getValue().restrict(pc);
+      for (PrimitiveVS<Machine> machineVs: machineListVs.getItems()) {
+        for (Machine m: machineVs.getValues()) {
+          result.makeMachine(m, Guard.constTrue());
         }
       }
     }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/replay/ReplayScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/replay/ReplayScheduler.java
@@ -3,6 +3,8 @@ package psym.runtime.scheduler.replay;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
 import lombok.Getter;
 import org.apache.commons.lang3.NotImplementedException;
 import psym.runtime.PSymGlobal;
@@ -12,6 +14,7 @@ import psym.runtime.machine.Machine;
 import psym.runtime.machine.events.Message;
 import psym.runtime.scheduler.Schedule;
 import psym.runtime.scheduler.Scheduler;
+import psym.runtime.scheduler.search.symmetry.SymmetryMode;
 import psym.utils.Assert;
 import psym.utils.exception.LivenessException;
 import psym.valuesummary.*;
@@ -147,6 +150,43 @@ public class ReplayScheduler extends Scheduler {
   }
 
   @Override
+  public PrimitiveVS<Machine> allocateMachine(
+          Guard pc,
+          Class<? extends Machine> machineType,
+          Function<Integer, ? extends Machine> constructor) {
+    if (!machineCounters.containsKey(machineType)) {
+      machineCounters.put(machineType, new PrimitiveVS<>(0));
+    }
+    PrimitiveVS<Integer> guardedCount = machineCounters.get(machineType).restrict(pc);
+
+    PrimitiveVS<Machine> allocated;
+    assert (schedule.hasMachine(machineType, guardedCount, pc));
+    allocated = schedule.getMachine(machineType, guardedCount).restrict(pc);
+    for (GuardedValue gv : allocated.getGuardedValues()) {
+      Guard g = gv.getGuard();
+      Machine m = (Machine) gv.getValue();
+      assert (!BooleanVS.isEverTrue(m.hasStarted().restrict(g)));
+      TraceLogger.onCreateMachine(pc.and(g), m);
+      if (!machines.contains(m)) {
+        machines.add(m);
+      }
+      currentMachines.add(m);
+      assert (machines.size() >= currentMachines.size());
+      m.setScheduler(this);
+      if (PSymGlobal.getConfiguration().getSymmetryMode() != SymmetryMode.None) {
+        PSymGlobal.getSymmetryTracker().createMachine(m, g);
+      }
+    }
+
+    guardedCount = IntegerVS.add(guardedCount, 1);
+
+    PrimitiveVS<Integer> mergedCount =
+            machineCounters.get(machineType).updateUnderGuard(pc, guardedCount);
+    machineCounters.put(machineType, mergedCount);
+    return allocated;
+  }
+
+  @Override
   public PrimitiveVS<Machine> getNextSchedulingChoice() {
     PrimitiveVS<Machine> res = schedule.getRepeatSchedulingChoice(choiceDepth);
     if (res.isEmptyVS()) {
@@ -176,5 +216,4 @@ public class ReplayScheduler extends Scheduler {
   public boolean isDone() {
     return super.isDone() || this.getChoiceDepth() >= schedule.size();
   }
-
 }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/SearchScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/SearchScheduler.java
@@ -150,6 +150,51 @@ public abstract class SearchScheduler extends Scheduler {
     }
   }
 
+  @Override
+  public PrimitiveVS<Machine> allocateMachine(
+          Guard pc,
+          Class<? extends Machine> machineType,
+          Function<Integer, ? extends Machine> constructor) {
+    if (!machineCounters.containsKey(machineType)) {
+      machineCounters.put(machineType, new PrimitiveVS<>(0));
+    }
+    PrimitiveVS<Integer> guardedCount = machineCounters.get(machineType).restrict(pc);
+
+    PrimitiveVS<Machine> allocated;
+    if (schedule.hasMachine(machineType, guardedCount, pc)) {
+      allocated = schedule.getMachine(machineType, guardedCount).restrict(pc);
+      for (GuardedValue gv : allocated.getGuardedValues()) {
+        Guard g = gv.getGuard();
+        Machine m = (Machine) gv.getValue();
+        assert (!BooleanVS.isEverTrue(m.hasStarted().restrict(g)));
+        TraceLogger.onCreateMachine(pc.and(g), m);
+        if (!machines.contains(m)) {
+          machines.add(m);
+        }
+        currentMachines.add(m);
+        assert (machines.size() >= currentMachines.size());
+        m.setScheduler(this);
+        if (PSymGlobal.getConfiguration().getSymmetryMode() != SymmetryMode.None) {
+          PSymGlobal.getSymmetryTracker().createMachine(m, g);
+        }
+      }
+    } else {
+      Machine newMachine = setupNewMachine(pc, guardedCount, constructor);
+
+      allocated = new PrimitiveVS<>(newMachine).restrict(pc);
+      if (PSymGlobal.getConfiguration().getSymmetryMode() != SymmetryMode.None) {
+        PSymGlobal.getSymmetryTracker().createMachine(newMachine, pc);
+      }
+    }
+
+    guardedCount = IntegerVS.add(guardedCount, 1);
+
+    PrimitiveVS<Integer> mergedCount =
+            machineCounters.get(machineType).updateUnderGuard(pc, guardedCount);
+    machineCounters.put(machineType, mergedCount);
+    return allocated;
+  }
+
   protected void storeSrcState() {
     if (!srcState.isEmpty()) return;
     for (Machine machine : currentMachines) {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/explicit/ExplicitSymmetryTracker.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/explicit/ExplicitSymmetryTracker.java
@@ -1,6 +1,8 @@
 package psym.runtime.scheduler.search.explicit;
 
 import java.util.*;
+
+import psym.runtime.PSymGlobal;
 import psym.runtime.machine.Machine;
 import psym.runtime.machine.Monitor;
 import psym.runtime.scheduler.search.symmetry.SymmetryTracker;
@@ -11,6 +13,8 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
   Set<Machine> pendingMerges;
 
   Map<Machine, Map<String, Object>> machineToSymData;
+  Map<Machine, Map<String, Machine>> machineToChildren;
+  Map<Machine, Machine> machineToParent;
 
   public ExplicitSymmetryTracker() {
     typeToSymmetryClasses = new HashMap<>();
@@ -19,12 +23,16 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
     }
     pendingMerges = new HashSet<>();
     machineToSymData = new HashMap<>();
+    machineToChildren = new HashMap<>();
+    machineToParent = new HashMap<>();
   }
 
   private ExplicitSymmetryTracker(
       Map<String, List<TreeSet<Machine>>> symClasses,
       Set<Machine> pending,
-      Map<Machine, Map<String, Object>> symData) {
+      Map<Machine, Map<String, Object>> symData,
+      Map<Machine, Map<String, Machine>> symChildren,
+      Map<Machine, Machine> symParent) {
     typeToSymmetryClasses = new HashMap<>();
     for (Map.Entry<String, List<TreeSet<Machine>>> entry: symClasses.entrySet()) {
       List<TreeSet<Machine>> newClasses = null;
@@ -38,10 +46,17 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
     }
     pendingMerges = new HashSet<>(pending);
     machineToSymData = new HashMap<>(symData);
+    machineToChildren = new HashMap<>(symChildren);
+    machineToParent = new HashMap<>(symParent);
   }
 
   public SymmetryTracker getCopy() {
-    return new ExplicitSymmetryTracker(typeToSymmetryClasses, pendingMerges, machineToSymData);
+    return new ExplicitSymmetryTracker(
+            typeToSymmetryClasses,
+            pendingMerges,
+            machineToSymData,
+            machineToChildren,
+            machineToParent);
   }
 
   public void reset() {
@@ -51,6 +66,8 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
     typeToSymmetryClasses.replaceAll((t, v) -> null);
     pendingMerges = new HashSet<>();
     machineToSymData = new HashMap<>();
+    machineToChildren = new HashMap<>();
+    machineToParent = new HashMap<>();
   }
 
   public void addMachineSymData(Machine machine, String dataName, Object data) {
@@ -60,6 +77,16 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
     }
     machineSymmetricData.put(dataName, data);
     machineToSymData.put(machine, machineSymmetricData);
+    if (data instanceof Machine) {
+      Machine depMachine  = (Machine) data;
+      Map<String, Machine> machineDeps = machineToChildren.get(machine);
+      if (machineDeps == null) {
+        machineDeps = new HashMap<>();
+      }
+      machineDeps.put(depMachine.getName(), depMachine);
+      machineToChildren.put(machine, machineDeps);
+      machineToParent.put(depMachine, machine);
+    }
   }
 
   public Object getMachineSymData(Machine machine, String dataName, Object curr) {
@@ -100,6 +127,9 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
       symClasses.set(0, symSet);
       // add to map
       typeToSymmetryClasses.put(machine.getName(), symClasses);
+      if (!machineToParent.containsKey(machine)) {
+        machineToParent.put(machine, machine);
+      }
     }
   }
 
@@ -127,26 +157,37 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
 
         Object value = guardedValues.get(0).getValue();
         if (value instanceof Machine) {
-          Machine machine = ((Machine) value);
+          Machine machineOrig = ((Machine) value);
+          Machine machineParent = machineToParent.get(machineOrig);
 
-          // check if symmetric machine
-          List<TreeSet<Machine>> symClasses =
-              typeToSymmetryClasses.get(machine.getName());
-          if (symClasses != null) {
+          if (machineParent != null) {
+            // check if symmetric machine
+            List<TreeSet<Machine>> symClasses = typeToSymmetryClasses.get(machineParent.getName());
+            assert (symClasses != null);
+
             // check each symmetry class
             for (TreeSet<Machine> symSet : symClasses) {
-              boolean hasMachine = symSet.contains(machine);
+              boolean hasMachine = symSet.contains(machineParent);
 
               if (hasMachine) {
                 // machine is present in the symmetry class
 
                 // get representative as first element of the class
-                Machine m = symSet.first();
-                assert (!m.getEventBuffer().isEmpty());
-                pendingSummaries.add(m);
+                Machine machineParentRep = symSet.first();
+
+                Machine machineRep = machineParentRep;
+                if (machineOrig != machineParent) {
+                  Map<String, Machine> machineParentRepChildren = machineToChildren.get(machineParentRep);
+                  assert (machineParentRepChildren != null);
+                  machineRep = machineParentRepChildren.get(machineOrig.getName());
+                }
+                assert (machineRep != null);
+
+                assert (!machineRep.getEventBuffer().isEmpty());
+                pendingSummaries.add(machineRep);
               }
+              added = true;
             }
-            added = true;
           }
         }
       }
@@ -155,19 +196,21 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
       }
     }
 
-    for (Machine m : pendingSummaries) {
-      assert (!m.getEventBuffer().isEmpty());
-      reduced.add(new PrimitiveVS(Collections.singletonMap(m, Guard.constTrue())));
+    for (Machine m_orig : pendingSummaries) {
+      assert (!m_orig.getEventBuffer().isEmpty());
+      reduced.add(new PrimitiveVS(Collections.singletonMap(m_orig, Guard.constTrue())));
     }
 
     return reduced;
   }
 
-  public void updateSymmetrySet(Machine machine, Guard guard) {
-    String type = machine.getName();
+  public void updateSymmetrySet(Machine machine_orig, Guard guard) {
+    Machine machine = machineToParent.get(machine_orig);
+    if (machine != null) {
+      String type = machine.getName();
 
-    List<TreeSet<Machine>> symClasses = typeToSymmetryClasses.get(type);
-    if (symClasses != null) {
+      List<TreeSet<Machine>> symClasses = typeToSymmetryClasses.get(type);
+      assert (symClasses != null);
       // iterate over each symmetry class
       for (TreeSet<Machine> symSet: symClasses) {
         // remove chosen from the ith class
@@ -239,10 +282,8 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
     }
   }
 
-  private boolean haveSymEqLocalState(Machine m1, Machine m2, Set<Machine> otherMachines) {
+  private boolean haveSymEqLocalState(Machine m1, Machine m2, Map<Machine, Machine> mapping) {
     assert (m1 != m2);
-    otherMachines.remove(m1);
-    otherMachines.remove(m2);
 
     List<ValueSummary> m1State = m1.getMachineLocalState().getLocals();
     List<ValueSummary> m2State = m2.getMachineLocalState().getLocals();
@@ -250,34 +291,12 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
 
     for (int i = 0; i < m1State.size(); i++) {
       ValueSummary original = m1State.get(i);
-      ValueSummary permuted = m2State.get(i).swap(m1, m2);
+      ValueSummary permuted = m2State.get(i).swap(mapping);
       if (original.isEmptyVS() && permuted.isEmptyVS()) {
         continue;
       }
       if (original.getConcreteHash() != permuted.getConcreteHash()) {
         return false;
-      }
-    }
-
-    Map<String, Object> m1SymData = machineToSymData.get(m1);
-    if (m1SymData != null) {
-      Map<String, Object> m2SymData = machineToSymData.get(m2);
-      if (m2SymData != null) {
-        for (String fieldName : m1SymData.keySet()) {
-              Object m1Object = m1SymData.get(fieldName);
-              if (m1Object != null && m1Object instanceof Machine) {
-                Machine m1Dep = (Machine) m1Object;
-                Object m2Object = m2SymData.get(fieldName);
-                if (m2Object != null && m2Object instanceof Machine) {
-                  Machine m2Dep = (Machine) m2Object;
-                  if (m1Dep != m2Dep) {
-                    if (!haveSymEqLocalState(m1Dep, m2Dep, otherMachines)) {
-                        return false;
-                    }
-                  }
-              }
-          }
-        }
       }
     }
 
@@ -287,22 +306,28 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
   private boolean isSymEquiv(Machine m1, Machine m2) {
     assert (m1 != m2);
 
-    Set<Machine> otherMachines = new HashSet<>();
-    for (Machine m : scheduler.getMachines()) {
-      if (m instanceof Monitor) {
+    Map<Machine, Machine> mapping = new HashMap<>();
+    getMappingWithDependencies(m1, m2, mapping);
+
+    Set<Machine> processed = new HashSet<>();
+    for (Map.Entry<Machine, Machine> entry: mapping.entrySet()) {
+      if (processed.contains(entry.getKey())) {
         continue;
       }
-      otherMachines.add(m);
+      if (!haveSymEqLocalState(entry.getKey(), entry.getValue(), mapping)) {
+        return false;
+      }
+      processed.add(entry.getKey());
+      processed.add(entry.getValue());
     }
 
-    if (!haveSymEqLocalState(m1, m2, otherMachines)) {
-      return false;
-    }
-
-    for (Machine other : otherMachines) {
-      assert (other != m1 && other != m2 && !(other instanceof Monitor));
+    for (Machine m : PSymGlobal.getScheduler().getMachines()) {
+      if (m instanceof Monitor || mapping.containsKey(m)) {
+        continue;
+      }
+      Machine other  = m;
       for (ValueSummary original : other.getMachineLocalState().getLocals()) {
-        ValueSummary permuted = original.swap(m1, m2);
+        ValueSummary permuted = original.swap(mapping);
         if (original.isEmptyVS() && permuted.isEmptyVS()) {
           continue;
         }
@@ -313,6 +338,30 @@ public class ExplicitSymmetryTracker extends SymmetryTracker {
     }
 
     return true;
+  }
+
+  private void getMappingWithDependencies(Machine m1, Machine m2, Map<Machine, Machine> mapping) {
+    assert (m1 != m2);
+    mapping.put(m1, m2);
+    mapping.put(m2, m1);
+
+    Map<String, Machine> m1Deps = machineToChildren.get(m1);
+    if (m1Deps != null) {
+      Map<String, Machine> m2Deps = machineToChildren.get(m2);
+      if (m2Deps != null) {
+        for (Map.Entry<String, Machine> entry : m1Deps.entrySet()) {
+          String machineType = entry.getKey();
+          Machine m1D = entry.getValue();
+          assert (m1D != null);
+
+          Machine m2D = m2Deps.get(machineType);
+          assert (m2D != null);
+
+          assert (m1D != m2D);
+          getMappingWithDependencies(m1D, m2D, mapping);
+        }
+      }
+    }
   }
 
 }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSearchScheduler.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSearchScheduler.java
@@ -55,7 +55,7 @@ public class SymbolicSearchScheduler extends SearchScheduler {
     int numMessagesExplored = 0;
     int numStates = 0;
 
-    if (PSymGlobal.getConfiguration().isIterative()
+    if (!PSymGlobal.getConfiguration().isIterative()
             && PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Symbolic) {
       ProtocolState srcProtocolState = new ProtocolState(currentMachines);
       for (int i = depth; i >= 0; i--) {
@@ -143,7 +143,7 @@ public class SymbolicSearchScheduler extends SearchScheduler {
       depth++;
     }
 
-    if (PSymGlobal.getConfiguration().isIterative()
+    if (!PSymGlobal.getConfiguration().isIterative()
             && PSymGlobal.getConfiguration().getStateCachingMode() == StateCachingMode.Symbolic) {
       Message effectNew = effect.restrict(done.not());
       if (effectNew.isEmptyVS()) {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSymmetryTracker.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symbolic/SymbolicSymmetryTracker.java
@@ -1,6 +1,8 @@
 package psym.runtime.scheduler.search.symbolic;
 
 import java.util.*;
+
+import psym.runtime.PSymGlobal;
 import psym.runtime.machine.Machine;
 import psym.runtime.machine.Monitor;
 import psym.runtime.scheduler.search.symmetry.SymmetryPendingMerges;
@@ -352,7 +354,7 @@ public class SymbolicSymmetryTracker extends SymmetryTracker {
 
     for (int i = 0; i < m1State.size(); i++) {
       ValueSummary original = m1State.get(i).restrict(pc);
-      ValueSummary permuted = m2State.get(i).restrict(pc).swap(m1, m2);
+      ValueSummary permuted = m2State.get(i).restrict(pc).swap(Collections.singletonMap(m1, m2));
       if (original.isEmptyVS() && permuted.isEmptyVS()) {
         continue;
       }
@@ -372,13 +374,13 @@ public class SymbolicSymmetryTracker extends SymmetryTracker {
       return result;
     }
 
-    for (Machine other : scheduler.getMachines()) {
+    for (Machine other : PSymGlobal.getScheduler().getMachines()) {
       if (other == m1 || other == m2 || other instanceof Monitor) {
         continue;
       }
       for (ValueSummary original : other.getMachineLocalState().getLocals()) {
         original = original.restrict(pc);
-        ValueSummary permuted = original.swap(m1, m2);
+        ValueSummary permuted = original.swap(Collections.singletonMap(m1, m2));
         if (original.isEmptyVS() && permuted.isEmptyVS()) {
           continue;
         }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symmetry/SymmetryTracker.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/runtime/scheduler/search/symmetry/SymmetryTracker.java
@@ -10,8 +10,6 @@ import psym.valuesummary.*;
 public abstract class SymmetryTracker implements Serializable {
   public static final Map<String, Set<Machine>> typeToAllSymmetricMachines = new HashMap<>();
 
-  @Setter protected static Scheduler scheduler;
-
   public static void addSymmetryType(String type) {
     typeToAllSymmetricMachines.put(type, new TreeSet<>());
   }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/ListVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/ListVS.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Getter;
@@ -57,17 +58,10 @@ public class ListVS<T extends ValueSummary<T>> implements ValueSummary<ListVS<T>
     return new ListVS(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public ListVS<T> swap(Machine m1, Machine m2) {
+  public ListVS<T> swap(Map<Machine, Machine> mapping) {
     return new ListVS(
         new PrimitiveVS<>(this.size),
-        this.items.stream().map(i -> i.swap(m1, m2)).collect(Collectors.toList()));
+        this.items.stream().map(i -> i.swap(mapping)).collect(Collectors.toList()));
   }
 
   /**

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/MapVS.java
@@ -58,29 +58,21 @@ public class MapVS<K, T extends ValueSummary<T>, V extends ValueSummary<V>>
     return new MapVS(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public MapVS<K, T, V> swap(Machine m1, Machine m2) {
+  public MapVS<K, T, V> swap(Map<Machine, Machine> mapping) {
     Map<K, V> newEntries = new HashMap<>();
     for (Map.Entry<K, V> kv : this.entries.entrySet()) {
       K key = kv.getKey();
       if (key instanceof Machine) {
-        Machine machineKey = (Machine) key;
-        if (key.equals(m1)) {
-          key = (K) m2;
-        } else if (key.equals(m2)) {
-          key = (K) m1;
+        Machine origMachine = (Machine) key;
+        Machine newMachine = mapping.get(origMachine);
+        if (newMachine != null) {
+          key = (K) newMachine;
         }
       }
-      V val = kv.getValue().swap(m1, m2);
+      V val = kv.getValue().swap(mapping);
       newEntries.put(key, val);
     }
-    return new MapVS(this.keys.swap(m1, m2), newEntries);
+    return new MapVS(this.keys.swap(mapping), newEntries);
   }
 
   /**

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/PrimitiveVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/PrimitiveVS.java
@@ -136,25 +136,16 @@ public class PrimitiveVS<T> implements ValueSummary<PrimitiveVS<T>> {
     return new PrimitiveVS(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public PrimitiveVS<T> swap(Machine m1, Machine m2) {
+  public PrimitiveVS<T> swap(Map<Machine, Machine> mapping) {
     boolean swapped = false;
     Map<T, Guard> newGuardedValues = new HashMap<>();
     for (Map.Entry<T, Guard> entry : guardedValues.entrySet()) {
       T key = entry.getKey();
       if (key instanceof Machine) {
-        Machine machineKey = (Machine) key;
-        if (key.equals(m1)) {
-          key = (T) m2;
-          swapped = true;
-        } else if (key.equals(m2)) {
-          key = (T) m1;
+        Machine origMachine = (Machine) key;
+        Machine newMachine = mapping.get(origMachine);
+        if (newMachine != null) {
+          key = (T) newMachine;
           swapped = true;
         }
       }

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/SetVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/SetVS.java
@@ -47,15 +47,8 @@ public class SetVS<T extends ValueSummary<T>> implements ValueSummary<SetVS<T>> 
     return new SetVS(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public SetVS<T> swap(Machine m1, Machine m2) {
-    return new SetVS<T>(this.elements.swap(m1, m2));
+  public SetVS<T> swap(Map<Machine, Machine> mapping) {
+    return new SetVS<T>(this.elements.swap(mapping));
   }
 
   public PrimitiveVS<Integer> size() {

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/TupleVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/TupleVS.java
@@ -1,9 +1,6 @@
 package psym.valuesummary;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Getter;
@@ -76,16 +73,9 @@ public class TupleVS implements ValueSummary<TupleVS> {
     return new TupleVS(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public TupleVS swap(Machine m1, Machine m2) {
+  public TupleVS swap(Map<Machine, Machine> mapping) {
     return new TupleVS(
-        Arrays.stream(this.fields).map(x -> x.swap(m1, m2)).toArray(size -> new ValueSummary[size]),
+        Arrays.stream(this.fields).map(x -> x.swap(mapping)).toArray(size -> new ValueSummary[size]),
         this.classes);
   }
 

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/UnionVS.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/UnionVS.java
@@ -84,16 +84,9 @@ public class UnionVS implements ValueSummary<UnionVS> {
     return new UnionVS(this);
   }
 
-  /**
-   * Permute the value summary
-   *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
-   */
-  public UnionVS swap(Machine m1, Machine m2) {
+  public UnionVS swap(Map<Machine, Machine> mapping) {
     Map<UnionVStype, ValueSummary> newValues = new HashMap<>(this.value);
-    newValues.replaceAll((k, v) -> v.swap(m1, m2));
+    newValues.replaceAll((k, v) -> v.swap(mapping));
     return new UnionVS(this.type.getCopy(), newValues);
   }
 

--- a/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/ValueSummary.java
+++ b/Src/PRuntimes/PSymRuntime/src/main/java/psym/valuesummary/ValueSummary.java
@@ -234,11 +234,10 @@ public interface ValueSummary<T extends ValueSummary<T>> extends Serializable {
   /**
    * Permute the value summary
    *
-   * @param m1 first machine
-   * @param m2 second machine
-   * @return A new cloned copy of the value summary with m1 and m2 swapped
+   * @param mapping map for each machine pairs
+   * @return A new cloned copy of the value summary with m1 and m2 swapped where mapping[m1] = m2
    */
-  T swap(Machine m1, Machine m2);
+  T swap(Map<Machine, Machine> mapping);
 
   /**
    * String representation of the value summary

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestCaseExecutor.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestCaseExecutor.java
@@ -193,7 +193,7 @@ public class TestCaseExecutor {
    * @throws IOException
    */
   private static Process buildRunProcess(String cmd, String outFolder) throws IOException {
-    ProcessBuilder builder = new ProcessBuilder(cmd.split(" "));
+    ProcessBuilder builder = new ProcessBuilder(cmd.split("\\s+"));
     File outFile = new File(outFolder + "/run.out");
     outFile.getParentFile().mkdirs();
     outFile.createNewFile();

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestCaseExecutor.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestCaseExecutor.java
@@ -142,7 +142,7 @@ public class TestCaseExecutor {
       } else if (resultCode == 2) {
         PSymTestLogger.log("      bug");
       } else if (resultCode == 3) {
-        PSymTestLogger.log("      timeout");
+        PSymTestLogger.log("      ok");
       } else if (resultCode == 4) {
         PSymTestLogger.log("      memout");
       } else {

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestCaseExecutor.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestCaseExecutor.java
@@ -142,7 +142,7 @@ public class TestCaseExecutor {
       } else if (resultCode == 2) {
         PSymTestLogger.log("      bug");
       } else if (resultCode == 3) {
-        PSymTestLogger.log("      ok");
+        PSymTestLogger.log("      timeout");
       } else if (resultCode == 4) {
         PSymTestLogger.log("      memout");
       } else {

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
@@ -62,7 +62,7 @@ public class TestSymbolicRegression {
     runArgs += String.format(" --timeout %s --iterations %s --max-steps %s", timeout, iterations, maxSteps);
 
     if (psymArgs != null && !psymArgs.isEmpty()) {
-      runArgs += " --psym-args :" + psymArgs.replace(" ", ":");
+      runArgs += String.format(" --psym-args :%s ", psymArgs.replace(" ", ":"));
     }
     PSymTestLogger.log(String.format("Running in mode %s with arguments:  %s", mode, runArgs));
   }

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
@@ -26,7 +26,7 @@ public class TestSymbolicRegression {
   private static final String outputDirectory = "output/testCases";
   private static final List<String> excluded = new ArrayList<>();
   private static String mode = "verification";
-  private static String runArgs = "--timeout 60 --iterations 100 --max-steps 300";
+  private static String runArgs = "--timeout 60 --iterations 50 --max-steps 300";
   private static boolean initialized = false;
 
   private static void setRunArgs() {

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
@@ -26,11 +26,17 @@ public class TestSymbolicRegression {
   private static final String outputDirectory = "output/testCases";
   private static final List<String> excluded = new ArrayList<>();
   private static String mode = "verification";
-  private static String runArgs = "--timeout 60 --iterations 50 --max-steps 300";
+  private static String timeout = "60";
+  private static String iterations = "50";
+  private static String maxSteps = "300";
+  private static String runArgs = "";
   private static boolean initialized = false;
 
   private static void setRunArgs() {
     String md = System.getProperty("mode");
+    String to = System.getProperty("timeout");
+    String it = System.getProperty("iterations");
+    String ms = System.getProperty("max.steps");
     String psymArgs = System.getProperty("psym.args");
 
     if (md != null && !md.isEmpty()) {
@@ -43,6 +49,18 @@ public class TestSymbolicRegression {
           break;
       }
     }
+    if (to != null && !to.isEmpty()) {
+      timeout = to;
+    }
+    if (it != null && !it.isEmpty()) {
+      iterations = it;
+    }
+    if (ms != null && !ms.isEmpty()) {
+      maxSteps = ms;
+    }
+
+    runArgs += String.format(" --timeout %s --iterations %s --max-steps %s", timeout, iterations, maxSteps);
+
     if (psymArgs != null && !psymArgs.isEmpty()) {
       runArgs += " --psym-args :" + psymArgs.replace(" ", ":");
     }


### PR DESCRIPTION
[PSym]
- Adds symbolic state caching with support for pruning explored states and fix point detection
- Updates CLI to include new symbolic strategies: symbolic-fixpoint and symbolic-iterative (choices bounded to 2 per iteration)
- Cex replayer: corrects behavior with dynamic machine creation in PSym mode

[PCover]
- Adds core algorithm to track dependent fields and perform symmetry-aware search with them

[CI]
- Minor updates relating to configuring checker run for PSym