### PR TITLE
Remove invalid '>' from while condition `(i < sizeof(sq)>)` in `P Expressions` doc

### DIFF
--- a/Docs/docs/manual/expressions.md
+++ b/Docs/docs/manual/expressions.md
@@ -194,7 +194,7 @@ P supports four other operations on collection types:
 
 ``` java
 var sq: seq[int];
-while (i < sizeof(sq)>) {
+while (i < sizeof(sq)) {
     ...
     i = i + 1;
 }


### PR DESCRIPTION
Found a typo in https://p-org.github.io/P/manual/expressions/#sizeof.

```
while (i < sizeof(sq)>) {
```

This PR fixes it.