### PR TITLE
[CLI] Support compiling for multiple targets together

### DIFF
--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -53,9 +53,10 @@ namespace Plang.Compiler
                 IRTransformer.SimplifyMethod(fun);
             }
 
+            DirectoryInfo parentDirectory = job.OutputDirectory;
             foreach (var entry in job.OutputLanguages)
             {
-                job.OutputDirectory = Directory.CreateDirectory(Path.Combine(job.OutputDirectory.FullName, entry.Key));
+                job.OutputDirectory = Directory.CreateDirectory(Path.Combine(parentDirectory.FullName, entry.Key));
                 job.Output = new DefaultCompilerOutput(job.OutputDirectory);
                 job.Backend = TargetLanguage.GetCodeGenerator(entry.Value);
                 

--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -54,14 +54,14 @@ namespace Plang.Compiler
             }
 
             DirectoryInfo parentDirectory = job.OutputDirectory;
-            foreach (var entry in job.OutputLanguages)
+            foreach (var entry in job.OutputLanguages.Distinct())
             {
-                job.OutputDirectory = Directory.CreateDirectory(Path.Combine(parentDirectory.FullName, entry.Key));
+                job.OutputDirectory = Directory.CreateDirectory(Path.Combine(parentDirectory.FullName, entry.ToString()));
                 job.Output = new DefaultCompilerOutput(job.OutputDirectory);
-                job.Backend = TargetLanguage.GetCodeGenerator(entry.Value);
+                job.Backend = TargetLanguage.GetCodeGenerator(entry);
                 
                 job.Output.WriteInfo($"----------------------------------------");
-                job.Output.WriteInfo($"Code generation for {entry.Key}...");
+                job.Output.WriteInfo($"Code generation for {entry}...");
 
                 // Run the selected backend on the project and write the files.
                 var compiledFiles = job.Backend.GenerateCode(job, scope);
@@ -82,7 +82,7 @@ namespace Plang.Compiler
                     }
                     catch (TranslationException e)
                     {
-                        job.Output.WriteError($"[{entry.Key} Compiling Generated Code:]\n" + e.Message);
+                        job.Output.WriteError($"[{entry} Compiling Generated Code:]\n" + e.Message);
                         job.Output.WriteError("[THIS SHOULD NOT HAVE HAPPENED, please report it to the P team or create a GitHub issue]\n" + e.Message);
                         Environment.ExitCode = 2;
                         return Environment.ExitCode;

--- a/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
@@ -20,12 +20,12 @@ namespace Plang.Compiler
             ProjectRootPath = new DirectoryInfo(Directory.GetCurrentDirectory());
             LocationResolver = new DefaultLocationResolver();
             Handler = new DefaultTranslationErrorHandler(LocationResolver);
-            OutputLanguage = CompilerOutput.CSharp;
-            Backend = TargetLanguage.GetCodeGenerator(OutputLanguage);
+            OutputLanguages = new Dictionary<string, CompilerOutput>{{"CSharp", CompilerOutput.CSharp}};
+            Backend = null;
             ProjectDependencies = new List<string>();
         }
-        public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, CompilerOutput outputLanguage, IList<string> inputFiles,
-            string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null)
+        public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IDictionary<string, CompilerOutput> outputLanguages, IList<string> inputFiles,
+            string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null, string pObservePackageName = null)
         {
             if (!inputFiles.Any())
             {
@@ -48,18 +48,18 @@ namespace Plang.Compiler
                 }
             }
             ProjectName = projectName ?? Path.GetFileNameWithoutExtension(inputFiles[0]);
-            PObservePackageName = $"{ProjectName}.pobserve";
+            PObservePackageName = pObservePackageName ?? $"{ProjectName}.pobserve";
             ProjectRootPath = projectRoot;
             LocationResolver = new DefaultLocationResolver();
             Handler = new DefaultTranslationErrorHandler(LocationResolver);
-            OutputLanguage = outputLanguage;
-            Backend = TargetLanguage.GetCodeGenerator(outputLanguage);
+            OutputLanguages = outputLanguages;
+            Backend = null;
             ProjectDependencies = projectDependencies ?? new List<string>();
         }
         
         public ICompilerOutput Output { get; set; }
         public DirectoryInfo OutputDirectory { get; set; }
-        public CompilerOutput OutputLanguage { get; set; }
+        public IDictionary<string, CompilerOutput> OutputLanguages { get; set; }
         public string ProjectName { get; set; }
         public string PObservePackageName { get; set; }
         public DirectoryInfo ProjectRootPath { get; set; }
@@ -83,7 +83,7 @@ namespace Plang.Compiler
             ProjectDependencies = parsedConfig.ProjectDependencies;
             ProjectName = parsedConfig.ProjectName;
             PObservePackageName = parsedConfig.PObservePackageName;
-            OutputLanguage = parsedConfig.OutputLanguage;
+            OutputLanguages = parsedConfig.OutputLanguages;
             ProjectRootPath = parsedConfig.ProjectRootPath;
         }
     }

--- a/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
@@ -20,11 +20,11 @@ namespace Plang.Compiler
             ProjectRootPath = new DirectoryInfo(Directory.GetCurrentDirectory());
             LocationResolver = new DefaultLocationResolver();
             Handler = new DefaultTranslationErrorHandler(LocationResolver);
-            OutputLanguages = new Dictionary<string, CompilerOutput>{{"CSharp", CompilerOutput.CSharp}};
+            OutputLanguages = new List<CompilerOutput>{CompilerOutput.CSharp};
             Backend = null;
             ProjectDependencies = new List<string>();
         }
-        public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IDictionary<string, CompilerOutput> outputLanguages, IList<string> inputFiles,
+        public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IList<CompilerOutput> outputLanguages, IList<string> inputFiles,
             string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null, string pObservePackageName = null)
         {
             if (!inputFiles.Any())
@@ -59,7 +59,7 @@ namespace Plang.Compiler
         
         public ICompilerOutput Output { get; set; }
         public DirectoryInfo OutputDirectory { get; set; }
-        public IDictionary<string, CompilerOutput> OutputLanguages { get; set; }
+        public IList<CompilerOutput> OutputLanguages { get; set; }
         public string ProjectName { get; set; }
         public string PObservePackageName { get; set; }
         public DirectoryInfo ProjectRootPath { get; set; }

--- a/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
@@ -10,7 +10,7 @@ namespace Plang.Compiler
         string ProjectName { get; }
         string PObservePackageName { get; }
         DirectoryInfo ProjectRootPath { get; }
-        public IDictionary<string, CompilerOutput> OutputLanguages { get; }
+        IList<CompilerOutput> OutputLanguages { get; }
         ICompilerOutput Output { get; set; }
         DirectoryInfo OutputDirectory { get; set; }
         ICodeGenerator Backend { get; set; }

--- a/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
@@ -10,10 +10,10 @@ namespace Plang.Compiler
         string ProjectName { get; }
         string PObservePackageName { get; }
         DirectoryInfo ProjectRootPath { get; }
-        CompilerOutput OutputLanguage { get; }
-        ICompilerOutput Output { get; }
-        DirectoryInfo OutputDirectory { get; }
-        ICodeGenerator Backend { get; }
+        public IDictionary<string, CompilerOutput> OutputLanguages { get; }
+        ICompilerOutput Output { get; set; }
+        DirectoryInfo OutputDirectory { get; set; }
+        ICodeGenerator Backend { get; set; }
         IList<string> InputPFiles { get; }
         IList<string> InputForeignFiles { get; }
         IList<string> ProjectDependencies { get; }

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -158,26 +158,26 @@ namespace Plang.Options
                     compilerConfiguration.ProjectName = (string)option.Value;
                     break;
                 case "mode":
-                    compilerConfiguration.OutputLanguages = new Dictionary<string, CompilerOutput>();
+                    compilerConfiguration.OutputLanguages = new List<CompilerOutput>();
                     switch (((string)option.Value).ToLowerInvariant())
                     {
                         case "bugfinding":
                         case "csharp":
-                            compilerConfiguration.OutputLanguages["CSharp"] = CompilerOutput.CSharp;
+                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.CSharp);
                             break;
                         case "verification":
                         case "coverage":
                         case "symbolic":
                         case "psym":
                         case "pcover":
-                            compilerConfiguration.OutputLanguages["Symbolic"] = CompilerOutput.Symbolic;
+                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.Symbolic);
                             break;
                         case "pobserve":
                         case "java":
-                            compilerConfiguration.OutputLanguages["Java"] = CompilerOutput.Java;
+                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.Java);
                             break;
                         case "stately":
-                            compilerConfiguration.OutputLanguages["Stately"] = CompilerOutput.Stately;
+                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.Stately);
                             break;
                         default:
                             throw new Exception($"Unexpected mode: '{option.Value}'");

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -158,17 +158,29 @@ namespace Plang.Options
                     compilerConfiguration.ProjectName = (string)option.Value;
                     break;
                 case "mode":
+                    compilerConfiguration.OutputLanguages = new Dictionary<string, CompilerOutput>();
+                    switch (((string)option.Value).ToLowerInvariant())
                     {
-                        compilerConfiguration.OutputLanguage = (string)option.Value switch
-                        {
-                            "bugfinding" => CompilerOutput.CSharp,
-                            "verification" => CompilerOutput.Symbolic,
-                            "coverage" => CompilerOutput.Symbolic,
-                            "pobserve" => CompilerOutput.Java,
-                            "stately" => CompilerOutput.Stately,
-                            _ => compilerConfiguration.OutputLanguage
-                        };
-                        compilerConfiguration.Backend = TargetLanguage.GetCodeGenerator(compilerConfiguration.OutputLanguage);
+                        case "bugfinding":
+                        case "csharp":
+                            compilerConfiguration.OutputLanguages["CSharp"] = CompilerOutput.CSharp;
+                            break;
+                        case "verification":
+                        case "coverage":
+                        case "symbolic":
+                        case "psym":
+                        case "pcover":
+                            compilerConfiguration.OutputLanguages["Symbolic"] = CompilerOutput.Symbolic;
+                            break;
+                        case "pobserve":
+                        case "java":
+                            compilerConfiguration.OutputLanguages["Java"] = CompilerOutput.Java;
+                            break;
+                        case "stately":
+                            compilerConfiguration.OutputLanguages["Stately"] = CompilerOutput.Stately;
+                            break;
+                        default:
+                            throw new Exception($"Unexpected mode: '{option.Value}'");
                     }
                     break;
                 case "pobserve-package":
@@ -234,9 +246,6 @@ namespace Plang.Options
                 compilerConfiguration.OutputDirectory = Directory.CreateDirectory("PGenerated");
                 compilerConfiguration.Output = new DefaultCompilerOutput(compilerConfiguration.OutputDirectory);
            }
-            
-            compilerConfiguration.OutputDirectory = Directory.CreateDirectory(Path.Combine(compilerConfiguration.OutputDirectory.FullName, compilerConfiguration.OutputLanguage.ToString()));
-            compilerConfiguration.Output = new DefaultCompilerOutput(compilerConfiguration.OutputDirectory);
         }
         
 

--- a/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
+++ b/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
@@ -208,13 +208,13 @@ namespace Plang.Parser
                 return Directory.GetCurrentDirectory();
         }
 
-        private IDictionary<string, CompilerOutput> GetTargetLanguages(FileInfo fullPathName)
+        private IList<CompilerOutput> GetTargetLanguages(FileInfo fullPathName)
         {
-            var outputLanguages = new Dictionary<string, CompilerOutput>();
+            var outputLanguages = new List<CompilerOutput>();
             var projectXml = XElement.Load(fullPathName.FullName);
             if (!projectXml.Elements("Target").Any())
             {
-                outputLanguages["CSharp"] = CompilerOutput.CSharp;
+                outputLanguages.Add(CompilerOutput.CSharp);
             }
             else
             {
@@ -226,21 +226,21 @@ namespace Plang.Parser
                     {
                         case "bugfinding":
                         case "csharp":
-                            outputLanguages["CSharp"] = CompilerOutput.CSharp;
+                            outputLanguages.Add(CompilerOutput.CSharp);
                             break;
                         case "verification":
                         case "coverage":
                         case "symbolic":
                         case "psym":
                         case "pcover":
-                            outputLanguages["Symbolic"] = CompilerOutput.Symbolic;
+                            outputLanguages.Add(CompilerOutput.Symbolic);
                             break;
                         case "pobserve":
                         case "java":
-                            outputLanguages["Java"] = CompilerOutput.Java;
+                            outputLanguages.Add(CompilerOutput.Java);
                             break;
                         case "stately":
-                            outputLanguages["Stately"] = CompilerOutput.Stately;
+                            outputLanguages.Add(CompilerOutput.Stately);
                             break;
                         default:
                             throw new CommandlineParsingError(

--- a/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
+++ b/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 using PChecker;
 using PChecker.IO.Debugging;
 using Plang.Compiler;
+using Debug = System.Diagnostics.Debug;
 
 namespace Plang.Parser
 {
@@ -30,7 +31,6 @@ namespace Plang.Parser
                 CommandLineOutput.WriteInfo($"----------------------------------------");
                 CommandLineOutput.WriteInfo($"==== Loading project file: {projectFile}");
 
-                var outputLanguage = CompilerOutput.CSharp;
                 var inputFiles = new HashSet<string>();
                 var projectDependencies = new HashSet<string>();
 
@@ -50,9 +50,17 @@ namespace Plang.Parser
 
                 // get output directory
                 var outputDirectory = GetOutputDirectory(projectFilePath);
+                
+                // get targets
+                var outputLanguages = GetTargetLanguages(projectFilePath);
+
+                // get pobserve package name
+                var pObservePackageName = GetPObservePackage(projectFilePath);
 
                 job = new CompilerConfiguration(output: new DefaultCompilerOutput(outputDirectory), outputDir: outputDirectory,
-                    outputLanguage: outputLanguage, inputFiles: inputFiles.ToList(), projectName: projectName, projectRoot: projectFilePath.Directory, projectDependencies: projectDependencies.ToList());
+                    outputLanguages: outputLanguages, inputFiles: inputFiles.ToList(), projectName: projectName, 
+                    projectRoot: projectFilePath.Directory, projectDependencies: projectDependencies.ToList(),
+                    pObservePackageName: pObservePackageName);
 
                 CommandLineOutput.WriteInfo($"----------------------------------------");
             }
@@ -156,6 +164,23 @@ namespace Plang.Parser
         }
 
         /// <summary>
+        /// Parse the PObserve package name from the pproj file
+        /// </summary>
+        /// <param name="projectFullPath">Path to the pproj file</param>
+        /// <returns>pobserve package name</returns>
+        private string GetPObservePackage(FileInfo projectFullPath)
+        {
+            string pObservePackageName = null;
+            var projectXml = XElement.Load(projectFullPath.FullName);
+            if (projectXml.Elements("pobserve-package").Any())
+            {
+                pObservePackageName = projectXml.Element("pobserve-package")?.Value;
+            }
+
+            return pObservePackageName;
+        }
+
+        /// <summary>
         /// Parse the output directory information from the pproj file
         /// </summary>
         /// <param name="fullPathName"></param>
@@ -183,43 +208,48 @@ namespace Plang.Parser
                 return Directory.GetCurrentDirectory();
         }
 
-        private void GetTargetLanguage(FileInfo fullPathName, ref CompilerOutput outputLanguage, ref bool generateSourceMaps)
+        private IDictionary<string, CompilerOutput> GetTargetLanguages(FileInfo fullPathName)
         {
+            var outputLanguages = new Dictionary<string, CompilerOutput>();
             var projectXml = XElement.Load(fullPathName.FullName);
-            if (!projectXml.Elements("Target").Any()) return;
-            switch (projectXml.Element("Target")?.Value.ToLowerInvariant())
+            if (!projectXml.Elements("Target").Any())
             {
-                case "c":
-                    outputLanguage = CompilerOutput.C;
-                    // check for generate source maps attribute
-                    try
-                    {
-                        if (projectXml.Element("Target")!.Attributes("sourcemaps").Any())
-                        {
-                            generateSourceMaps = bool.Parse(projectXml.Element("Target")?.Attribute("sourcemaps")?.Value ?? string.Empty);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        throw new CommandlineParsingError($"Expected true or false, received {projectXml.Element("Target")?.Attribute("sourcemaps")?.Value}");
-                    }
-                    break;
-
-                case "csharp":
-                    outputLanguage = CompilerOutput.CSharp;
-                    break;
-
-                case "java":
-                    outputLanguage = CompilerOutput.Java;
-                    break;
-
-                case "symbolic":
-                    outputLanguage = CompilerOutput.Symbolic;
-                    break;
-
-                default:
-                    throw new CommandlineParsingError($"Expected c, csharp, java, or symbolic as target, received {projectXml.Element("Target")?.Value}");
+                outputLanguages["CSharp"] = CompilerOutput.CSharp;
             }
+            else
+            {
+                string[] values = projectXml.Element("Target")?.Value.Split(new[] { ',', ' ' }, 
+                    StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < values!.Length; i++)
+                {
+                    switch (values[i].ToLowerInvariant())
+                    {
+                        case "bugfinding":
+                        case "csharp":
+                            outputLanguages["CSharp"] = CompilerOutput.CSharp;
+                            break;
+                        case "verification":
+                        case "coverage":
+                        case "symbolic":
+                        case "psym":
+                        case "pcover":
+                            outputLanguages["Symbolic"] = CompilerOutput.Symbolic;
+                            break;
+                        case "pobserve":
+                        case "java":
+                            outputLanguages["Java"] = CompilerOutput.Java;
+                            break;
+                        case "stately":
+                            outputLanguages["Stately"] = CompilerOutput.Stately;
+                            break;
+                        default:
+                            throw new CommandlineParsingError(
+                                $"Expected CSharp, Java, Stately, or Symbolic as target, received {projectXml.Element("Target")?.Value}");
+                    }
+                }
+            }
+
+            return outputLanguages;
         }
 
         /// <summary>

--- a/Tst/UnitTests/Core/TestCaseFactory.cs
+++ b/Tst/UnitTests/Core/TestCaseFactory.cs
@@ -87,7 +87,7 @@ namespace UnitTests.Core
             ICompilerTestRunner runner;
             ITestResultsValidator validator;
 
-            var output = new Dictionary<string, CompilerOutput>{{"C", CompilerOutput.C}};
+            var output = new List<CompilerOutput>{CompilerOutput.C};
             runner = new CompileOnlyRunner(output, inputFiles.Select(x => x.FullName).ToList());
 
             // TODO: validate information about the particular kind of compiler error

--- a/Tst/UnitTests/Core/TestCaseFactory.cs
+++ b/Tst/UnitTests/Core/TestCaseFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Plang.Compiler;
@@ -86,7 +87,7 @@ namespace UnitTests.Core
             ICompilerTestRunner runner;
             ITestResultsValidator validator;
 
-            var output = CompilerOutput.C;
+            var output = new Dictionary<string, CompilerOutput>{{"C", CompilerOutput.C}};
             runner = new CompileOnlyRunner(output, inputFiles.Select(x => x.FullName).ToList());
 
             // TODO: validate information about the particular kind of compiler error

--- a/Tst/UnitTests/Runners/CompileOnlyRunner.cs
+++ b/Tst/UnitTests/Runners/CompileOnlyRunner.cs
@@ -14,18 +14,18 @@ namespace UnitTests.Runners
     /// </summary>
     public class CompileOnlyRunner : ICompilerTestRunner
     {
-        private readonly CompilerOutput compilerOutput;
+        private readonly IDictionary<string, CompilerOutput> compilerOutputs;
         private readonly IList<string> inputFiles;
 
         /// <summary>
         ///     Box a new compile runner
         /// </summary>
-        /// <param name="compilerOutput"></param>
+        /// <param name="compilerOutputs"></param>
         /// <param name="inputFiles">The P source files to compile</param>
-        public CompileOnlyRunner(CompilerOutput compilerOutput, IList<string> inputFiles)
+        public CompileOnlyRunner(IDictionary<string, CompilerOutput> compilerOutputs, IList<string> inputFiles)
         {
             this.inputFiles = inputFiles;
-            this.compilerOutput = compilerOutput;
+            this.compilerOutputs = compilerOutputs;
         }
 
         /// <inheritdoc />
@@ -45,7 +45,7 @@ namespace UnitTests.Runners
             var stderrWriter = new StringWriter();
             var outputStream = new TestCaseOutputStream(stdoutWriter, stderrWriter);
 
-            var job = new CompilerConfiguration(outputStream, scratchDirectory, compilerOutput, inputFiles, Path.GetFileNameWithoutExtension(inputFiles.First()));
+            var job = new CompilerConfiguration(outputStream, scratchDirectory, compilerOutputs, inputFiles, Path.GetFileNameWithoutExtension(inputFiles.First()));
 
             try
             {

--- a/Tst/UnitTests/Runners/CompileOnlyRunner.cs
+++ b/Tst/UnitTests/Runners/CompileOnlyRunner.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Runners
     /// </summary>
     public class CompileOnlyRunner : ICompilerTestRunner
     {
-        private readonly IDictionary<string, CompilerOutput> compilerOutputs;
+        private readonly IList<CompilerOutput> compilerOutputs;
         private readonly IList<string> inputFiles;
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace UnitTests.Runners
         /// </summary>
         /// <param name="compilerOutputs"></param>
         /// <param name="inputFiles">The P source files to compile</param>
-        public CompileOnlyRunner(IDictionary<string, CompilerOutput> compilerOutputs, IList<string> inputFiles)
+        public CompileOnlyRunner(IList<CompilerOutput> compilerOutputs, IList<string> inputFiles)
         {
             this.inputFiles = inputFiles;
             this.compilerOutputs = compilerOutputs;

--- a/Tst/UnitTests/Runners/PCheckerRunner.cs
+++ b/Tst/UnitTests/Runners/PCheckerRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Plang.Compiler;
@@ -155,7 +156,7 @@ namespace PImplementation
         {
             var compiler = new Compiler();
             var outputStream = new TestExecutionStream(scratchDirectory);
-            var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, CompilerOutput.CSharp, sources.Select(x => x.FullName).ToList(), "Main", scratchDirectory);
+            var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, new Dictionary<string, CompilerOutput>{{"CSharp", CompilerOutput.CSharp}}, sources.Select(x => x.FullName).ToList(), "Main", scratchDirectory);
             try
             {
                 return compiler.Compile(compilerConfiguration);

--- a/Tst/UnitTests/Runners/PCheckerRunner.cs
+++ b/Tst/UnitTests/Runners/PCheckerRunner.cs
@@ -50,22 +50,25 @@ namespace UnitTests.Runners
         {
             stdout = "";
             stderr = "";
+
+            // path to generated code
+            DirectoryInfo scratchDirectoryGenerated = Directory.CreateDirectory(Path.Combine(scratchDirectory.FullName, "CSharp"));
             // Do not want to use the auto-generated Test.cs file
-            CreateFileWithMainFunction(scratchDirectory);
+            CreateFileWithMainFunction(scratchDirectoryGenerated);
             // Do not want to use the auto-generated csproj file
-            CreateCSProjFile(scratchDirectory);
+            CreateCSProjFile(scratchDirectoryGenerated);
             // copy the foreign code to the folder
             foreach (var nativeFile in nativeSources)
             {
-                FileCopy(nativeFile.FullName, Path.Combine(scratchDirectory.FullName, nativeFile.Name), true);
+                FileCopy(nativeFile.FullName, Path.Combine(scratchDirectoryGenerated.FullName, nativeFile.Name), true);
             }
 
             var exitCode = DoCompile(scratchDirectory);
 
             if (exitCode == 0)
             {
-                exitCode = RunPChecker(scratchDirectory.FullName,
-                    Path.Combine(scratchDirectory.FullName, "./net6.0/Main.dll"), out var testStdout, out var testStderr);
+                exitCode = RunPChecker(scratchDirectoryGenerated.FullName,
+                    Path.Combine(scratchDirectoryGenerated.FullName, "./net6.0/Main.dll"), out var testStdout, out var testStderr);
                 stdout += testStdout;
                 stderr += testStderr;
             }

--- a/Tst/UnitTests/Runners/PCheckerRunner.cs
+++ b/Tst/UnitTests/Runners/PCheckerRunner.cs
@@ -159,7 +159,7 @@ namespace PImplementation
         {
             var compiler = new Compiler();
             var outputStream = new TestExecutionStream(scratchDirectory);
-            var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, new Dictionary<string, CompilerOutput>{{"CSharp", CompilerOutput.CSharp}}, sources.Select(x => x.FullName).ToList(), "Main", scratchDirectory);
+            var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, new List<CompilerOutput>{CompilerOutput.CSharp}, sources.Select(x => x.FullName).ToList(), "Main", scratchDirectory);
             try
             {
                 return compiler.Compile(compilerConfiguration);

--- a/Tst/UnitTests/Runners/PrtRunner.cs
+++ b/Tst/UnitTests/Runners/PrtRunner.cs
@@ -79,7 +79,7 @@ namespace UnitTests.Runners
             var compiler = new Compiler();
             var outputStream = new TestExecutionStream(scratchDirectory);
             var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, 
-                new Dictionary<string, CompilerOutput>{{"C", CompilerOutput.C}}, sources.Select(x => x.FullName).ToList(), "main");
+                new List<CompilerOutput>{CompilerOutput.C}, sources.Select(x => x.FullName).ToList(), "main");
             compiler.Compile(compilerConfiguration);
         }
 

--- a/Tst/UnitTests/Runners/PrtRunner.cs
+++ b/Tst/UnitTests/Runners/PrtRunner.cs
@@ -78,7 +78,8 @@ namespace UnitTests.Runners
         {
             var compiler = new Compiler();
             var outputStream = new TestExecutionStream(scratchDirectory);
-            var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, CompilerOutput.C, sources.Select(x => x.FullName).ToList(), "main");
+            var compilerConfiguration = new CompilerConfiguration(outputStream, scratchDirectory, 
+                new Dictionary<string, CompilerOutput>{{"C", CompilerOutput.C}}, sources.Select(x => x.FullName).ToList(), "main");
             compiler.Compile(compilerConfiguration);
         }
 


### PR DESCRIPTION
Updates include:
- Support compiling for multiple backend targets together. Simply add all your desired backend targets in the `<Target>` field in *.pproj file. E.g., `<Target>CSharp, PObserve, Stately, Symbolic</Target>`
- Support configuring PObserve package name through *.pproj using field `<pobserve-package>`