### PR TITLE
Fix p check replay bug and stately code generator bug

### DIFF
--- a/Src/PChecker/CheckerCore/CheckerConfiguration.cs
+++ b/Src/PChecker/CheckerCore/CheckerConfiguration.cs
@@ -527,20 +527,22 @@ namespace PChecker
                 Directory.Delete(older, true);
             }
 
-            for (var history = MaxHistory - 2; history >= 0; --history)
-            {
-                var newer = makeHistoryDirName(history);
-                if (Directory.Exists(newer))
+            if(this.SchedulingStrategy != "replay"){
+                for (var history = MaxHistory - 2; history >= 0; --history)
                 {
-                    Directory.Move(newer, older);
+                    var newer = makeHistoryDirName(history);
+                    if (Directory.Exists(newer))
+                    {
+                        Directory.Move(newer, older);
+                    }
+
+                    older = newer;
                 }
 
-                older = newer;
-            }
-
-            if (Directory.Exists(OutputDirectory))
-            {
-                Directory.Move(OutputDirectory, older);
+                if (Directory.Exists(OutputDirectory))
+                {
+                    Directory.Move(OutputDirectory, older);
+                }
             }
 
             // Now create the new directory.

--- a/Src/PCompiler/CompilerCore/Backend/Stately/StatelyCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Stately/StatelyCodeGenerator.cs
@@ -157,7 +157,7 @@ namespace Plang.Compiler.Backend.Stately {
 
             }
             //All the go to Statements in a state (of a machine)
-            var gotoStmts = new Dictionary<String, List<String>>();
+            var gotoStmts = new Dictionary<String, HashSet<String>>();
             foreach (var pair in state.AllEventHandlers)
             {
                 var handledEvent = pair.Key;
@@ -167,23 +167,13 @@ namespace Plang.Compiler.Backend.Stately {
                 {
                     //on... goto...
                     case EventGotoState goAct:
-                        List<String> target = new List<String> { goAct.Target.Name };
-                        if (gotoStmts.ContainsKey(goAct.Trigger.Name))
-                        {
-                            target.AddRange(gotoStmts[goAct.Trigger.Name]);
-                        }
-                        gotoStmts[goAct.Trigger.Name] =  target;
+                        gotoStmts[goAct.Trigger.Name].Add(goAct.Target.Name)
                         break;
                     //on... do...
                     case EventDoAction doAct:
                         foreach (var stmt in doAct.Target.Body.Statements)
                         {
-                            List<String> funCallS = WriteStmt(stmt);
-                            if (gotoStmts.ContainsKey(doAct.Trigger.Name))
-                            {
-                                funCallS.AddRange(gotoStmts[doAct.Trigger.Name]);
-                            }
-                            gotoStmts[doAct.Trigger.Name] =  funCallS;
+                            gotoStmts[doAct.Trigger.Name].UnionWith(WriteStmt(stmt));
                         }
                         break;
                     

--- a/Src/PCompiler/CompilerCore/Backend/Stately/StatelyCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Stately/StatelyCodeGenerator.cs
@@ -167,7 +167,7 @@ namespace Plang.Compiler.Backend.Stately {
                 {
                     //on... goto...
                     case EventGotoState goAct:
-                        gotoStmts[goAct.Trigger.Name].Add(goAct.Target.Name)
+                        gotoStmts[goAct.Trigger.Name].Add(goAct.Target.Name);
                         break;
                     //on... do...
                     case EventDoAction doAct:


### PR DESCRIPTION
This PR fixes the below issues:
1. The P output files were moved before replay command is run, causing a "File not found" error
2. The stately generator code was generating duplicate handlers for a state