### PR TITLE
JSON logs Announce and Print actions

### DIFF
--- a/Src/PChecker/CheckerCore/Actors/Actor.cs
+++ b/Src/PChecker/CheckerCore/Actors/Actor.cs
@@ -15,6 +15,7 @@ using PChecker.Actors.Events;
 using PChecker.Actors.Exceptions;
 using PChecker.Actors.Handlers;
 using PChecker.Actors.Managers;
+using PChecker.Actors.Logging;
 using PChecker.Exceptions;
 using PChecker.IO.Debugging;
 using EventInfo = PChecker.Actors.Events.EventInfo;
@@ -112,6 +113,11 @@ namespace PChecker.Actors
         /// The installed runtime logger.
         /// </summary>
         protected TextWriter Logger => Runtime.Logger;
+        
+        /// <summary>
+        /// The installed runtime json logger.
+        /// </summary>
+        protected JsonWriter JsonLogger => Runtime.JsonLogger;
 
         /// <summary>
         /// User-defined hashed state of the actor. Override to improve the

--- a/Src/PChecker/CheckerCore/Actors/ActorRuntime.cs
+++ b/Src/PChecker/CheckerCore/Actors/ActorRuntime.cs
@@ -41,6 +41,11 @@ namespace PChecker.Actors
         /// to replace the logger with a custom one.
         /// </summary>
         public override TextWriter Logger => LogWriter.Logger;
+        
+        /// <summary>
+        /// Used to log json trace outputs.
+        /// </summary>
+        public JsonWriter JsonLogger => LogWriter.JsonLogger;
 
         /// <summary>
         /// Callback that is fired when a Coyote event is dropped.

--- a/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
+++ b/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
@@ -670,7 +670,17 @@ namespace PChecker.Actors.Logging
             /// <summary>
             /// Invoked when the specified actor waits to receive multiple events of a specified type.
             /// </summary>
-            WaitMultipleEvents
+            WaitMultipleEvents,
+            
+            /// <summary>
+            /// Invoked on a print statement
+            /// </summary>
+            Print,
+            
+            /// <summary>
+            /// Invoked on a print statement
+            /// </summary>
+            Announce,
         }
 
         /// <summary>

--- a/Src/PChecker/CheckerCore/Actors/Logging/LogWriter.cs
+++ b/Src/PChecker/CheckerCore/Actors/Logging/LogWriter.cs
@@ -29,7 +29,7 @@ namespace PChecker.Actors.Logging
         /// <summary>
         /// Used to log json messages.
         /// </summary>
-        private JsonWriter JsonLogger { get; set; }
+        public JsonWriter JsonLogger { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LogWriter"/> class.

--- a/Src/PChecker/CheckerCore/Specifications/Monitors/Monitor.cs
+++ b/Src/PChecker/CheckerCore/Specifications/Monitors/Monitor.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using PChecker.Actors;
+using PChecker.Actors.Logging;
 using PChecker.Actors.Events;
 using PChecker.Actors.Handlers;
 using PChecker.Actors.StateTransitions;
@@ -101,6 +102,11 @@ namespace PChecker.Specifications.Monitors
         /// See <see href="/coyote/learn/core/logging" >Logging</see> for more information.
         /// </remarks>
         protected TextWriter Logger => Runtime.Logger;
+        
+        /// <summary>
+        /// The runtime installed json logger;
+        /// </summary>
+        protected JsonWriter JsonLogger => Runtime.JsonLogger;
 
         /// <summary>
         /// Gets the current state.

--- a/Src/PCompiler/CompilerCore/Backend/CSharp/CSharpCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/CSharp/CSharpCodeGenerator.cs
@@ -983,7 +983,7 @@ namespace Plang.Compiler.Backend.CSharp
                     break;
 
                 case PrintStmt printStmt:
-                    context.Write(output, $"PModule.runtime.Logger.WriteLine(\"<PrintLog> \" + ");
+                    context.Write(output, $"currentMachine.LogLine(\"\" + ");
                     WriteExpr(context, output, printStmt.Message);
                     context.WriteLine(output, ");");
                     break;

--- a/Src/PRuntimes/PCSharpRuntime/PMonitor.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PMonitor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using PChecker.Actors.Events;
+using PChecker.Actors.Logging;
 using PChecker.Specifications.Monitors;
 
 namespace Plang.CSharpRuntime
@@ -38,6 +39,11 @@ namespace Plang.CSharpRuntime
         public void LogLine(string message)
         {
             Logger.WriteLine($"<PrintLog> {message}");
+            
+            // Log message to JSON output
+            JsonLogger.AddLogType(JsonWriter.LogType.Print); 
+            JsonLogger.AddLog(message);
+            JsonLogger.AddToLogs(updateVcMap: false);
         }
 
         public void Log(string message)


### PR DESCRIPTION
#### Example of Print log JSON

```
{
  "type": "Print",
  "details": {
    "log": "Withdrawal with rId = 3 failed, account balance = 13"
  }
},
```

#### Example of Announce log JSON

```
{
  "type": "Announce",
  "details": {
    "log": "TestWithSingleClient(2) announced event eSpec_BankBalanceIsAlwaysCorrect_Init with payload (\u003C0-\u003E107\u003E).",
    "id": "TestWithSingleClient(2)",
    "event": "eSpec_BankBalanceIsAlwaysCorrect_Init",
    "payload": {
      "0": 107
    },
    "clock": {
      "TestWithSingleClient(2)": 2
    }
  }
},
```