### PR TITLE
Vector clock updated for OnMonitorProcessEvents

### DIFF
--- a/Src/PRuntimes/PCSharpRuntime/PJsonFormatter.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PJsonFormatter.cs
@@ -472,8 +472,9 @@ namespace Plang.CSharpRuntime
 
             Writer.AddLogType(JsonWriter.LogType.MonitorProcessEvent);
             Writer.LogDetails.Monitor = monitorType;
-            Writer.LogDetails.Event = GetShortName(e.GetType().Name);
             Writer.LogDetails.State = stateName;
+            Writer.LogDetails.Sender = senderName;
+            Writer.LogDetails.Event = GetShortName(e.GetType().Name);
             Writer.LogDetails.Payload = GetEventPayloadInJson(e);
             Writer.AddLog(log);
             Writer.AddToLogs(updateVcMap: true);


### PR DESCRIPTION
#### Update
For `OnMonitorProcessEvents`, the monitor's vector clock will be connected to the `senderMachine`'s vector clock so there is some timeline association between when the monitor processed the event and when the senderMachine sent the event. 

#### Previous Issue
The issue before was that since there was no association between the monitor's and the senderMachine's events, all the monitor's individual events get's stacked.

<img width="1746" alt="Screenshot 2023-08-30 at 5 16 46 PM" src="https://github.com/p-org/P/assets/137958518/cfaca2b1-5be1-4859-812c-59bc473eaaf7">

#### Solution
Now, the individual events are expanded to better align with when the event was actually sent.

<img width="1746" alt="Screenshot 2023-08-30 at 5 15 01 PM" src="https://github.com/p-org/P/assets/137958518/486d63ed-2a1a-4c5d-825e-b617fe30acd4">

<img width="1746" alt="Screenshot 2023-08-30 at 5 14 25 PM" src="https://github.com/p-org/P/assets/137958518/7d542adc-72e8-4208-862e-bc0da73bcc82">
