### PR TITLE
Fix typo in the document for `P Statements`

### DIFF
--- a/Docs/docs/manual/statements.md
+++ b/Docs/docs/manual/statements.md
@@ -322,7 +322,7 @@ Insert statement is used to insert or add an element into a collection.
 
     !!! warning "Index for a sequence"
         The value of index `i` above should be between `0 <= i <= sizeof(sq)`. 
-        `i = 0` insserts x at the start of `sq` and `i = sizeof(sq)` appends x at the end of `sq`
+        `i = 0` inserts x at the start of `sq` and `i = sizeof(sq)` appends x at the end of `sq`
 
 === "Insert into a map or update map"
 


### PR DESCRIPTION
This PR fixes a typo in https://p-org.github.io/P/manual/statements/#insert.