### PR TITLE
[PObserve] Correct name conflict in FFI interface

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -80,6 +80,7 @@ in the body of each function definition as necessary for your project's business
 
         public static readonly string FFIPackage = "PForeign";
         public static readonly string FFIGlobalScopeCname = "PObserveGlobal";
+        public static readonly string FFILocalScopeSuffix = "Foreign";
 
 
         // Something that is clearly not valid Java.

--- a/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/FFIStubGenerator.cs
@@ -144,7 +144,7 @@ namespace Plang.Compiler.Backend.Java
         private void WriteFFIHeader(string monitorName)
         {
             WriteLine(Constants.AsFFIComment(
-                $"Please place and complete the following class in {Constants.FFIPackage}/{monitorName}.java :"));
+                $"Please place and complete the following class in {Constants.FFIPackage}/{monitorName}{Constants.FFILocalScopeSuffix}.java :"));
         }
 
         private void WriteForeignTypeStub(ForeignType t)
@@ -275,7 +275,7 @@ namespace Plang.Compiler.Backend.Java
             // Class definition: By convention, this "para-class" has the same name as
             // the P machine it is defined within, to mimic the C#-style partial class mixin
             // functionalty that we are not afforded in Java, unfortunately.
-            WriteLine($"public class {mname} {{");
+            WriteLine($"public class {mname}{Constants.FFILocalScopeSuffix} {{");
             foreach (var f in ffs)
             {
                 WriteForeignFunctionStub(f, m);
@@ -324,7 +324,7 @@ namespace Plang.Compiler.Backend.Java
             }
 
             WriteLine(") {");
-            WriteLine(" /* throws RaiseEventException, TransitionException */ {");
+            WriteLine(" /* throws RaiseEventException, TransitionException */");
 
             if (ret is TypeManager.JType.JVoid _)
             {

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -625,7 +625,7 @@ namespace Plang.Compiler.Backend.Java {
                 var ffiBridge = Names.FFIBridgeForMachine(
                     isStatic
                     ? Constants.FFIGlobalScopeCname
-                    : _currentMachine.Name);
+                    : $"{_currentMachine.Name}{Constants.FFILocalScopeSuffix}");
                 Write($"{ffiBridge}.{fname}(");
 
                 // All foreign functions have an implicit first argument to the current machine


### PR DESCRIPTION
Corrects spec machine name conflicts when calling spec local foreign functions

Renamed to <spec machine>Foreign to implement foreign functions local to a spec machine