### PR TITLE
Add logic to remove null key-value pairs in trace json

### DIFF
--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -592,6 +592,36 @@ namespace PChecker.SystematicTesting
         }
 
         /// <summary>
+        /// Returns an object where the keys with null values are removed
+        /// </summary>
+        public object RecursivelyRemoveNullValueKeys(object obj) {
+            if (obj == null) {
+                return null;
+            }
+            if (obj is Dictionary<string, object> dictionary) {
+                var newDictionary = new Dictionary<string, object>();
+                foreach (var item in dictionary) {
+                    var newVal = RecursivelyRemoveNullValueKeys(item.Value);
+                    if (newVal != null)
+                        newDictionary[item.Key] = newVal;
+                }
+                return newDictionary;
+            }
+            else if (obj is List<object> list) {
+                var newList = new List<object>();
+                foreach (var item in list) {
+                    var newItem = RecursivelyRemoveNullValueKeys(item);
+                    if (newItem != null)
+                        newList.Add(newItem);
+                }
+                return newList;
+            }
+            else {
+                return obj;
+            }
+        }
+
+        /// <summary>
         /// Tries to emit the testing traces, if any.
         /// </summary>
         public void TryEmitTraces(string directory, string file)
@@ -640,6 +670,11 @@ namespace PChecker.SystematicTesting
                 var jsonPath = directory + file + "_" + index + ".trace.json";
                 Logger.WriteLine($"..... Writing {jsonPath}");
                 
+                // Remove the null objects from payload recursively for each log event
+                for(int i=0; i<JsonLogger.Logs.Count; i++) {
+                    JsonLogger.Logs[i].Details.Payload = RecursivelyRemoveNullValueKeys(JsonLogger.Logs[i].Details.Payload);
+                }
+
                 // Stream directly to the output file while serializing the JSON
                 using var jsonStreamFile = File.Create(jsonPath);
                 JsonSerializer.Serialize(jsonStreamFile, JsonLogger.Logs, jsonSerializerConfig);

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -592,16 +592,16 @@ namespace PChecker.SystematicTesting
         }
 
         /// <summary>
-        /// Returns an object where the keys with null values are removed
+        /// Returns an object where the value null is replaced with "null"
         /// </summary>
-        public object RecursivelyRemoveNullValueKeys(object obj) {
+        public object RecursivelyReplaceNullWithString(object obj) {
             if (obj == null) {
-                return null;
+                return "null";
             }
             if (obj is Dictionary<string, object> dictionary) {
                 var newDictionary = new Dictionary<string, object>();
                 foreach (var item in dictionary) {
-                    var newVal = RecursivelyRemoveNullValueKeys(item.Value);
+                    var newVal = RecursivelyReplaceNullWithString(item.Value);
                     if (newVal != null)
                         newDictionary[item.Key] = newVal;
                 }
@@ -610,7 +610,7 @@ namespace PChecker.SystematicTesting
             else if (obj is List<object> list) {
                 var newList = new List<object>();
                 foreach (var item in list) {
-                    var newItem = RecursivelyRemoveNullValueKeys(item);
+                    var newItem = RecursivelyReplaceNullWithString(item);
                     if (newItem != null)
                         newList.Add(newItem);
                 }
@@ -672,7 +672,7 @@ namespace PChecker.SystematicTesting
                 
                 // Remove the null objects from payload recursively for each log event
                 for(int i=0; i<JsonLogger.Logs.Count; i++) {
-                    JsonLogger.Logs[i].Details.Payload = RecursivelyRemoveNullValueKeys(JsonLogger.Logs[i].Details.Payload);
+                    JsonLogger.Logs[i].Details.Payload = RecursivelyReplaceNullWithString(JsonLogger.Logs[i].Details.Payload);
                 }
 
                 // Stream directly to the output file while serializing the JSON


### PR DESCRIPTION
The Json serializer removes keys with null values in the parent attributes only. If the one of the attributes has children and if the child has a key with null value, that child key is not removed. This resulted in the trace json having null values and the visualizer failed to show the trace.

The current fix recursively traverses through the event payload and removes the keys that have null values