### PR TITLE
[Tutorial] Fix #642, updates 2PC, adds a new regression test

### DIFF
--- a/Tst/RegressionTests/Integration/Correct/PingPongNonDet/PingPongNonDet.p
+++ b/Tst/RegressionTests/Integration/Correct/PingPongNonDet/PingPongNonDet.p
@@ -1,0 +1,61 @@
+event Ping: machine;
+event Pong;
+event Success;
+
+machine Main {
+    var pongId: machine;
+
+    start state Ping_Init {
+        entry {
+      	    pongId = new PONG();
+    	    raise Success;   	   
+        }
+        on Success goto Ping_SendPing;
+    }
+
+    state Ping_SendPing {
+        entry {
+    	    send pongId, Ping, this;
+    	    raise Success;
+	    }
+        on Success goto Ping_WaitPong;
+     }
+
+     state Ping_WaitPong {
+        on Pong do {
+            jumpToDoneNonDeterministic();
+            if ($) {
+                goto Ping_SendPing;
+            }
+        }
+     }
+
+     fun jumpToDoneNonDeterministic() {
+        if ($) {
+            jumpToDone();
+        }
+     }
+
+     fun jumpToDone() {
+        goto Done;
+     }
+
+    state Done {
+        ignore Pong;
+    }
+}
+
+machine PONG {
+    start state Pong_WaitPing {
+        entry { }
+        on Ping goto Pong_SendPong;
+    }
+
+    state Pong_SendPong {
+        entry (payload: machine) {
+             send payload, Pong;
+             raise Success;
+        }
+        on Success goto Pong_WaitPing;
+    }
+}

--- a/Tutorial/2_TwoPhaseCommit/PForeign/GlobalFunctions.java
+++ b/Tutorial/2_TwoPhaseCommit/PForeign/GlobalFunctions.java
@@ -1,0 +1,25 @@
+package psym.model;
+
+import psym.runtime.values.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+public class GlobalFunctions {
+    public static PNamedTuple ChooseRandomTransaction(PInt uniqueId) {
+        List<String> fields = new ArrayList<>();
+        fields.add("key");
+        fields.add("val");
+        fields.add("transId");
+
+        Map<String, PValue<?>> values = new HashMap<>();
+        Random rand = new Random();
+        values.put("key", new PString(String.format("%d", rand.nextInt(10))));
+        values.put("val", new PInt(rand.nextInt(10)));
+        values.put("transId", new PInt(uniqueId));
+
+        return new PNamedTuple(fields, values);
+    }
+}

--- a/Tutorial/Common/Timer/PSrc/Timer.p
+++ b/Tutorial/Common/Timer/PSrc/Timer.p
@@ -1,39 +1,6 @@
 /*****************************************************************************************
 The timer state machine models the non-deterministic behavior of an OS timer
 ******************************************************************************************/
-machine Timer
-{
-    // user of the timer
-  var client: machine;
-  start state Init {
-    entry (_client : machine){
-      client = _client;
-      goto WaitForTimerRequests;
-    }
-  }
-
-  state WaitForTimerRequests {
-    on eStartTimer goto TimerStarted;
-    ignore eCancelTimer, eDelayedTimeOut;
-  }
-
-  state TimerStarted {
-    defer eStartTimer;
-    entry {
-      if($)
-      {
-        send client, eTimeOut;
-        goto WaitForTimerRequests;
-      }
-      else
-      {
-        send this, eDelayedTimeOut;
-      }
-    }
-    on eDelayedTimeOut goto TimerStarted;
-    on eCancelTimer goto WaitForTimerRequests;
-  }
-}
 
 /************************************************
 Events used to interact with the timer machine
@@ -42,23 +9,69 @@ event eStartTimer;
 event eCancelTimer;
 event eTimeOut;
 event eDelayedTimeOut;
+
+machine Timer {
+  // user/client of the timer
+  var client: machine;
+
+  start state Init {
+    entry (_client : machine) {
+      client = _client;
+      goto WaitForTimerRequests;
+    }
+  }
+
+  state WaitForTimerRequests {
+    on eStartTimer goto TimerStarted;
+
+    ignore eCancelTimer, eDelayedTimeOut;
+  }
+
+  state TimerStarted {
+    entry {
+      if($) {
+        send client, eTimeOut;
+        goto WaitForTimerRequests;
+      } else {
+        send this, eDelayedTimeOut;
+      }
+    }
+
+    on eDelayedTimeOut goto TimerDelayed;
+    on eCancelTimer goto WaitForTimerRequests;
+    defer eStartTimer;    
+  }
+
+  state TimerDelayed {
+    entry {
+      if($) {
+        send client, eTimeOut;
+        goto WaitForTimerRequests;
+      } else {
+        // do nothing, wait for eCancelTimer and ignore any old eDelayedTimeOut
+      }
+    }
+
+    on eCancelTimer goto WaitForTimerRequests;    
+    defer eStartTimer;
+    ignore eDelayedTimeOut;
+  }
+}
+
 /************************************************
 Functions or API's to interact with the OS Timer
 *************************************************/
 // create timer
-fun CreateTimer(client: machine) : Timer
-{
+fun CreateTimer(client: machine) : Timer {
   return new Timer(client);
 }
 
 // start timer
-fun StartTimer(timer: Timer)
-{
+fun StartTimer(timer: Timer) {
   send timer, eStartTimer;
 }
 
 // cancel timer
-fun CancelTimer(timer: Timer)
-{
+fun CancelTimer(timer: Timer) {
   send timer, eCancelTimer;
 }


### PR DESCRIPTION
[Tutorial]
- Corrects infinite looping in Timer by allowing delayed timeout at most once. Fixes #642 
- 2PC: adds Java-equivalent of foreign function for PSym

[Tst]
- Adds a new regression test with non-deterministic jump in ping-pong example

[Testing]
- Confirmed fix for #642 by running PCover on 2PC example
````
p compile -md coverage
p check -md coverage --fail-on-maxsteps -s 10000 -tc tcSingleClientNoFailure
````
Before the fix, a cycle is detected. After the fix, no cycle is detected.
