### PR TITLE
Added JSON representation of payload of all types, beyond named tuples

### DIFF
--- a/Src/PRuntimes/PCSharpRuntime/PEvent.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PEvent.cs
@@ -26,6 +26,11 @@ namespace Plang.CSharpRuntime
         {
             throw new NotImplementedException();
         }
+
+        public object ToDict()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class PHalt : PEvent

--- a/Src/PRuntimes/PCSharpRuntime/PEvent.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PEvent.cs
@@ -29,7 +29,7 @@ namespace Plang.CSharpRuntime
 
         public object ToDict()
         {
-            throw new NotImplementedException();
+            return GetType().FullName;
         }
     }
 

--- a/Src/PRuntimes/PCSharpRuntime/PEvent.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PEvent.cs
@@ -29,7 +29,7 @@ namespace Plang.CSharpRuntime
 
         public object ToDict()
         {
-            return GetType().FullName;
+            throw new NotImplementedException();
         }
     }
 

--- a/Src/PRuntimes/PCSharpRuntime/PJsonFormatter.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PJsonFormatter.cs
@@ -41,40 +41,7 @@ namespace Plang.CSharpRuntime
 
             return log;
         }
-
-        /// <summary>
-        /// Parse payload input to dictionary format.
-        /// I.e.
-        /// Input: (<source:Client(4), accountId:0, amount:8, rId:19, >)
-        /// Parsed Output: {
-        ///     "source": "Client(4)",
-        ///     "accountId": "0",
-        ///     "amount": "8",
-        ///     "rId": "19",
-        /// }
-        /// </summary>
-        /// <param name="payload">String representing the payload.</param>
-        /// <returns>The dictionary object representation of the payload.</returns>
-        private static Dictionary<string, string> ParsePayloadToDictionary(string payload)
-        {
-            var parsedPayload = new Dictionary<string, string>();
-            var trimmedPayload = payload.Trim('(', ')', '<', '>');
-            var payloadKeyValuePairs = trimmedPayload.Split(',');
-
-            foreach (var payloadPair in payloadKeyValuePairs)
-            {
-                var payloadKeyValue = payloadPair.Split(':');
-
-                if (payloadKeyValue.Length != 2) continue;
-                var key = payloadKeyValue[0].Trim();
-                var value = payloadKeyValue[1].Trim();
-
-                parsedPayload[key] = value;
-            }
-
-            return parsedPayload;
-        }
-
+        
         /// <summary>
         /// Method taken from PLogFormatter.cs file. Takes in a string and only get the
         /// last element of the string separated by a period.
@@ -85,24 +52,7 @@ namespace Plang.CSharpRuntime
         /// <param name="name">String representing the name to be parsed.</param>
         /// <returns>The split string.</returns>
         private static string GetShortName(string name) => name?.Split('.').Last();
-
-        /// TODO: What other forms can the payload be in? Have the method implemented in IPrtValue?
-        /// <summary>
-        /// Cleans the payload string to remove "<" and "/>" and replacing ':' with '='
-        /// I.e.
-        /// Input: (<source:Client(4), accountId:0, amount:4, rId:18, >)
-        /// Output: (source=Client(4), accountId=0, amount=4, rId=18)
-        /// </summary>
-        /// <param name="payload">String representation of the payload.</param>
-        /// <returns>The cleaned payload.</returns>
-        private static string CleanPayloadString(string payload)
-        {
-            var output = payload.Replace("<", string.Empty);
-            output = output.Replace(':', '=');
-            output = output.Replace(", >", string.Empty);
-            return output;
-        }
-
+        
         /// <summary>
         /// Method taken from PLogFormatter.cs file. Takes in Event e and returns string
         /// with details about the event such as event name and its payload. Slightly modified
@@ -117,10 +67,10 @@ namespace Plang.CSharpRuntime
             {
                 return e.GetType().Name;
             }
-
+            
             var pe = (PEvent)(e);
             var payload = pe.Payload == null ? "null" : pe.Payload.ToEscapedString();
-            var msg = pe.Payload == null ? "" : $" with payload ({CleanPayloadString(payload)})";
+            var msg = pe.Payload == null ? "" : $" with payload ({payload})";
             return $"{GetShortName(e.GetType().Name)}{msg}";
         }
 
@@ -129,7 +79,7 @@ namespace Plang.CSharpRuntime
         /// </summary>
         /// <param name="e">Event input.</param>
         /// <returns>Dictionary representation of the payload for the event, if any.</returns>
-        private static Dictionary<string, string> GetEventPayloadInJson(Event e)
+        private static object GetEventPayloadInJson(Event e)
         {
             if (e.GetType().Name.Contains("GotoStateEvent"))
             {
@@ -137,7 +87,7 @@ namespace Plang.CSharpRuntime
             }
 
             var pe = (PEvent)(e);
-            return pe.Payload != null ? ParsePayloadToDictionary(pe.Payload.ToEscapedString()) : null;
+            return pe.Payload == null ? null : pe.Payload.ToDict();
         }
 
         public override void OnCompleted()

--- a/Src/PRuntimes/PCSharpRuntime/PMachine.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PMachine.cs
@@ -219,6 +219,11 @@ namespace Plang.CSharpRuntime
             {
                 throw new NotImplementedException();
             }
+
+            public object ToDict()
+            {
+                throw new NotImplementedException();
+            }
         }
 
         public class InitializeParametersEvent : PEvent

--- a/Src/PRuntimes/PCSharpRuntime/Values/IPrtValue.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/IPrtValue.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Plang.CSharpRuntime.Values
 {
@@ -14,5 +15,7 @@ namespace Plang.CSharpRuntime.Values
         {
             return ToString();
         }
+        
+        object ToDict();
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/IPrtValue.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/IPrtValue.cs
@@ -16,6 +16,9 @@ namespace Plang.CSharpRuntime.Values
             return ToString();
         }
         
-        object ToDict();
+        object ToDict()
+        {
+            return ToEscapedString();
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PMachineValue.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PMachineValue.cs
@@ -47,5 +47,10 @@ namespace Plang.CSharpRuntime.Values
         {
             return Id.Name.Split('.').Last();
         }
+        
+        public object ToDict()
+        {
+            return ToString();
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtBool.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtBool.cs
@@ -25,6 +25,11 @@ namespace Plang.CSharpRuntime.Values
         {
             return value.ToString();
         }
+        
+        public object ToDict()
+        {
+            return value;
+        }
 
         private readonly bool value;
 

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtEnum.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtEnum.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Plang.CSharpRuntime.Values
 {
@@ -22,6 +23,11 @@ namespace Plang.CSharpRuntime.Values
         public static void Clear()
         {
             enumElements.Clear();
+        }
+        
+        public object ToDict()
+        {
+            return enumElements.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToDict());
         }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtFloat.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtFloat.cs
@@ -24,6 +24,11 @@ namespace Plang.CSharpRuntime.Values
         {
             return value.ToString();
         }
+        
+        public object ToDict()
+        {
+            return value;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(IPrtValue other)

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtInt.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtInt.cs
@@ -38,6 +38,11 @@ namespace Plang.CSharpRuntime.Values
         {
             return value.ToString();
         }
+        
+        public object ToDict()
+        {
+            return value;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator PrtInt(byte val)

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtMap.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtMap.cs
@@ -215,5 +215,20 @@ namespace Plang.CSharpRuntime.Values
             sb.Append(")");
             return sb.ToString();
         }
+        
+        public object ToDict()
+        {
+            var mapDict = new Dictionary<string, object>();
+            
+            foreach (var value in map)
+            {
+                var mapKey = value.Key.ToEscapedString();
+                var mapValue = value.Value.ToDict();
+                
+                mapDict.Add(mapKey, mapValue);
+            }
+            
+            return mapDict;
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtSeq.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtSeq.cs
@@ -163,5 +163,10 @@ namespace Plang.CSharpRuntime.Values
             sb.Append(")");
             return sb.ToString();
         }
+
+        public object ToDict()
+        {
+            return values.Select(value => value == null ? null : value.ToDict()).ToList();
+        }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtSet.cs
@@ -136,6 +136,11 @@ namespace Plang.CSharpRuntime.Values
             return sb.ToString();
         }
 
+        public object ToDict()
+        {
+            return set.Select(value => value == null ? null : value.ToDict()).ToList();
+        }
+
         public IPrtValue this[int index]
         {
             get => set.ElementAt(index);

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtString.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtString.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Plang.CSharpRuntime.Values
@@ -186,6 +187,12 @@ namespace Plang.CSharpRuntime.Values
         {
             var v = value ?? "";
             return $"\"{v.Replace("\"", "\\\"")}\"";
+        }
+
+
+        public object ToDict()
+        {
+            return ToString();
         }
     }
 }

--- a/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
+++ b/Src/PRuntimes/PCSharpRuntime/Values/PrtTuple.cs
@@ -99,6 +99,19 @@ namespace Plang.CSharpRuntime.Values
             retStr += ">";
             return retStr;
         }
+
+        public object ToDict()
+        {
+            var tupleDict = new Dictionary<int, object>();
+
+            for (var i = 0; i < fieldValues.Count; i++)
+            {
+                var fieldValue = fieldValues[i];
+                tupleDict.Add(i, fieldValue);
+            }
+
+            return tupleDict;
+        }
     }
 
     [Serializable]
@@ -223,6 +236,20 @@ namespace Plang.CSharpRuntime.Values
 
             retStr += ">";
             return retStr;
+        }
+
+        public object ToDict()
+        {
+            var namedTupleDict = new Dictionary<string, object>();
+
+            for (var i = 0; i < fieldValues.Count; i++)
+            {
+                var fieldValue = fieldValues[i] == null ? null : fieldValues[i].ToDict();
+                var fieldName = fieldNames[i];
+                namedTupleDict.Add(fieldName, fieldValue);
+            }
+
+            return namedTupleDict;
         }
     }
 }


### PR DESCRIPTION
\+ Added JSON representation of payload all P data types, beyond just named tuples

Added `object ToDict()` method for all `IPrtValues`

JSON payload should you represent all valid P data types, including nested data types.

### JSON representation of the different data types.

#### `tuple`
```
{
   [index]: value,
   ...
}

Example: (0, false, "foo") becomes
{
   0: 0,
   1: false,
   2: "foo",
}
```

####  `named tuple`
```
{
   [name]: value,
   ...
}

Example: (client=Client(7), trans=(key=8, val=8, transId=12)) becomes
{
   "client": "Client(7)",
   "trans": {
      "key": 8,
      "val": 8,
      "transId": 12
   }
}
```

#### `int`, `bool`, `float`, `string`
```
[value itself]

Example: int 8 becomes
8
bool false becomes
false
etc...
```

#### `enum`
```
{
   [name]: [int value],
   ...
}

Example: { ERROR = 500, SUCCESS = 200, TIMEOUT = 400; } becomes
{
   "ERROR": 500,
   "SUCCESS": 200,
   "TIMEOUT": 400,
}
```

#### `map`
```
{
   [key]: [value],
   ...
}

Example: (<key1 -> 2>, <key2 -> 4>) becomes
{
   "key1": 2,
   "key2": 4,
}
```

#### `seq`, `set`
```
[ [value], ... ]

Example: Both (<5>, <"value">, <false>) (set) and (5, "value", false) (seq) becomes
[ 5, "value", false ]
```