### PR TITLE
Add option to enable/disable debug logs in pobserve mode

### DIFF
--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -592,6 +592,36 @@ namespace PChecker.SystematicTesting
         }
 
         /// <summary>
+        /// Returns an object where the keys with null values are removed
+        /// </summary>
+        public object RecursivelyRemoveNullValueKeys(object obj) {
+            if (obj == null) {
+                return null;
+            }
+            if (obj is Dictionary<string, object> dictionary) {
+                var newDictionary = new Dictionary<string, object>();
+                foreach (var item in dictionary) {
+                    var newVal = RecursivelyRemoveNullValueKeys(item.Value);
+                    if (newVal != null)
+                        newDictionary[item.Key] = newVal;
+                }
+                return newDictionary;
+            }
+            else if (obj is List<object> list) {
+                var newList = new List<object>();
+                foreach (var item in list) {
+                    var newItem = RecursivelyRemoveNullValueKeys(item);
+                    if (newItem != null)
+                        newList.Add(newItem);
+                }
+                return newList;
+            }
+            else {
+                return obj;
+            }
+        }
+
+        /// <summary>
         /// Tries to emit the testing traces, if any.
         /// </summary>
         public void TryEmitTraces(string directory, string file)
@@ -640,6 +670,11 @@ namespace PChecker.SystematicTesting
                 var jsonPath = directory + file + "_" + index + ".trace.json";
                 Logger.WriteLine($"..... Writing {jsonPath}");
                 
+                // Remove the null objects from payload recursively for each log event
+                for(int i=0; i<JsonLogger.Logs.Count; i++) {
+                    JsonLogger.Logs[i].Details.Payload = RecursivelyRemoveNullValueKeys(JsonLogger.Logs[i].Details.Payload);
+                }
+
                 // Stream directly to the output file while serializing the JSON
                 using var jsonStreamFile = File.Create(jsonPath);
                 JsonSerializer.Serialize(jsonStreamFile, JsonLogger.Logs, jsonSerializerConfig);

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -592,16 +592,16 @@ namespace PChecker.SystematicTesting
         }
 
         /// <summary>
-        /// Returns an object where the keys with null values are removed
+        /// Returns an object where the value null is replaced with "null"
         /// </summary>
-        public object RecursivelyRemoveNullValueKeys(object obj) {
+        public object RecursivelyReplaceNullWithString(object obj) {
             if (obj == null) {
-                return null;
+                return "null";
             }
             if (obj is Dictionary<string, object> dictionary) {
                 var newDictionary = new Dictionary<string, object>();
                 foreach (var item in dictionary) {
-                    var newVal = RecursivelyRemoveNullValueKeys(item.Value);
+                    var newVal = RecursivelyReplaceNullWithString(item.Value);
                     if (newVal != null)
                         newDictionary[item.Key] = newVal;
                 }
@@ -610,7 +610,7 @@ namespace PChecker.SystematicTesting
             else if (obj is List<object> list) {
                 var newList = new List<object>();
                 foreach (var item in list) {
-                    var newItem = RecursivelyRemoveNullValueKeys(item);
+                    var newItem = RecursivelyReplaceNullWithString(item);
                     if (newItem != null)
                         newList.Add(newItem);
                 }
@@ -672,7 +672,7 @@ namespace PChecker.SystematicTesting
                 
                 // Remove the null objects from payload recursively for each log event
                 for(int i=0; i<JsonLogger.Logs.Count; i++) {
-                    JsonLogger.Logs[i].Details.Payload = RecursivelyRemoveNullValueKeys(JsonLogger.Logs[i].Details.Payload);
+                    JsonLogger.Logs[i].Details.Payload = RecursivelyReplaceNullWithString(JsonLogger.Logs[i].Details.Payload);
                 }
 
                 // Stream directly to the output file while serializing the JSON

--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -27,7 +27,8 @@ namespace Plang.Compiler.Backend.Java
         private static readonly string[] JreDefaultImports =
         {
             "java.io.Serializable",
-            "java.util.*"
+            "java.util.*",
+            "java.util.logging.*"
         };
 
         /// <summary>

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -16,9 +16,11 @@ namespace Plang.Compiler.Backend.Java {
 
         private Machine _currentMachine; // Some generated code is machine-dependent, so stash the current machine here.
         private HashSet<Function> _calledStaticFunctions = new HashSet<Function>(); // static functions allowed 
+        private bool debug = false;
 
         internal MachineGenerator(ICompilerConfiguration job, string filename) : base(job, filename)
         {
+            debug = job.Debug;
         }
 
         /// <summary>
@@ -34,6 +36,12 @@ namespace Plang.Compiler.Backend.Java {
         protected override void GenerateCodeImpl()
         {
             WriteLine($"public class {Constants.MachineNamespaceName} {{");
+            WriteLine($"private static Logger logger = Logger.getLogger({Constants.MachineNamespaceName}.class.getName());");
+            if (debug) {
+                WriteLine($"static {{ logger.setLevel(Level.ALL); }};");
+            } else {
+                WriteLine($"static {{ logger.setLevel(Level.OFF); }};");
+            }
 
             foreach (var m in GlobalScope.Machines)
             {
@@ -462,7 +470,7 @@ namespace Plang.Compiler.Backend.Java {
                     break;
 
                 case PrintStmt printStmt:
-                    Write("System.out.println(");
+                    Write("logger.info(");
                     WriteExpr(printStmt.Message);
                     WriteLine(");");
                     break;

--- a/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
@@ -23,9 +23,10 @@ namespace Plang.Compiler
             OutputLanguages = new List<CompilerOutput>{CompilerOutput.CSharp};
             Backend = null;
             ProjectDependencies = new List<string>();
+            Debug = false;
         }
         public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IList<CompilerOutput> outputLanguages, IList<string> inputFiles,
-            string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null, string pObservePackageName = null)
+            string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null, string pObservePackageName = null, bool debug = false)
         {
             if (!inputFiles.Any())
             {
@@ -55,6 +56,7 @@ namespace Plang.Compiler
             OutputLanguages = outputLanguages;
             Backend = null;
             ProjectDependencies = projectDependencies ?? new List<string>();
+            Debug = debug;
         }
         
         public ICompilerOutput Output { get; set; }
@@ -70,6 +72,7 @@ namespace Plang.Compiler
         public ITranslationErrorHandler Handler { get; set; }
 
         public IList<string> ProjectDependencies { get; set;  }
+        public bool Debug { get; set; }
 
         public void Copy(CompilerConfiguration parsedConfig)
         {
@@ -85,6 +88,7 @@ namespace Plang.Compiler
             PObservePackageName = parsedConfig.PObservePackageName;
             OutputLanguages = parsedConfig.OutputLanguages;
             ProjectRootPath = parsedConfig.ProjectRootPath;
+            Debug = parsedConfig.Debug;
         }
     }
 }

--- a/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
@@ -19,5 +19,6 @@ namespace Plang.Compiler
         IList<string> ProjectDependencies { get; }
         ILocationResolver LocationResolver { get; }
         ITranslationErrorHandler Handler { get; }
+        bool Debug { get; }
     }
 }

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -44,6 +44,9 @@ namespace Plang.Options
             modes.IsHidden = true;
 
             Parser.AddArgument("pobserve-package", "po", "PObserve package name").IsHidden = true;
+
+            var debug = Parser.AddArgument("debug", "d", "Enable or Disable debug logs in pobserve mode (Disabled by default)");
+            debug.AllowedValues = new List<string>() { "true", "false" };
         }
 
         /// <summary>
@@ -156,6 +159,9 @@ namespace Plang.Options
                     break;
                 case "projname":
                     compilerConfiguration.ProjectName = (string)option.Value;
+                    break;
+                case "debug":
+                    compilerConfiguration.Debug = bool.Parse((string)option.Value);
                     break;
                 case "mode":
                     compilerConfiguration.OutputLanguages = new List<CompilerOutput>();

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -45,8 +45,7 @@ namespace Plang.Options
 
             Parser.AddArgument("pobserve-package", "po", "PObserve package name").IsHidden = true;
 
-            var debug = Parser.AddArgument("debug", "d", "Enable or Disable debug logs in pobserve mode (Disabled by default)");
-            debug.AllowedValues = new List<string>() { "true", "false" };
+            Parser.AddArgument("debug", "d", "Enable debug logs", typeof(bool)).IsHidden = true;
         }
 
         /// <summary>
@@ -161,7 +160,7 @@ namespace Plang.Options
                     compilerConfiguration.ProjectName = (string)option.Value;
                     break;
                 case "debug":
-                    compilerConfiguration.Debug = bool.Parse((string)option.Value);
+                    compilerConfiguration.Debug = true;
                     break;
                 case "mode":
                     compilerConfiguration.OutputLanguages = new List<CompilerOutput>();


### PR DESCRIPTION
This PR includes the following changes:
1. Converts P spec print statement to java logger statements instead of System.out when run in pobserve mode
2. Provides an option to enable or disable these log statements through command line option (--debug)

Usage: p compile --mode pobserve --debug (true|false)

