### PR TITLE
[PExplicit] Support stateless DFS with all P lang features

### DIFF
--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -1,7 +1,6 @@
 name: CI on MacOS
 
-on: #[push, pull_request]
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
   Build-And-Test-MacOS:

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -1,6 +1,7 @@
 name: CI on MacOS
 
 on: #[push, pull_request]
+  workflow_dispatch:
 
 jobs:
   Build-And-Test-MacOS:

--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -1,6 +1,6 @@
 name: CI on MacOS
 
-on: [push, pull_request]
+on: #[push, pull_request]
 
 jobs:
   Build-And-Test-MacOS:

--- a/.github/workflows/pcover.yml
+++ b/.github/workflows/pcover.yml
@@ -4,8 +4,8 @@
 name: PCover on Ubuntu
 
 on:
-  push:
-  pull_request:
+#  push:
+#  pull_request:
   workflow_dispatch:
     inputs:
       args:

--- a/.github/workflows/pexplicit.yml
+++ b/.github/workflows/pexplicit.yml
@@ -1,0 +1,32 @@
+# This workflow will build and test PExplicit, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: PExplicit on Ubuntu
+
+on: [push, pull_request]
+
+jobs:
+  PExplicit-Build-And-Test-Ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.0.x
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build PExplicit
+        working-directory: Src/PRuntimes/PExplicitRuntime
+        run: ./scripts/build.sh
+      - name: Test PExplicit
+        working-directory: Src/PRuntimes/PExplicitRuntime
+        run: mvn test

--- a/.github/workflows/pexplicit.yml
+++ b/.github/workflows/pexplicit.yml
@@ -3,8 +3,15 @@
 
 name: PExplicit on Ubuntu
 
-on: [push, pull_request]
-
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      args:
+        description: Additional arguments
+        default: ""
+        required: false
 jobs:
   PExplicit-Build-And-Test-Ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/psym.yml
+++ b/.github/workflows/psym.yml
@@ -4,8 +4,8 @@
 name: PSym on Ubuntu
 
 on:
-  push:
-  pull_request:
+#  push:
+#  pull_request:
   workflow_dispatch:
     inputs:
       args:

--- a/.github/workflows/psymb.yml
+++ b/.github/workflows/psymb.yml
@@ -4,8 +4,8 @@
 name: PSymB on Ubuntu
 
 on:
-  push:
-  pull_request:
+#  push:
+#  pull_request:
   workflow_dispatch:
     inputs:
       args:

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -3,8 +3,7 @@
 
 name: Tutorials
 
-on: #[push, pull_request]
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
   Build-MacOS:

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -3,7 +3,7 @@
 
 name: Tutorials
 
-on: [push, pull_request]
+on: #[push, pull_request]
 
 jobs:
   Build-MacOS:

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -4,6 +4,7 @@
 name: Tutorials
 
 on: #[push, pull_request]
+  workflow_dispatch:
 
 jobs:
   Build-MacOS:

--- a/.github/workflows/ubuntuci.yml
+++ b/.github/workflows/ubuntuci.yml
@@ -1,6 +1,7 @@
 name: CI on Ubuntu
 
 on: #[push, pull_request]
+  workflow_dispatch:
 
 jobs:
   Build-And-Test-Ubuntu:

--- a/.github/workflows/ubuntuci.yml
+++ b/.github/workflows/ubuntuci.yml
@@ -1,6 +1,6 @@
 name: CI on Ubuntu
 
-on: [push, pull_request]
+on: #[push, pull_request]
 
 jobs:
   Build-And-Test-Ubuntu:

--- a/.github/workflows/ubuntuci.yml
+++ b/.github/workflows/ubuntuci.yml
@@ -1,7 +1,6 @@
 name: CI on Ubuntu
 
-on: #[push, pull_request]
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
   Build-And-Test-Ubuntu:

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -1,7 +1,6 @@
 name: CI on Windows
 
-on: #[push, pull_request]
-  workflow_dispatch:
+on: [push, pull_request]
 
 jobs:
   Build-And-Test-Windows:

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -1,6 +1,7 @@
 name: CI on Windows
 
 on: #[push, pull_request]
+  workflow_dispatch:
 
 jobs:
   Build-And-Test-Windows:

--- a/.github/workflows/windowsci.yml
+++ b/.github/workflows/windowsci.yml
@@ -1,6 +1,6 @@
 name: CI on Windows
 
-on: [push, pull_request]
+on: #[push, pull_request]
 
 jobs:
   Build-And-Test-Windows:

--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,7 @@ Bld/*
 !Bld/Jars/
 !Bld/Deps/
 PGenerated/
+PCheckerOutput/
 !Src/**/Zing/*.zing
 stubs.c
 *.idb

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/CompilationContext.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/CompilationContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using Plang.Compiler.Backend.PExplicit;
 using Plang.Compiler.TypeChecker.AST;
 using Plang.Compiler.TypeChecker.AST.Declarations;
 using Plang.Compiler.TypeChecker.AST.States;
@@ -11,8 +10,6 @@ namespace Plang.Compiler.Backend.PExplicit
 {
     internal class CompilationContext : CompilationContextBase
     {
-        int nextLoopId;
-        int nextBranchId;
         int nextTempVarId;
         IDictionary<Continuation, int> continuationNames;
 
@@ -35,7 +32,7 @@ namespace Plang.Compiler.Backend.PExplicit
             if (!IsSafeJavaIdentifier(job.ProjectName))
                 throw new TranslationException(
                     $"Invalid project name '{ProjectName}'.  " +
-                    "When generating code for the 'Symbolic' target, the project name should " +
+                    "When generating code for the 'PExplicit' target, the project name should " +
                     "begin with an alphabetic character and contain only alphanumeric characters");
 
             MainClassName = ProjectName+"PModel";
@@ -98,35 +95,11 @@ namespace Plang.Compiler.Backend.PExplicit
             return $"var_{rawName}";
         }
 
-        internal LoopScope FreshLoopScope()
-        {
-            return new LoopScope(nextLoopId++);
-        }
-
-        internal BranchScope FreshBranchScope()
-        {
-            return new BranchScope(nextBranchId++);
-        }
-
         internal string FreshTempVar()
         {
             var id = nextTempVarId;
             nextTempVarId++;
             return $"temp_var_{id}";
-        }
-
-        internal void WriteCommaSeparated<T>(TextWriter output, IEnumerable<T> items, Action<T> writeItem)
-        {
-            var needComma = false;
-            foreach (var item in items)
-            {
-                if (needComma)
-                {
-                    Write(output, ", ");
-                }
-                writeItem(item);
-                needComma = true;
-            }
         }
         
         private static bool IsAsciiAlphabetic(char c)
@@ -163,30 +136,6 @@ namespace Plang.Compiler.Backend.PExplicit
 
             return true;
         }
-    }
-
-    internal struct LoopScope
-    {
-        internal readonly int id;
-
-        internal LoopScope(int id)
-        {
-            this.id = id;
-        }
-
-        internal string LoopEarlyReturnFlag => $"loop_early_ret_{id}";
-    }
-
-    internal struct BranchScope
-    {
-        internal readonly int id;
-
-        internal BranchScope(int id)
-        {
-            this.id = id;
-        }
-
-        internal string JumpedOutFlag => $"jumpedOut_{id}";
     }
 
 }

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -747,7 +747,7 @@ namespace Plang.Compiler.Backend.PExplicit
                             } else
                             {
                                 var inlineCastPrefix = GetInlineCastPrefix(assignStmt.Value.Type, assignStmt.Location.Type);
-                                context.Write(output, $"{locationTemp} = {inlineCastPrefix}");
+                                context.Write(output, $"{locationTemp} = ({GetPExplicitType(assignStmt.Location.Type)}) {inlineCastPrefix}");
                                 WriteExpr(context, output, expr);
                                 if (inlineCastPrefix != "") context.Write(output, ")");
                                 context.WriteLine(output, ";");
@@ -768,7 +768,7 @@ namespace Plang.Compiler.Backend.PExplicit
                         locationTemp =>
                         {
                             var inlineCastPrefix = GetInlineCastPrefix(moveStmt.FromVariable.Type, moveStmt.ToLocation.Type);
-                            context.Write(output, $"{locationTemp} = {inlineCastPrefix}");
+                            context.Write(output, $"{locationTemp} = ({GetPExplicitType(moveStmt.ToLocation.Type)}) {inlineCastPrefix}");
                             WriteExpr(context, output, new VariableAccessExpr(moveStmt.FromVariable.SourceLocation, moveStmt.FromVariable));
                             if (inlineCastPrefix != "") context.Write(output, ")");
                             context.WriteLine(output, ";");
@@ -790,7 +790,7 @@ namespace Plang.Compiler.Backend.PExplicit
                     {
                         context.Write(output, $"{CompilationContext.ReturnValue} = ");
                         var inlineCastPrefix = GetInlineCastPrefix(returnStmt.ReturnValue.Type, context.ReturnType);
-                        context.Write(output, $"{inlineCastPrefix}");
+                        context.Write(output, $"({GetPExplicitType(context.ReturnType)}) {inlineCastPrefix}");
                         WriteExpr(context, output, returnStmt.ReturnValue);
                         if (inlineCastPrefix != "") context.Write(output, ")");
                         context.WriteLine(output, $";");
@@ -1215,7 +1215,7 @@ namespace Plang.Compiler.Backend.PExplicit
         private string GetInlineCastPrefix(PLanguageType valueType, PLanguageType locationType) {
             if (valueType.Equals(locationType))
             {
-                return $"(({GetPExplicitType(locationType)}) ";
+                return "";
             }
             
             var valueIsMachineRef = valueType.IsSameTypeAs(PrimitiveType.Machine) || valueType is PermissionType;

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -851,6 +851,10 @@ namespace Plang.Compiler.Backend.PExplicit
                     context.WriteLine(output, "break;");
                     break;
 
+                case ContinueStmt _:
+                    context.WriteLine(output, "continue;");
+                    break;
+
                 case CompoundStmt compoundStmt:
                     foreach (var subStmt in compoundStmt.Statements)
                     {
@@ -1106,9 +1110,13 @@ namespace Plang.Compiler.Backend.PExplicit
                         context.WriteLine(output, $"{GetPExplicitType(local.Type)} {CompilationContext.GetVar(local.Name)} = {GetDefaultValue(local.Type)};");
                     }
                 }
-                allCasesExited &= WriteStmt(continuation, context, output, caseContext, caseFun.Body);
+                bool caseExited = WriteStmt(continuation, context, output, caseContext, caseFun.Body);
+                allCasesExited &= caseExited;
                 context.WriteLine(output, "}");
-                context.WriteLine(output, "break;");
+                if (!caseExited)
+                {
+                    context.WriteLine(output, "break;");
+                }
             }
             context.WriteLine(output, "default:");
             context.WriteLine(output, "{");

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -604,7 +604,7 @@ namespace Plang.Compiler.Backend.PExplicit
             {
                 if (i > 0)
                     context.WriteLine(output, ",");
-                string foreignType = GetForeignBoxedType(param.Type);
+                string foreignType = GetType(param.Type);
                 if (foreignType == "Object") {
                     context.Write(output, $"args.get({i})");
                 } else {
@@ -2019,7 +2019,7 @@ namespace Plang.Compiler.Backend.PExplicit
             }
         }
 
-        private string GetForeignBoxedType(PLanguageType type)
+        private string GetType(PLanguageType type)
         {
             switch (type.Canonicalize())
             {
@@ -2048,8 +2048,12 @@ namespace Plang.Compiler.Backend.PExplicit
                     return "PTuple";
                 case EnumType _:
                     return "PEnum";
+                case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Null):
+                    return "void";
+                case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Any):
+                    return "PValue<?>";
                 default:
-                    return "Object";
+                    throw new NotImplementedException($"PExplicit type '{type.OriginalRepresentation}' not supported");
             }
         }
 

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -672,7 +672,7 @@ namespace Plang.Compiler.Backend.PExplicit
 
             if (!function.Signature.ReturnType.IsSameTypeAs(PrimitiveType.Null))
             {
-                context.WriteLine(output, $"{GetPExplicitType(function.Signature.ReturnType)} {CompilationContext.ReturnValue} = new {GetPExplicitType(function.Signature.ReturnType)}({GetDefaultValue(function.Signature.ReturnType)});");
+                context.WriteLine(output, $"{GetPExplicitType(function.Signature.ReturnType)} {CompilationContext.ReturnValue} = {GetDefaultValue(function.Signature.ReturnType)};");
             }
 
             bool exited = false;

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -2078,7 +2078,7 @@ namespace Plang.Compiler.Backend.PExplicit
                 case BinOpType.Div:
                     return "div";
                 case BinOpType.Mod:
-                    return "mode";
+                    return "mod";
                 case BinOpType.Lt:
                     return "lt";
                 case BinOpType.Le:

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/TransformASTPass.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/TransformASTPass.cs
@@ -143,17 +143,9 @@ namespace Plang.Compiler.Backend.PExplicit
             {
                 if (handler.Key.IsNullEvent)
                 {
-                    throw new NotImplementedException($"Null actions are not supported, found in state {transformedState.Name} of machine {transformedState.OwningMachine.Name}");
+                    throw new NotImplementedException($"Null events are not supported, found in state {transformedState.Name} of machine {transformedState.OwningMachine.Name}");
                 }
                 transformedState[handler.Key] = TransformAction(handler.Value, functionMap);
-            }
-
-            if (transformedState.Exit != null)
-            {
-                if (transformedState.Exit.CanReceive == true)
-                {
-                    throw new NotImplementedException($"Receive in state exit functions are not supported, found in state {transformedState.Name} of machine {transformedState.OwningMachine.Name}");
-                }
             }
 
             return transformedState;
@@ -606,6 +598,10 @@ namespace Plang.Compiler.Backend.PExplicit
                                 var canReceiveInCase = false;
                                 foreach (var c in recv.Cases)
                                 {
+                                    if (c.Key.IsNullEvent)
+                                    {
+                                        throw new NotImplementedException($"Null events are not supported, found in a receive statement of machine {machine.Name}");
+                                    }
                                     if (c.Value.CanReceive == true)
                                     {
                                         canReceiveInCase = true;

--- a/Src/PRuntimes/PExplicitRuntime/pom.xml
+++ b/Src/PRuntimes/PExplicitRuntime/pom.xml
@@ -147,11 +147,9 @@
                 <configuration>
                     <systemPropertyVariables>
                         <propertyName>java.library.path</propertyName>
-                        <mode/>
                         <timeout/>
                         <schedules/>
                         <max.steps/>
-                        <pexplicit.args/>
                     </systemPropertyVariables>
                     <systemProperties>
                         <property>

--- a/Src/PRuntimes/PExplicitRuntime/pom.xml
+++ b/Src/PRuntimes/PExplicitRuntime/pom.xml
@@ -135,8 +135,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <source>16</source>
+                    <target>16</target>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 </configuration>
             </plugin>

--- a/Src/PRuntimes/PExplicitRuntime/pom.xml
+++ b/Src/PRuntimes/PExplicitRuntime/pom.xml
@@ -135,8 +135,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 </configuration>
             </plugin>
@@ -278,8 +276,9 @@
     </distributionManagement>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <log4j2.configurationFile>${project.basedir}/src/main/resources/log4j2.xml</log4j2.configurationFile>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <revision>0.0.1</revision>

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
@@ -2,15 +2,13 @@ package pexplicit;
 
 import org.reflections.Reflections;
 import pexplicit.commandline.PExplicitOptions;
+import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.PModel;
 import pexplicit.runtime.logger.Log4JConfig;
 import pexplicit.runtime.logger.PExplicitLogger;
-
-import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.machine.PTestDriver;
 import pexplicit.utils.exceptions.BugFoundException;
-import pexplicit.utils.exceptions.NotImplementedException;
 import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.utils.monitor.TimeMonitor;
 import pexplicit.utils.random.RandomNumberGenerator;
@@ -104,6 +102,7 @@ public class PExplicit {
 
     /**
      * Sanitize the model name by removing trailing "PModel" keyword
+     *
      * @param name Name of the PModel class
      * @return Class name without trailing "PModel"
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -83,7 +83,9 @@ public class RuntimeExecutor {
     }
 
     private static void postprocess(boolean printStats) {
-        scheduler.updateResult();
+        if (!PExplicitGlobal.getStatus().equals("cex")) {
+            scheduler.updateResult();
+        }
 
         Instant end = Instant.now();
         if (printStats) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -3,7 +3,6 @@ package pexplicit;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.StatWriter;
-import pexplicit.runtime.scheduler.Scheduler;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.MemoutException;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -120,6 +120,7 @@ public class RuntimeExecutor {
             if (PExplicitGlobal.getConfig().getVerbosity() > 0) {
                 PExplicitLogger.printStackTrace(e, false);
             }
+            throw e;
         } catch (InterruptedException e) {
             PExplicitGlobal.setStatus("interrupted");
             throw new Exception("INTERRUPTED", e);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -17,25 +17,35 @@ public class PExplicitConfig {
     @Setter
     String testDriver = testDriverDefault;
     // name of the project
-    @Setter String projectName = "default";
+    @Setter
+    String projectName = "default";
     // name of the output folder
-    @Setter String outputFolder = "output";
+    @Setter
+    String outputFolder = "output";
     // time limit in seconds (0 means infinite)
-    @Setter double timeLimit = 0;
+    @Setter
+    double timeLimit = 0;
     // memory limit in megabytes (0 means infinite)
-    @Setter double memLimit = (Runtime.getRuntime().maxMemory() / 2.0 / 1024.0 / 1024.0);
+    @Setter
+    double memLimit = (Runtime.getRuntime().maxMemory() / 2.0 / 1024.0 / 1024.0);
     // level of verbosity for the logging
-    @Setter int verbosity = 0;
+    @Setter
+    int verbosity = 0;
     // strategy of exploration
-    @Setter String strategy = "dfs";
+    @Setter
+    String strategy = "dfs";
     // max number of schedules bound provided by the user
-    @Setter int maxSchedules = 1;
+    @Setter
+    int maxSchedules = 1;
     // max steps/depth bound provided by the user
-    @Setter int maxStepBound = 10000;
+    @Setter
+    int maxStepBound = 10000;
     // fail on reaching the maximum scheduling step bound
-    @Setter boolean failOnMaxStepBound = false;
+    @Setter
+    boolean failOnMaxStepBound = false;
     // random seed
-    @Setter long randomSeed = System.currentTimeMillis();
+    @Setter
+    long randomSeed = System.currentTimeMillis();
     // buffer semantics
     @Setter
     BufferSemantics bufferSemantics = BufferSemantics.SenderQueue;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -1,9 +1,10 @@
 package pexplicit.commandline;
 
-import static java.lang.System.exit;
-
-import java.io.*;
 import org.apache.commons.cli.*;
+
+import java.io.PrintWriter;
+
+import static java.lang.System.exit;
 
 /**
  * Represents the CLI options for PExplicit runtime

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -38,7 +38,7 @@ public class PExplicitGlobal {
      **/
     @Getter
     @Setter
-    private static String status = "incomplete";
+    private static STATUS status = STATUS.INCOMPLETE;
 
     /**
      * Result of the run

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -4,12 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import pexplicit.commandline.PExplicitConfig;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.machine.PMonitor;
-import pexplicit.runtime.machine.events.StateEvents;
 import pexplicit.runtime.scheduler.Scheduler;
-import pexplicit.values.PEvent;
 
-import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -84,7 +80,7 @@ public class PExplicitGlobal {
     /**
      * Add a machine.
      *
-     * @param machine  Machine to add
+     * @param machine      Machine to add
      * @param machineCount Machine type count
      */
     public static void addGlobalMachine(PMachine machine, int machineCount) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -51,13 +51,13 @@ public class PExplicitGlobal {
      * Mapping from machine type to list of all machine instances
      */
     @Getter
-    private static Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>();
+    private static final Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>();
 
     /**
      * Set of machines
      */
     @Getter
-    private static SortedSet<PMachine> machineSet = new TreeSet<>();
+    private static final SortedSet<PMachine> machineSet = new TreeSet<>();
 
     /**
      * Get a machine of a given type and index if exists, else return null.

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/STATUS.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/STATUS.java
@@ -1,0 +1,12 @@
+package pexplicit.runtime;
+
+public enum STATUS {
+    INCOMPLETE,         // search still ongoing
+    SCHEDULEOUT,        // schedule limit reached
+    TIMEOUT,            // timeout reached
+    MEMOUT,             // memout reached
+    VERIFIED,           // full state space explored and no bug found
+    BUG_FOUND,          // found a bug
+    INTERRUPTED,        // interrupted by user
+    ERROR               // unexpected error encountered
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -234,16 +234,24 @@ public class PExplicitLogger {
     }
 
     /**
-     * Log when a machine transitions to a new state
+     * Log when a machine enters a new state
      *
-     * @param machine  Machine that is processing the state transition
-     * @param newState New state
+     * @param machine  Machine that is entering the state
      */
-    public static void logStateTransition(PMachine machine, State newState) {
+    public static void logStateEntry(PMachine machine) {
         if (verbosity > 3) {
-            String msg =
-                    String.format("Machine %s transitioning to state %s", machine, newState);
-            log.info(msg);
+            log.info(String.format("Machine %s entering state %s", machine, machine.getCurrentState()));
+        }
+    }
+
+    /**
+     * Log when a machine exits the current state
+     *
+     * @param machine  Machine that is exiting the state
+     */
+    public static void logStateExit(PMachine machine) {
+        if (verbosity > 3) {
+            log.info(String.format("Machine %s exiting state %s", machine, machine.getCurrentState()));
         }
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -14,6 +14,7 @@ import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.values.PEvent;
+import pexplicit.values.PValue;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -243,6 +244,30 @@ public class PExplicitLogger {
             String msg =
                     String.format("Machine %s transitioning to state %s", machine, newState);
             log.info(msg);
+        }
+    }
+
+    public static void logRepeatScheduleChoice(PMachine choice, int step, int idx) {
+        if (verbosity > 1) {
+            log.info(String.format("  @%d::%d %s (repeat)", step, idx, choice));
+        }
+    }
+
+    public static void logCurrentScheduleChoice(PMachine choice, int step, int idx) {
+        if (verbosity > 1) {
+            log.info(String.format("  @%d::%d %s", step, idx, choice));
+        }
+    }
+
+    public static void logRepeatDataChoice(PValue<?> choice, int step, int idx) {
+        if (verbosity > 1) {
+            log.info(String.format("  @%d::%d %s (repeat)", step, idx, choice));
+        }
+    }
+
+    public static void logCurrentDataChoice(PValue<?> choice, int step, int idx) {
+        if (verbosity > 1) {
+            log.info(String.format("  @%d::%d %s", step, idx, choice));
         }
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -8,12 +8,9 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.utils.monitor.MemoryMonitor;
-import pexplicit.values.PEvent;
 import pexplicit.values.PValue;
 
 import java.io.PrintWriter;
@@ -130,6 +127,7 @@ public class PExplicitLogger {
 
     /**
      * Log at the start of an iteration
+     *
      * @param iter Iteration number
      * @param step Starting step number
      */
@@ -153,6 +151,7 @@ public class PExplicitLogger {
 
     /**
      * Log at the end of an iteration
+     *
      * @param step Step number
      */
     public static void logFinishedIteration(int step) {
@@ -165,9 +164,9 @@ public class PExplicitLogger {
      * Logs message at the end of a run.
      *
      * @param totalIter Total number of completed iterations
-     * @param newIter Number of newly complexted iterations
+     * @param newIter   Number of newly complexted iterations
      * @param timeSpent Time spent in seconds
-     * @param result Result of the run
+     * @param result    Result of the run
      */
     public static void logEndOfRun(int totalIter, int newIter, long timeSpent, String result) {
         log.info("--------------------");
@@ -236,7 +235,7 @@ public class PExplicitLogger {
     /**
      * Log when a machine enters a new state
      *
-     * @param machine  Machine that is entering the state
+     * @param machine Machine that is entering the state
      */
     public static void logStateEntry(PMachine machine) {
         if (verbosity > 3) {
@@ -247,7 +246,7 @@ public class PExplicitLogger {
     /**
      * Log when a machine exits the current state
      *
-     * @param machine  Machine that is exiting the state
+     * @param machine Machine that is exiting the state
      */
     public static void logStateExit(PMachine machine) {
         if (verbosity > 3) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/ScratchLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/ScratchLogger.java
@@ -1,9 +1,5 @@
 package pexplicit.runtime.logger;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Date;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,43 +9,51 @@ import org.apache.logging.log4j.core.appender.OutputStreamAppender;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import pexplicit.runtime.PExplicitGlobal;
 
-/** Represents the scratch logger */
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * Represents the scratch logger
+ */
 public class ScratchLogger {
-  static Logger log = null;
-  static LoggerContext context = null;
+    static Logger log = null;
+    static LoggerContext context = null;
 
-  @Setter static int verbosity;
+    @Setter
+    static int verbosity;
 
-  public static void Initialize() {
-    verbosity = PExplicitGlobal.getConfig().getVerbosity();
-    log = Log4JConfig.getContext().getLogger(ScratchLogger.class.getName());
-    org.apache.logging.log4j.core.Logger coreLogger =
-        (org.apache.logging.log4j.core.Logger) LogManager.getLogger(ScratchLogger.class.getName());
-    context = coreLogger.getContext();
+    public static void Initialize() {
+        verbosity = PExplicitGlobal.getConfig().getVerbosity();
+        log = Log4JConfig.getContext().getLogger(ScratchLogger.class.getName());
+        org.apache.logging.log4j.core.Logger coreLogger =
+                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(ScratchLogger.class.getName());
+        context = coreLogger.getContext();
 
-    try {
-      // get new file name
-      Date date = new Date();
-      String fileName = PExplicitGlobal.getConfig().getOutputFolder() + "/scratch" + ".log";
-      File file = new File(fileName);
-      file.getParentFile().mkdirs();
-      file.createNewFile();
+        try {
+            // get new file name
+            Date date = new Date();
+            String fileName = PExplicitGlobal.getConfig().getOutputFolder() + "/scratch" + ".log";
+            File file = new File(fileName);
+            file.getParentFile().mkdirs();
+            file.createNewFile();
 
-      // Define new file printer
-      FileOutputStream fout = new FileOutputStream(fileName, false);
+            // Define new file printer
+            FileOutputStream fout = new FileOutputStream(fileName, false);
 
-      PatternLayout layout = Log4JConfig.getPatternLayout();
-      Appender fileAppender =
-          OutputStreamAppender.createAppender(layout, null, fout, fileName, false, true);
-      fileAppender.start();
+            PatternLayout layout = Log4JConfig.getPatternLayout();
+            Appender fileAppender =
+                    OutputStreamAppender.createAppender(layout, null, fout, fileName, false, true);
+            fileAppender.start();
 
-      context.getConfiguration().addLoggerAppender(coreLogger, fileAppender);
-    } catch (IOException e) {
-      System.out.println("Failed to set printer to the ScratchLogger!!");
+            context.getConfiguration().addLoggerAppender(coreLogger, fileAppender);
+        } catch (IOException e) {
+            System.out.println("Failed to set printer to the ScratchLogger!!");
+        }
     }
-  }
 
-  public static void log(String str) {
-    log.info(str);
-  }
+    public static void log(String str) {
+        log.info(str);
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/TraceLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/TraceLogger.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.core.appender.OutputStreamAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PMessage;
 
 import java.io.File;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -186,6 +186,25 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
     }
 
     /**
+     * Raise an event
+
+     * @param event Event to raise
+     * @param payload Payload
+     */
+    public void raiseEvent(PEvent event, PValue<?> payload) {
+        processEventToCompletion(new PMessage(event, this, payload));
+    }
+
+    /**
+     * Raise an event
+
+     * @param event Event to raise
+     */
+    public void raiseEvent(PEvent event) {
+        processEventToCompletion(new PMessage(event, this, null));
+    }
+
+    /**
      * Goto a state
      *
      * @param state State to go to

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -317,7 +317,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
             return;
         }
 
-        PMessage msg = new PMessage(event, this, null);
+        PMessage msg = new PMessage(event, this, payload);
 
         // do nothing if event is ignored in current state
         if (currentState.isIgnored(msg.getEvent())) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -8,6 +8,7 @@ import pexplicit.runtime.machine.buffer.SenderQueue;
 import pexplicit.runtime.machine.eventhandlers.EventHandler;
 import pexplicit.runtime.machine.events.PContinuation;
 import pexplicit.runtime.machine.events.PMessage;
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.NotImplementedException;
 import pexplicit.utils.misc.Assert;
 import pexplicit.utils.serialize.SerializableBiFunction;
@@ -188,6 +189,10 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
      * @param payload Payload corresponding to the event
      */
     public void sendEvent(PMachineValue target, PEvent event, PValue<?> payload) {
+        if (PValue.isEqual(target, null)) {
+            throw new BugFoundException("Machine in send event cannot be null.");
+        }
+
         PMessage msg = new PMessage(event, target.getValue(), payload);
         sendBuffer.add(msg);
         PExplicitGlobal.getScheduler().runMonitors(msg);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -19,7 +19,6 @@ import pexplicit.values.PValue;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.ArrayList;
 import java.util.function.Function;
 
 /**
@@ -114,6 +113,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
     /**
      * Check if this machine can run.
+     *
      * @return true if machine has started and is not halted, else false
      */
     public boolean canRun() {
@@ -154,7 +154,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
      * Create a new machine instance
      *
      * @param machineType Machine type
-     * @param payload payload associated with machine's constructor
+     * @param payload     payload associated with machine's constructor
      * @param constructor Machine constructor
      * @return New machine as a PMachineValue
      */
@@ -184,8 +184,8 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
     /**
      * Send an event to a target machine
      *
-     * @param target Target machine
-     * @param event PEvent to send
+     * @param target  Target machine
+     * @param event   PEvent to send
      * @param payload Payload corresponding to the event
      */
     public void sendEvent(PMachineValue target, PEvent event, PValue<?> payload) {
@@ -201,7 +201,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
     /**
      * Goto a state
      *
-     * @param state State to go to
+     * @param state   State to go to
      * @param payload Payload for entry function of the state
      */
     public void gotoState(State state, PValue<?> payload) {
@@ -210,20 +210,22 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
     /**
      * Register a continuation
-     * @param name Name of the continuation
+     *
+     * @param name      Name of the continuation
      * @param handleFun Function executed when unblocking
-     * @param clearFun Function that clears corresponding continuation variables
+     * @param clearFun  Function that clears corresponding continuation variables
      */
     protected void registerContinuation(
             String name,
             SerializableBiFunction<PMachine, PMessage> handleFun,
             SerializableRunnable clearFun,
-            String ... caseEvents) {
+            String... caseEvents) {
         continuationMap.put(name, new PContinuation(handleFun, clearFun, caseEvents));
     }
 
     /**
      * TODO
+     *
      * @param continuationName
      */
     public void blockUntil(String continuationName) {
@@ -285,13 +287,14 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
         List<PMessage> deferredMessages = new ArrayList<>(deferQueue.getElements());
         deferQueue.clear();
-        for (PMessage msg: deferredMessages) {
+        for (PMessage msg : deferredMessages) {
             processEvent(msg);
         }
     }
 
     /**
      * Process an event at the current state.
+     *
      * @param message Message to process
      */
     void processEvent(PMessage message) {
@@ -305,6 +308,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
     /**
      * Run an event at the current state.
+     *
      * @param message Message to process
      */
     void runEvent(PMessage message) {
@@ -322,7 +326,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
             } else {
                 Assert.fromModel(false,
                         String.format("Unexpected event %s received in a receive for machine %s in state %s",
-                        event, this, this.currentState));
+                                event, this, this.currentState));
             }
 
             // post process
@@ -334,8 +338,8 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
     /**
      * Raise an event
-
-     * @param event Event to raise
+     *
+     * @param event   Event to raise
      * @param payload Payload
      */
     public void raiseEvent(PEvent event, PValue<?> payload) {
@@ -359,7 +363,7 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
     /**
      * Raise an event
-
+     *
      * @param event Event to raise
      */
     public void raiseEvent(PEvent event) {
@@ -368,8 +372,9 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
     /**
      * Process state transition to a new state
+     *
      * @param newState New state to transition to
-     * @param payload Entry function payload for the new state
+     * @param payload  Entry function payload for the new state
      */
     public void processStateTransition(State newState, PValue<?> payload) {
         if (isBlocked()) {
@@ -412,8 +417,8 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
             return;
         }
 
-        blockedEntryState= null;
-        blockedEntryPayload= null;
+        blockedEntryState = null;
+        blockedEntryPayload = null;
 
         // change current state to new state
         currentState = newState;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/State.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/State.java
@@ -116,11 +116,8 @@ public abstract class State implements Serializable {
             // execute the event handler
             handler.handleEvent(machine, msg.getPayload());
             done = true;
-        }
-
-        // check if halt event
-        if (msg.getEvent().isHaltMachineEvent()) {
-            // execute the event handler
+        } else if (msg.getEvent().isHaltMachineEvent()) {
+            // halt the machine
             machine.halt();
             done = true;
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/State.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/State.java
@@ -103,7 +103,7 @@ public abstract class State implements Serializable {
     /**
      * Handle an event by executing the corresponding event handler.
      *
-     * @param msg PMessage to handle
+     * @param msg     PMessage to handle
      * @param machine PMachine to handle the event at
      */
     public void handleEvent(PMessage msg, PMachine machine) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/DeferQueue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/DeferQueue.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
  */
 public class DeferQueue extends MessageQueue implements Serializable {
 
-  public DeferQueue(PMachine owner) {
-    super(owner);
-  }
+    public DeferQueue(PMachine owner) {
+        super(owner);
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
@@ -49,6 +49,7 @@ public abstract class MessageQueue implements Serializable {
 
     /**
      * Check whether the peek is valid
+     *
      * @return true if peek is valid, else false
      */
     private boolean isPeekValid() {
@@ -63,6 +64,7 @@ public abstract class MessageQueue implements Serializable {
     /**
      * Get the peek message corresponding to the peek index
      * Assumes peek index is already valid
+     *
      * @return peek message corresponding to the peek index
      */
     private PMessage getPeekMsg() {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/eventhandlers/GotoEventHandler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/eventhandlers/GotoEventHandler.java
@@ -23,6 +23,9 @@ public class GotoEventHandler extends EventHandler {
         this.gotoState = dest;
     }
 
+    public void transitionFunction(PMachine target, PValue<?> payload) {
+    }
+
     /**
      * Handle the goto event at the target machine.
      *
@@ -31,6 +34,7 @@ public class GotoEventHandler extends EventHandler {
      */
     @Override
     public void handleEvent(PMachine target, PValue<?> payload) {
+        transitionFunction(target, payload);
         target.processStateTransition(gotoState, payload);
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/eventhandlers/GotoEventHandler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/eventhandlers/GotoEventHandler.java
@@ -2,7 +2,6 @@ package pexplicit.runtime.machine.eventhandlers;
 
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.State;
-import pexplicit.utils.exceptions.NotImplementedException;
 import pexplicit.values.PEvent;
 import pexplicit.values.PValue;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PContinuation.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PContinuation.java
@@ -12,11 +12,11 @@ import java.util.Set;
 
 @Getter
 public class PContinuation {
-    private Set<String> caseEvents;
-    private SerializableBiFunction<PMachine, PMessage> handleFun;
-    private SerializableRunnable clearFun;
+    private final Set<String> caseEvents;
+    private final SerializableBiFunction<PMachine, PMessage> handleFun;
+    private final SerializableRunnable clearFun;
 
-    public PContinuation(SerializableBiFunction<PMachine, PMessage> handleFun, SerializableRunnable clearFun, String ... ev) {
+    public PContinuation(SerializableBiFunction<PMachine, PMessage> handleFun, SerializableRunnable clearFun, String... ev) {
         this.handleFun = handleFun;
         this.clearFun = clearFun;
         this.caseEvents = new HashSet<>(Set.of(ev));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PMessage.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PMessage.java
@@ -30,6 +30,10 @@ public class PMessage extends PValue<PMessage> {
         this.payload = payload;
     }
 
+    public PMessage setTarget(PMachine target) {
+        return new PMessage(event, target, payload);
+    }
+
     @Override
     public PMessage clone() {
         return new PMessage(this.event, this.target, this.payload);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PMessage.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PMessage.java
@@ -2,10 +2,8 @@ package pexplicit.runtime.machine.events;
 
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.utils.exceptions.NotImplementedException;
 import pexplicit.values.ComputeHash;
 import pexplicit.values.PEvent;
-import pexplicit.values.PTuple;
 import pexplicit.values.PValue;
 
 /**
@@ -48,22 +46,17 @@ public class PMessage extends PValue<PMessage> {
     public boolean equals(Object obj) {
         if (obj == this) return true;
 
-        if (!(obj instanceof PMessage)) {
+        if (!(obj instanceof PMessage other)) {
             return false;
         }
 
-        PMessage other = (PMessage) obj;
         if (this.target != other.target) {
             return false;
         }
         if (this.event != other.event) {
             return false;
         }
-        if (this.payload != other.payload) {
-            return false;
-        }
-
-        return true;
+        return this.payload == other.payload;
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -16,13 +16,13 @@ public class Schedule implements Serializable {
      * Mapping from machine type to list of machine instances
      */
     @Getter
-    private Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>();
+    private final Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>();
 
     /**
      * Set of machines
      */
     @Getter
-    private SortedSet<PMachine> machineSet = new TreeSet<>();
+    private final SortedSet<PMachine> machineSet = new TreeSet<>();
 
     /**
      * List of choices

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -2,8 +2,6 @@ package pexplicit.runtime.scheduler;
 
 import lombok.Getter;
 import lombok.Setter;
-import pexplicit.runtime.PExplicitGlobal;
-import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.values.PValue;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -2,6 +2,8 @@ package pexplicit.runtime.scheduler;
 
 import lombok.Getter;
 import lombok.Setter;
+import pexplicit.runtime.PExplicitGlobal;
+import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.values.PValue;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
@@ -8,7 +8,8 @@ import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.utils.exceptions.NotImplementedException;
 import pexplicit.values.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
@@ -31,19 +32,21 @@ public abstract class Scheduler implements SchedulerInterface {
     /**
      * Run the scheduler.
      *
-     * @throws TimeoutException Throws timeout exception if timeout is reached
+     * @throws TimeoutException     Throws timeout exception if timeout is reached
      * @throws InterruptedException Throws interrupt exception if interrupted
      */
     public abstract void run() throws TimeoutException, InterruptedException;
 
     /**
      * Run an iteration.
+     *
      * @throws TimeoutException Throws timeout exception if timeout is reached.
      */
     protected abstract void runIteration() throws TimeoutException;
 
     /**
      * Run a step in the current iteration.
+     *
      * @throws TimeoutException Throws timeout exception if timeout is reached.
      */
     protected abstract void runStep() throws TimeoutException;
@@ -55,12 +58,14 @@ public abstract class Scheduler implements SchedulerInterface {
 
     /**
      * Get the next schedule choice.
+     *
      * @return PMachine as schedule choice
      */
     protected abstract PMachine getNextScheduleChoice();
 
     /**
      * Get the next data choice.
+     *
      * @return PValue as data choice
      */
     protected abstract PValue<?> getNextDataChoice(List<PValue<?>> input_choices);
@@ -143,7 +148,7 @@ public abstract class Scheduler implements SchedulerInterface {
         assert (schedule.getStepNumber() == 0);
 
         // start monitors first
-        for (PMonitor monitor: PExplicitGlobal.getModel().getMonitors()) {
+        for (PMonitor monitor : PExplicitGlobal.getModel().getMonitors()) {
             startMachine(monitor);
         }
 
@@ -173,6 +178,7 @@ public abstract class Scheduler implements SchedulerInterface {
 
     /**
      * Allocate a machine
+     *
      * @param machineType
      * @param constructor
      * @return

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
@@ -85,7 +85,11 @@ public abstract class Scheduler implements SchedulerInterface {
      */
     public PInt getRandomInt(PInt bound) {
         List<PValue<?>> choices = new ArrayList<>();
-        for (int i = 0; i < bound.getValue(); i++) {
+        int boundInt = bound.getValue();
+        if (boundInt == 0) {
+            boundInt = 1;
+        }
+        for (int i = 0; i < boundInt; i++) {
             choices.add(new PInt(i));
         }
         return (PInt) getNextDataChoice(choices);
@@ -128,7 +132,7 @@ public abstract class Scheduler implements SchedulerInterface {
      * @return data choice
      */
     public PValue<?> getRandomEntry(PMap map) {
-        return getRandomEntry(map.getKeys().toList());
+        return getRandomEntry(map.toList());
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
@@ -203,7 +203,7 @@ public abstract class Scheduler implements SchedulerInterface {
         List<PMonitor> listenersForEvent = PExplicitGlobal.getModel().getListeners().get(message.getEvent());
         if (listenersForEvent != null) {
             for (PMonitor m : listenersForEvent) {
-                m.processEventToCompletion(message);
+                m.processEventToCompletion(message.setTarget(m));
             }
         }
     }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -146,6 +146,9 @@ public class ExplicitSearchScheduler extends Scheduler {
 
     // process message
     msg.getTarget().processEventToCompletion(msg);
+
+    // update done stepping flag
+    isDoneStepping = (schedule.getStepNumber() >= PExplicitGlobal.getConfig().getMaxStepBound());
   }
 
   /**
@@ -170,6 +173,8 @@ public class ExplicitSearchScheduler extends Scheduler {
     if (schedule.getChoiceNumber() < backtrackChoiceNumber) {
       // pick the current schedule choice
       result = schedule.getCurrentScheduleChoice(schedule.getChoiceNumber());
+      PExplicitLogger.logRepeatScheduleChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
+
       schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
       return result;
     }
@@ -190,6 +195,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     // pick the first choice
     result = choices.get(0);
     schedule.setCurrentScheduleChoice(result, schedule.getChoiceNumber());
+    PExplicitLogger.logCurrentScheduleChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
 
     // remove the first choice from unexplored choices
     choices.remove(0);
@@ -215,6 +221,8 @@ public class ExplicitSearchScheduler extends Scheduler {
       // pick the current data choice
       result = schedule.getCurrentDataChoice(schedule.getChoiceNumber());
       assert (input_choices.contains(result));
+      PExplicitLogger.logRepeatDataChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
+
       schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
       return result;
     }
@@ -236,6 +244,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     // pick the first choice
     result = choices.get(0);
     schedule.setCurrentDataChoice(result, schedule.getChoiceNumber());
+    PExplicitLogger.logCurrentDataChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
 
     // remove the first choice from unexplored choices
     choices.remove(0);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -1,11 +1,5 @@
 package pexplicit.runtime.scheduler.explicit;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -22,396 +16,406 @@ import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.utils.monitor.TimeMonitor;
 import pexplicit.values.PValue;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 /**
  * Represents the scheduler for performing explicit-state model checking
  */
 public class ExplicitSearchScheduler extends Scheduler {
-  /**
-   * Current iteration
-   */
-  @Getter
-  private int iteration = 0;
+    /**
+     * Current iteration
+     */
+    @Getter
+    private int iteration = 0;
 
-  /**
-   * Max step number explored
-   */
-  @Getter
-  private int maxStepNumber = 0;
+    /**
+     * Max step number explored
+     */
+    @Getter
+    private int maxStepNumber = 0;
 
-  /**
-   * Backtrack choice number
-   */
-  @Getter
-  private int backtrackChoiceNumber = 0;
+    /**
+     * Backtrack choice number
+     */
+    @Getter
+    private int backtrackChoiceNumber = 0;
 
-  /**
-   * Whether done with all iterations
-   */
-  private boolean isDoneIterating = false;
+    /**
+     * Whether done with all iterations
+     */
+    private boolean isDoneIterating = false;
 
-  /**
-   * Whether done with current iteration
-   */
-  private boolean isDoneStepping = false;
+    /**
+     * Whether done with current iteration
+     */
+    private boolean isDoneStepping = false;
 
-  /**
-   * Time of last status report
-   */
-  @Getter
-  @Setter
-  private transient Instant lastReportTime = Instant.now();
+    /**
+     * Time of last status report
+     */
+    @Getter
+    @Setter
+    private transient Instant lastReportTime = Instant.now();
 
-  /**
-   * Constructor.
-   */
-  public ExplicitSearchScheduler() {
-    super();
-  }
-
-  /**
-   * Run the scheduler to perform explicit-state search.
-   *
-   * @throws TimeoutException Throws timeout exception if timeout is reached
-   */
-  @Override
-  public void run() throws TimeoutException {
-    PExplicitGlobal.setResult("incomplete");
-    start();
-
-    if (PExplicitGlobal.getConfig().getVerbosity() == 0) {
-      printProgressHeader(true);
-    }
-    isDoneIterating = false;
-    while (!isDoneIterating) {
-      iteration++;
-      PExplicitLogger.logStartIteration(iteration, schedule.getStepNumber());
-      runIteration();
-      postProcessIteration();
-    }
-  }
-
-  /**
-   * Run an iteration.
-   * @throws TimeoutException Throws timeout exception if timeout is reached.
-   */
-  @Override
-  protected void runIteration() throws TimeoutException {
-    isDoneStepping = false;
-    while (!isDoneStepping) {
-      printProgress(false);
-      runStep();
-    }
-    printProgress(false);
-    if (schedule.getStepNumber() > maxStepNumber) {
-      maxStepNumber = schedule.getStepNumber();
-    }
-    Assert.fromModel(
-            !PExplicitGlobal.getConfig().isFailOnMaxStepBound() || (schedule.getStepNumber() < PExplicitGlobal.getConfig().getMaxStepBound()),
-            "Step bound of " + PExplicitGlobal.getConfig().getMaxStepBound() + " reached.");
-    if (PExplicitGlobal.getConfig().getMaxSchedules() > 0) {
-      isDoneIterating = (iteration >= PExplicitGlobal.getConfig().getMaxSchedules());
-    }
-  }
-
-  /**
-   * Run a step in the current iteration.
-   * @throws TimeoutException Throws timeout exception if timeout is reached.
-   */
-  @Override
-  protected void runStep() throws TimeoutException {
-    // check for timeout/memout
-    TimeMonitor.checkTimeout();
-    MemoryMonitor.checkMemout();
-
-    // get a scheduling choice as sender machine
-    PMachine sender = getNextScheduleChoice();
-
-    if (sender == null) {
-      // no scheduling choice remains, done with this schedule
-      isDoneStepping = true;
-      PExplicitLogger.logFinishedIteration(schedule.getStepNumber());
-      return;
+    /**
+     * Constructor.
+     */
+    public ExplicitSearchScheduler() {
+        super();
     }
 
-    // pop message from sender queue
-    PMessage msg = sender.getSendBuffer().remove();
-
-    if (!msg.getEvent().isCreateMachineEvent()) {
-      // update step number
-      schedule.setStepNumber(schedule.getStepNumber()+1);
-    }
-
-    // log start step
-    PExplicitLogger.logStartStep(schedule.getStepNumber(), sender, msg);
-
-    // process message
-    msg.getTarget().processEventToCompletion(msg);
-
-    // update done stepping flag
-    isDoneStepping = (schedule.getStepNumber() >= PExplicitGlobal.getConfig().getMaxStepBound());
-  }
-
-  /**
-   * Reset the scheduler.
-   */
-  @Override
-  protected void reset() {
-    schedule.setStepNumber(0);
-    schedule.setChoiceNumber(0);
-    schedule.getMachineListByType().clear();
-    schedule.getMachineSet().clear();
-  }
-
-  /**
-   * Get the next schedule choice.
-   * @return Machine as scheduling choice.
-   */
-  @Override
-  public PMachine getNextScheduleChoice() {
-    PMachine result;
-
-    if (schedule.getChoiceNumber() < backtrackChoiceNumber) {
-      // pick the current schedule choice
-      result = schedule.getCurrentScheduleChoice(schedule.getChoiceNumber());
-      PExplicitLogger.logRepeatScheduleChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
-
-      schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
-      return result;
-    }
-
-    // get existing unexplored choices, if any
-    List<PMachine> choices = schedule.getUnexploredScheduleChoices(schedule.getChoiceNumber());
-
-    if (choices.isEmpty()) {
-      // no existing unexplored choices, so try generating new choices
-      choices = getNewScheduleChoices();
-      if (choices.isEmpty()) {
-        // no unexplored choices remaining
-        schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
-        return null;
-      }
-    }
-
-    // pick the first choice
-    result = choices.get(0);
-    schedule.setCurrentScheduleChoice(result, schedule.getChoiceNumber());
-    PExplicitLogger.logCurrentScheduleChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
-
-    // remove the first choice from unexplored choices
-    choices.remove(0);
-
-    // set unexplored choices
-    schedule.setUnexploredScheduleChoices(choices, schedule.getChoiceNumber());
-
-    // increment choice number
-    schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
-
-    return result;
-  }
-
-  /**
-   * Get the next data choice.
-   * @return PValue as data choice
-   */
-  @Override
-  public PValue<?> getNextDataChoice(List<PValue<?>> input_choices) {
-    PValue<?> result;
-
-    if (schedule.getChoiceNumber() < backtrackChoiceNumber) {
-      // pick the current data choice
-      result = schedule.getCurrentDataChoice(schedule.getChoiceNumber());
-      assert (input_choices.contains(result));
-      PExplicitLogger.logRepeatDataChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
-
-      schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
-      return result;
-    }
-
-    // get existing unexplored choices, if any
-    List<PValue<?>> choices = schedule.getUnexploredDataChoices(schedule.getChoiceNumber());
-    assert (input_choices.containsAll(choices));
-
-    if (choices.isEmpty()) {
-      // no existing unexplored choices, so try generating new choices
-      choices = input_choices;
-      if (choices.isEmpty()) {
-        // no unexplored choices remaining
-        schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
-        return null;
-      }
-    }
-
-    // pick the first choice
-    result = choices.get(0);
-    schedule.setCurrentDataChoice(result, schedule.getChoiceNumber());
-    PExplicitLogger.logCurrentDataChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
-
-    // remove the first choice from unexplored choices
-    choices.remove(0);
-
-    // set unexplored choices
-    schedule.setUnexploredDataChoices(choices, schedule.getChoiceNumber());
-
-    // increment choice number
-    schedule.setChoiceNumber(schedule.getChoiceNumber()+1);
-
-    return result;
-  }
-
-  private void postProcessIteration() {
-    if (!isDoneIterating) {
-      postIterationCleanup();
-    }
-  }
-
-  private void postIterationCleanup() {
-    for (int cIdx = schedule.size() - 1; cIdx >= 0; cIdx--) {
-      Choice choice = schedule.getChoice(cIdx);
-      schedule.clearCurrent(cIdx);
-      if (choice.isUnexploredNonEmpty()) {
-        PExplicitLogger.logBacktrack(cIdx);
-        backtrackChoiceNumber = cIdx;
-        for (PMachine machine : schedule.getMachineSet()) {
-          machine.reset();
-        }
-        reset();
+    /**
+     * Run the scheduler to perform explicit-state search.
+     *
+     * @throws TimeoutException Throws timeout exception if timeout is reached
+     */
+    @Override
+    public void run() throws TimeoutException {
+        PExplicitGlobal.setResult("incomplete");
         start();
-        return;
-      } else {
-        schedule.clearChoice(cIdx);
-      }
-    }
-    isDoneIterating = true;
-  }
 
-  private List<PMachine> getNewScheduleChoices() {
-    // prioritize create machine events
-    for (PMachine machine : schedule.getMachineSet()) {
-      if (machine.getSendBuffer().nextIsCreateMachineMsg()) {
-        return new ArrayList<>(Collections.singletonList(machine));
-      }
+        if (PExplicitGlobal.getConfig().getVerbosity() == 0) {
+            printProgressHeader(true);
+        }
+        isDoneIterating = false;
+        while (!isDoneIterating) {
+            iteration++;
+            PExplicitLogger.logStartIteration(iteration, schedule.getStepNumber());
+            runIteration();
+            postProcessIteration();
+        }
     }
 
-    // now there are no create machine events remaining
-    List<PMachine> choices = new ArrayList<>();
-
-    for (PMachine machine : schedule.getMachineSet()) {
-      if (machine.getSendBuffer().nextHasTargetRunning()) {
-        choices.add(machine);
-      }
+    /**
+     * Run an iteration.
+     *
+     * @throws TimeoutException Throws timeout exception if timeout is reached.
+     */
+    @Override
+    protected void runIteration() throws TimeoutException {
+        isDoneStepping = false;
+        while (!isDoneStepping) {
+            printProgress(false);
+            runStep();
+        }
+        printProgress(false);
+        if (schedule.getStepNumber() > maxStepNumber) {
+            maxStepNumber = schedule.getStepNumber();
+        }
+        Assert.fromModel(
+                !PExplicitGlobal.getConfig().isFailOnMaxStepBound() || (schedule.getStepNumber() < PExplicitGlobal.getConfig().getMaxStepBound()),
+                "Step bound of " + PExplicitGlobal.getConfig().getMaxStepBound() + " reached.");
+        if (PExplicitGlobal.getConfig().getMaxSchedules() > 0) {
+            isDoneIterating = (iteration >= PExplicitGlobal.getConfig().getMaxSchedules());
+        }
     }
 
-    return choices;
-  }
+    /**
+     * Run a step in the current iteration.
+     *
+     * @throws TimeoutException Throws timeout exception if timeout is reached.
+     */
+    @Override
+    protected void runStep() throws TimeoutException {
+        // check for timeout/memout
+        TimeMonitor.checkTimeout();
+        MemoryMonitor.checkMemout();
 
-  public void updateResult() {
-    String result = "";
-    int maxStepBound = PExplicitGlobal.getConfig().getMaxStepBound();
-    int numUnexplored = schedule.getNumUnexploredChoices();
-    if (maxStepNumber < maxStepBound) {
-      if (numUnexplored == 0) {
-        result += "correct for any depth";
-      } else {
-        result += String.format("partially correct with %d choices remaining", numUnexplored);
-      }
-    } else {
-      if (numUnexplored == 0) {
-        result += String.format("correct up to step %d", maxStepNumber);
-      } else {
-        result += String.format("partially correct up to step %d with %d choices remaining", maxStepNumber, numUnexplored);
-      }
+        // get a scheduling choice as sender machine
+        PMachine sender = getNextScheduleChoice();
+
+        if (sender == null) {
+            // no scheduling choice remains, done with this schedule
+            isDoneStepping = true;
+            PExplicitLogger.logFinishedIteration(schedule.getStepNumber());
+            return;
+        }
+
+        // pop message from sender queue
+        PMessage msg = sender.getSendBuffer().remove();
+
+        if (!msg.getEvent().isCreateMachineEvent()) {
+            // update step number
+            schedule.setStepNumber(schedule.getStepNumber() + 1);
+        }
+
+        // log start step
+        PExplicitLogger.logStartStep(schedule.getStepNumber(), sender, msg);
+
+        // process message
+        msg.getTarget().processEventToCompletion(msg);
+
+        // update done stepping flag
+        isDoneStepping = (schedule.getStepNumber() >= PExplicitGlobal.getConfig().getMaxStepBound());
     }
-    PExplicitGlobal.setResult(result);
-  }
 
-  public void recordStats() {
-    double timeUsed = (Duration.between(TimeMonitor.getStart(), Instant.now()).toMillis() / 1000.0);
-    double memoryUsed = MemoryMonitor.getMemSpent();
-
-    printProgress(true);
-    PExplicitLogger.log("\n--------------------");
-
-    // print basic statistics
-    StatWriter.log("time-seconds", String.format("%.1f", timeUsed));
-    StatWriter.log("memory-max-MB", String.format("%.1f", MemoryMonitor.getMaxMemSpent()));
-    StatWriter.log("memory-current-MB", String.format("%.1f", memoryUsed));
-    StatWriter.log("#-schedules", String.format("%d", iteration));
-    StatWriter.log("max-steps", String.format("%d", maxStepNumber));
-    PExplicitLogger.log( String.format("Max Schedule Length       %d", maxStepNumber));
-    StatWriter.log("#-choices-unexplored", String.format("%d", schedule.getNumUnexploredChoices()));
-    StatWriter.log("%-choices-unexplored-data", String.format("%.1f", schedule.getUnexploredDataChoicesPercent()));
-  }
-
-  private void printCurrentStatus(double newRuntime) {
-    StringBuilder s = new StringBuilder(100);
-
-    s.append("--------------------");
-    s.append(String.format("\n    Status after %.2f seconds:", newRuntime));
-    s.append(String.format("\n      Memory:           %.2f MB", MemoryMonitor.getMemSpent()));
-    s.append(String.format("\n      Depth:            %d", schedule.getStepNumber()));
-
-    s.append(String.format("\n      Schedules:        %d", iteration));
-    s.append(String.format("\n      Unexplored:       %d", schedule.getNumUnexploredChoices()));
-
-    ScratchLogger.log(s.toString());
-  }
-
-  private void printProgressHeader(boolean consolePrint) {
-    StringBuilder s = new StringBuilder(100);
-    s.append(StringUtils.center("Time", 11));
-    s.append(StringUtils.center("Memory", 9));
-    s.append(StringUtils.center("Step", 7));
-
-    s.append(StringUtils.center("Schedule", 12));
-    s.append(StringUtils.center("Unexplored", 24));
-
-    if (consolePrint) {
-      System.out.println(s);
-    } else {
-      PExplicitLogger.info(s.toString());
+    /**
+     * Reset the scheduler.
+     */
+    @Override
+    protected void reset() {
+        schedule.setStepNumber(0);
+        schedule.setChoiceNumber(0);
+        schedule.getMachineListByType().clear();
+        schedule.getMachineSet().clear();
     }
-  }
 
-  protected void printProgress(boolean forcePrint) {
-    if (forcePrint || (TimeMonitor.findInterval(getLastReportTime()) > 5)) {
-      setLastReportTime(Instant.now());
-      double newRuntime = TimeMonitor.getRuntime();
-      printCurrentStatus(newRuntime);
-      boolean consolePrint = (PExplicitGlobal.getConfig().getVerbosity() == 0);
-      if (consolePrint || forcePrint) {
-        long runtime = (long) (newRuntime * 1000);
-        String runtimeHms =
-            String.format(
-                "%02d:%02d:%02d",
-                TimeUnit.MILLISECONDS.toHours(runtime),
-                TimeUnit.MILLISECONDS.toMinutes(runtime) % TimeUnit.HOURS.toMinutes(1),
-                TimeUnit.MILLISECONDS.toSeconds(runtime) % TimeUnit.MINUTES.toSeconds(1));
+    /**
+     * Get the next schedule choice.
+     *
+     * @return Machine as scheduling choice.
+     */
+    @Override
+    public PMachine getNextScheduleChoice() {
+        PMachine result;
 
+        if (schedule.getChoiceNumber() < backtrackChoiceNumber) {
+            // pick the current schedule choice
+            result = schedule.getCurrentScheduleChoice(schedule.getChoiceNumber());
+            PExplicitLogger.logRepeatScheduleChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
+
+            schedule.setChoiceNumber(schedule.getChoiceNumber() + 1);
+            return result;
+        }
+
+        // get existing unexplored choices, if any
+        List<PMachine> choices = schedule.getUnexploredScheduleChoices(schedule.getChoiceNumber());
+
+        if (choices.isEmpty()) {
+            // no existing unexplored choices, so try generating new choices
+            choices = getNewScheduleChoices();
+            if (choices.isEmpty()) {
+                // no unexplored choices remaining
+                schedule.setChoiceNumber(schedule.getChoiceNumber() + 1);
+                return null;
+            }
+        }
+
+        // pick the first choice
+        result = choices.get(0);
+        schedule.setCurrentScheduleChoice(result, schedule.getChoiceNumber());
+        PExplicitLogger.logCurrentScheduleChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
+
+        // remove the first choice from unexplored choices
+        choices.remove(0);
+
+        // set unexplored choices
+        schedule.setUnexploredScheduleChoices(choices, schedule.getChoiceNumber());
+
+        // increment choice number
+        schedule.setChoiceNumber(schedule.getChoiceNumber() + 1);
+
+        return result;
+    }
+
+    /**
+     * Get the next data choice.
+     *
+     * @return PValue as data choice
+     */
+    @Override
+    public PValue<?> getNextDataChoice(List<PValue<?>> input_choices) {
+        PValue<?> result;
+
+        if (schedule.getChoiceNumber() < backtrackChoiceNumber) {
+            // pick the current data choice
+            result = schedule.getCurrentDataChoice(schedule.getChoiceNumber());
+            assert (input_choices.contains(result));
+            PExplicitLogger.logRepeatDataChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
+
+            schedule.setChoiceNumber(schedule.getChoiceNumber() + 1);
+            return result;
+        }
+
+        // get existing unexplored choices, if any
+        List<PValue<?>> choices = schedule.getUnexploredDataChoices(schedule.getChoiceNumber());
+        assert (input_choices.containsAll(choices));
+
+        if (choices.isEmpty()) {
+            // no existing unexplored choices, so try generating new choices
+            choices = input_choices;
+            if (choices.isEmpty()) {
+                // no unexplored choices remaining
+                schedule.setChoiceNumber(schedule.getChoiceNumber() + 1);
+                return null;
+            }
+        }
+
+        // pick the first choice
+        result = choices.get(0);
+        schedule.setCurrentDataChoice(result, schedule.getChoiceNumber());
+        PExplicitLogger.logCurrentDataChoice(result, schedule.getStepNumber(), schedule.getChoiceNumber());
+
+        // remove the first choice from unexplored choices
+        choices.remove(0);
+
+        // set unexplored choices
+        schedule.setUnexploredDataChoices(choices, schedule.getChoiceNumber());
+
+        // increment choice number
+        schedule.setChoiceNumber(schedule.getChoiceNumber() + 1);
+
+        return result;
+    }
+
+    private void postProcessIteration() {
+        if (!isDoneIterating) {
+            postIterationCleanup();
+        }
+    }
+
+    private void postIterationCleanup() {
+        for (int cIdx = schedule.size() - 1; cIdx >= 0; cIdx--) {
+            Choice choice = schedule.getChoice(cIdx);
+            schedule.clearCurrent(cIdx);
+            if (choice.isUnexploredNonEmpty()) {
+                PExplicitLogger.logBacktrack(cIdx);
+                backtrackChoiceNumber = cIdx;
+                for (PMachine machine : schedule.getMachineSet()) {
+                    machine.reset();
+                }
+                reset();
+                start();
+                return;
+            } else {
+                schedule.clearChoice(cIdx);
+            }
+        }
+        isDoneIterating = true;
+    }
+
+    private List<PMachine> getNewScheduleChoices() {
+        // prioritize create machine events
+        for (PMachine machine : schedule.getMachineSet()) {
+            if (machine.getSendBuffer().nextIsCreateMachineMsg()) {
+                return new ArrayList<>(Collections.singletonList(machine));
+            }
+        }
+
+        // now there are no create machine events remaining
+        List<PMachine> choices = new ArrayList<>();
+
+        for (PMachine machine : schedule.getMachineSet()) {
+            if (machine.getSendBuffer().nextHasTargetRunning()) {
+                choices.add(machine);
+            }
+        }
+
+        return choices;
+    }
+
+    public void updateResult() {
+        String result = "";
+        int maxStepBound = PExplicitGlobal.getConfig().getMaxStepBound();
+        int numUnexplored = schedule.getNumUnexploredChoices();
+        if (maxStepNumber < maxStepBound) {
+            if (numUnexplored == 0) {
+                result += "correct for any depth";
+            } else {
+                result += String.format("partially correct with %d choices remaining", numUnexplored);
+            }
+        } else {
+            if (numUnexplored == 0) {
+                result += String.format("correct up to step %d", maxStepNumber);
+            } else {
+                result += String.format("partially correct up to step %d with %d choices remaining", maxStepNumber, numUnexplored);
+            }
+        }
+        PExplicitGlobal.setResult(result);
+    }
+
+    public void recordStats() {
+        double timeUsed = (Duration.between(TimeMonitor.getStart(), Instant.now()).toMillis() / 1000.0);
+        double memoryUsed = MemoryMonitor.getMemSpent();
+
+        printProgress(true);
+        PExplicitLogger.log("\n--------------------");
+
+        // print basic statistics
+        StatWriter.log("time-seconds", String.format("%.1f", timeUsed));
+        StatWriter.log("memory-max-MB", String.format("%.1f", MemoryMonitor.getMaxMemSpent()));
+        StatWriter.log("memory-current-MB", String.format("%.1f", memoryUsed));
+        StatWriter.log("#-schedules", String.format("%d", iteration));
+        StatWriter.log("max-steps", String.format("%d", maxStepNumber));
+        PExplicitLogger.log(String.format("Max Schedule Length       %d", maxStepNumber));
+        StatWriter.log("#-choices-unexplored", String.format("%d", schedule.getNumUnexploredChoices()));
+        StatWriter.log("%-choices-unexplored-data", String.format("%.1f", schedule.getUnexploredDataChoicesPercent()));
+    }
+
+    private void printCurrentStatus(double newRuntime) {
+
+        String s = "--------------------" +
+                String.format("\n    Status after %.2f seconds:", newRuntime) +
+                String.format("\n      Memory:           %.2f MB", MemoryMonitor.getMemSpent()) +
+                String.format("\n      Depth:            %d", schedule.getStepNumber()) +
+                String.format("\n      Schedules:        %d", iteration) +
+                String.format("\n      Unexplored:       %d", schedule.getNumUnexploredChoices());
+
+        ScratchLogger.log(s);
+    }
+
+    private void printProgressHeader(boolean consolePrint) {
         StringBuilder s = new StringBuilder(100);
-        if (consolePrint) {
-          s.append('\r');
-        } else {
-          PExplicitLogger.info("--------------------");
-          printProgressHeader(false);
-        }
-        s.append(StringUtils.center(String.format("%s", runtimeHms), 11));
-        s.append(
-            StringUtils.center(String.format("%.1f GB", MemoryMonitor.getMemSpent() / 1024), 9));
-        s.append(StringUtils.center(String.format("%d", schedule.getStepNumber()), 7));
+        s.append(StringUtils.center("Time", 11));
+        s.append(StringUtils.center("Memory", 9));
+        s.append(StringUtils.center("Step", 7));
 
-        s.append(StringUtils.center(String.format("%d", iteration), 12));
-        s.append(
-            StringUtils.center(
-                String.format(
-                    "%d (%.0f %% data)", schedule.getNumUnexploredChoices(), schedule.getUnexploredDataChoicesPercent()),
-                24));
+        s.append(StringUtils.center("Schedule", 12));
+        s.append(StringUtils.center("Unexplored", 24));
 
         if (consolePrint) {
-          System.out.print(s);
+            System.out.println(s);
         } else {
-          PExplicitLogger.log(s.toString());
+            PExplicitLogger.info(s.toString());
         }
-      }
     }
-  }
+
+    protected void printProgress(boolean forcePrint) {
+        if (forcePrint || (TimeMonitor.findInterval(getLastReportTime()) > 5)) {
+            setLastReportTime(Instant.now());
+            double newRuntime = TimeMonitor.getRuntime();
+            printCurrentStatus(newRuntime);
+            boolean consolePrint = (PExplicitGlobal.getConfig().getVerbosity() == 0);
+            if (consolePrint || forcePrint) {
+                long runtime = (long) (newRuntime * 1000);
+                String runtimeHms =
+                        String.format(
+                                "%02d:%02d:%02d",
+                                TimeUnit.MILLISECONDS.toHours(runtime),
+                                TimeUnit.MILLISECONDS.toMinutes(runtime) % TimeUnit.HOURS.toMinutes(1),
+                                TimeUnit.MILLISECONDS.toSeconds(runtime) % TimeUnit.MINUTES.toSeconds(1));
+
+                StringBuilder s = new StringBuilder(100);
+                if (consolePrint) {
+                    s.append('\r');
+                } else {
+                    PExplicitLogger.info("--------------------");
+                    printProgressHeader(false);
+                }
+                s.append(StringUtils.center(String.format("%s", runtimeHms), 11));
+                s.append(
+                        StringUtils.center(String.format("%.1f GB", MemoryMonitor.getMemSpent() / 1024), 9));
+                s.append(StringUtils.center(String.format("%d", schedule.getStepNumber()), 7));
+
+                s.append(StringUtils.center(String.format("%d", iteration), 12));
+                s.append(
+                        StringUtils.center(
+                                String.format(
+                                        "%d (%.0f %% data)", schedule.getNumUnexploredChoices(), schedule.getUnexploredDataChoicesPercent()),
+                                24));
+
+                if (consolePrint) {
+                    System.out.print(s);
+                } else {
+                    PExplicitLogger.log(s.toString());
+                }
+            }
+        }
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import pexplicit.runtime.PExplicitGlobal;
+import pexplicit.runtime.STATUS;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.ScratchLogger;
 import pexplicit.runtime.logger.StatWriter;
@@ -112,7 +113,10 @@ public class ExplicitSearchScheduler extends Scheduler {
                 !PExplicitGlobal.getConfig().isFailOnMaxStepBound() || (schedule.getStepNumber() < PExplicitGlobal.getConfig().getMaxStepBound()),
                 "Step bound of " + PExplicitGlobal.getConfig().getMaxStepBound() + " reached.");
         if (PExplicitGlobal.getConfig().getMaxSchedules() > 0) {
-            isDoneIterating = (iteration >= PExplicitGlobal.getConfig().getMaxSchedules());
+            if (iteration >= PExplicitGlobal.getConfig().getMaxSchedules()) {
+                isDoneIterating = true;
+                PExplicitGlobal.setStatus(STATUS.SCHEDULEOUT);
+            }
         }
     }
 
@@ -326,6 +330,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             } else {
                 result += String.format("partially correct up to step %d with %d choices remaining", maxStepNumber, numUnexplored);
             }
+
         }
         PExplicitGlobal.setResult(result);
     }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/exceptions/LivenessException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/exceptions/LivenessException.java
@@ -1,7 +1,7 @@
 package pexplicit.utils.exceptions;
 
 public class LivenessException extends BugFoundException {
-  public LivenessException(String message) {
-    super(message);
-  }
+    public LivenessException(String message) {
+        super(message);
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/exceptions/MemoutException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/exceptions/MemoutException.java
@@ -9,7 +9,7 @@ public class MemoutException extends RuntimeException {
     }
 
     public MemoutException(String message, double memSpent, Throwable cause) {
-        super(message,  cause);
+        super(message, cause);
         this.memSpent = memSpent;
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/misc/Assert.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/misc/Assert.java
@@ -3,6 +3,7 @@ package pexplicit.utils.misc;
 import lombok.Getter;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.LivenessException;
+import pexplicit.values.PString;
 
 public class Assert {
     @Getter
@@ -16,6 +17,10 @@ public class Assert {
             failureMsg = "Property violated: " + msg;
             throw new BugFoundException(failureMsg);
         }
+    }
+
+    public static void fromModel(boolean p, PString msg) {
+        fromModel(p, msg.getValue());
     }
 
     public static void liveness(boolean p, String msg) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/MemoryMonitor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/MemoryMonitor.java
@@ -1,53 +1,57 @@
 package pexplicit.utils.monitor;
 
 import com.sun.management.GarbageCollectionNotificationInfo;
-import java.lang.management.GarbageCollectorMXBean;
-import java.lang.management.ManagementFactory;
-import javax.management.Notification;
-import javax.management.NotificationEmitter;
-import javax.management.NotificationListener;
 import lombok.Getter;
 import pexplicit.utils.exceptions.MemoutException;
 
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+
 public class MemoryMonitor {
-  private static NotificationListener notificationListener;
-  @Getter private static double maxMemSpent = 0; // max memory in megabytes
-  @Getter private static double memSpent = 0; // max memory in megabytes
-  @Getter private static double memLimit = 0; // memory limit in megabytes (0 means infinite)
+    private static NotificationListener notificationListener;
+    @Getter
+    private static double maxMemSpent = 0; // max memory in megabytes
+    @Getter
+    private static double memSpent = 0; // max memory in megabytes
+    @Getter
+    private static double memLimit = 0; // memory limit in megabytes (0 means infinite)
 
-  public static void setup(double ml) {
-    memSpent = 0;
-    maxMemSpent = 0;
-    memLimit = ml;
+    public static void setup(double ml) {
+        memSpent = 0;
+        maxMemSpent = 0;
+        memLimit = ml;
 
-    notificationListener =
-        new NotificationListener() {
-          @Override
-          public void handleNotification(Notification notification, Object handback) {
-            if (notification
-                .getType()
-                .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
-              Runtime runtime = Runtime.getRuntime();
-              memSpent = (runtime.totalMemory() - runtime.freeMemory()) / 1000000.0;
-              if (maxMemSpent < memSpent) maxMemSpent = memSpent;
+        notificationListener =
+                new NotificationListener() {
+                    @Override
+                    public void handleNotification(Notification notification, Object handback) {
+                        if (notification
+                                .getType()
+                                .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
+                            Runtime runtime = Runtime.getRuntime();
+                            memSpent = (runtime.totalMemory() - runtime.freeMemory()) / 1000000.0;
+                            if (maxMemSpent < memSpent) maxMemSpent = memSpent;
+                        }
+                    }
+                };
+
+        // register our listener with all gc beans
+        for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            NotificationEmitter emitter = (NotificationEmitter) gcBean;
+            emitter.addNotificationListener(notificationListener, null, null);
+        }
+    }
+
+    public static void checkMemout() throws MemoutException {
+        if (memLimit > 0) {
+            if (MemoryMonitor.getMemSpent() > memLimit) {
+                throw new MemoutException(
+                        String.format("Max memory limit reached: %.1f MB", MemoryMonitor.getMemSpent()),
+                        MemoryMonitor.getMemSpent());
             }
-          }
-        };
-
-    // register our listener with all gc beans
-    for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
-      NotificationEmitter emitter = (NotificationEmitter) gcBean;
-      emitter.addNotificationListener(notificationListener, null, null);
+        }
     }
-  }
-
-  public static void checkMemout() throws MemoutException {
-    if (memLimit > 0) {
-      if (MemoryMonitor.getMemSpent() > memLimit) {
-        throw new MemoutException(
-                String.format("Max memory limit reached: %.1f MB", MemoryMonitor.getMemSpent()),
-                MemoryMonitor.getMemSpent());
-      }
-    }
-  }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimeMonitor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimeMonitor.java
@@ -1,52 +1,58 @@
 package pexplicit.utils.monitor;
 
+import lombok.Getter;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeoutException;
-import lombok.Getter;
 
 /**
  * Represents the time monitor to track runtime and enforce timeout
  */
 public class TimeMonitor {
-  /** Stores the start time to track total runtime */
-  @Getter private static Instant start;
+    /**
+     * Stores the start time to track total runtime
+     */
+    @Getter
+    private static Instant start;
 
-  // time limit in seconds (0 means infinite)
-  private static double timeLimit;
+    // time limit in seconds (0 means infinite)
+    private static double timeLimit;
 
-  /** Stores the beginning time to track when a time interval begins */
-  private static Instant begin;
+    /**
+     * Stores the beginning time to track when a time interval begins
+     */
+    private static Instant begin;
 
-  public static void setup(double tl) {
-    start = Instant.now();
-    begin = Instant.now();
-    timeLimit = tl;
-  }
-
-  public static double getRuntime() {
-    return findInterval(start);
-  }
-
-  public static void startInterval() {
-    begin = Instant.now();
-  }
-
-  public static double stopInterval() {
-    return Duration.between(begin, Instant.now()).toMillis() / 1000.0;
-  }
-
-  public static double findInterval(Instant intervalBegin) {
-    return Duration.between(intervalBegin, Instant.now()).toMillis() / 1000.0;
-  }
-
-  public static void checkTimeout() throws TimeoutException {
-    if (timeLimit != 0) {
-      double elapsedTime = getRuntime();
-      if (elapsedTime > timeLimit) {
-        throw new TimeoutException(
-            String.format("Max time limit reached. Runtime: %.1f seconds", elapsedTime));
-      }
+    public static void setup(double tl) {
+        start = Instant.now();
+        begin = Instant.now();
+        timeLimit = tl;
     }
-  }
+
+    public static double getRuntime() {
+        return findInterval(start);
+    }
+
+    public static void startInterval() {
+        begin = Instant.now();
+    }
+
+    public static double stopInterval() {
+        return Duration.between(begin, Instant.now()).toMillis() / 1000.0;
+    }
+
+    public static double findInterval(Instant intervalBegin) {
+        return Duration.between(intervalBegin, Instant.now()).toMillis() / 1000.0;
+    }
+
+    public static void checkTimeout() throws TimeoutException {
+        if (timeLimit != 0) {
+            double elapsedTime = getRuntime();
+            if (elapsedTime > timeLimit) {
+                throw new TimeoutException(
+                        String.format("Max time limit reached. Runtime: %.1f seconds", elapsedTime));
+            }
+        }
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
@@ -1,31 +1,31 @@
 package pexplicit.utils.monitor;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeoutException;
-
 import pexplicit.runtime.scheduler.Scheduler;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.MemoutException;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
 public class TimedCall implements Callable<Integer> {
-  private final Scheduler scheduler;
+    private final Scheduler scheduler;
 
-  public TimedCall(Scheduler scheduler, boolean resume) {
-    this.scheduler = scheduler;
-  }
-
-  @Override
-  public Integer call()
-      throws MemoutException, BugFoundException, TimeoutException, InterruptedException {
-    try {
-      this.scheduler.run();
-    } catch (OutOfMemoryError e) {
-      throw new MemoutException(e.getMessage(), MemoryMonitor.getMemSpent(), e);
-    } catch (NullPointerException | StackOverflowError e) {
-      throw new BugFoundException(e.getMessage(), e);
-    } catch (MemoutException | BugFoundException | TimeoutException | InterruptedException e) {
-      throw e;
+    public TimedCall(Scheduler scheduler, boolean resume) {
+        this.scheduler = scheduler;
     }
-      return 0;
-  }
+
+    @Override
+    public Integer call()
+            throws MemoutException, BugFoundException, TimeoutException, InterruptedException {
+        try {
+            this.scheduler.run();
+        } catch (OutOfMemoryError e) {
+            throw new MemoutException(e.getMessage(), MemoryMonitor.getMemSpent(), e);
+        } catch (NullPointerException | StackOverflowError e) {
+            throw new BugFoundException(e.getMessage(), e);
+        } catch (MemoutException | BugFoundException | TimeoutException | InterruptedException e) {
+            throw e;
+        }
+        return 0;
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
@@ -21,7 +21,7 @@ public class TimedCall implements Callable<Integer> {
             this.scheduler.run();
         } catch (OutOfMemoryError e) {
             throw new MemoutException(e.getMessage(), MemoryMonitor.getMemSpent(), e);
-        } catch (NullPointerException | StackOverflowError e) {
+        } catch (NullPointerException | StackOverflowError | ClassCastException e) {
             throw new BugFoundException(e.getMessage(), e);
         } catch (MemoutException | BugFoundException | TimeoutException | InterruptedException e) {
             throw e;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/monitor/TimedCall.java
@@ -21,6 +21,8 @@ public class TimedCall implements Callable<Integer> {
       this.scheduler.run();
     } catch (OutOfMemoryError e) {
       throw new MemoutException(e.getMessage(), MemoryMonitor.getMemSpent(), e);
+    } catch (NullPointerException | StackOverflowError e) {
+      throw new BugFoundException(e.getMessage(), e);
     } catch (MemoutException | BugFoundException | TimeoutException | InterruptedException e) {
       throw e;
     }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/serialize/SerializableRunnable.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/serialize/SerializableRunnable.java
@@ -2,5 +2,6 @@ package pexplicit.utils.serialize;
 
 import java.io.Serializable;
 
-public interface SerializableRunnable extends Serializable, Runnable {}
+public interface SerializableRunnable extends Serializable, Runnable {
+}
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/ComputeHash.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/ComputeHash.java
@@ -35,7 +35,7 @@ public class ComputeHash {
     /**
      * Compute hash value for a PMachine and an array of PValues.
      */
-    public static int getHashCode(PMachine machine, PValue<?> ... values) {
+    public static int getHashCode(PMachine machine, PValue<?>... values) {
         int hashValue = 0x802CBBDB;
         if (machine != null) hashValue = hashValue ^ machine.hashCode();
         for (PValue<?> val : values) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
@@ -72,6 +72,14 @@ public class PBool extends PValue<PBool> {
         return new PBool(value || val.value);
     }
 
+    /**
+     * Convert to a PInt
+     * @return PInt object
+     */
+    public PInt toInt() {
+        return new PInt(value?1:0);
+    }
+
     @Override
     public PBool clone() {
         return new PBool(value);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
@@ -48,6 +48,7 @@ public class PBool extends PValue<PBool> {
 
     /**
      * Logical Not operation
+     *
      * @return PBool object after operation
      */
     public PBool not() {
@@ -56,6 +57,7 @@ public class PBool extends PValue<PBool> {
 
     /**
      * Logical And operation
+     *
      * @param val value to and to
      * @return PBool object after operation
      */
@@ -65,6 +67,7 @@ public class PBool extends PValue<PBool> {
 
     /**
      * Logical Or operation
+     *
      * @param val value to or to
      * @return PBool object after operation
      */
@@ -74,10 +77,11 @@ public class PBool extends PValue<PBool> {
 
     /**
      * Convert to a PInt
+     *
      * @return PInt object
      */
     public PInt toInt() {
-        return new PInt(value?1:0);
+        return new PInt(value ? 1 : 0);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
@@ -46,6 +46,32 @@ public class PBool extends PValue<PBool> {
         return value;
     }
 
+    /**
+     * Logical Not operation
+     * @return PBool object after operation
+     */
+    public PBool not() {
+        return new PBool(!value);
+    }
+
+    /**
+     * Logical And operation
+     * @param val value to and to
+     * @return PBool object after operation
+     */
+    public PBool and(PBool val) {
+        return new PBool(value && val.value);
+    }
+
+    /**
+     * Logical Or operation
+     * @param val value to or to
+     * @return PBool object after operation
+     */
+    public PBool or(PBool val) {
+        return new PBool(value || val.value);
+    }
+
     @Override
     public PBool clone() {
         return new PBool(value);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
@@ -9,7 +9,7 @@ public interface PCollection {
      *
      * @return size
      */
-    public abstract PInt size();
+    PInt size();
 
     /**
      * Check if the collection contains the given item.
@@ -17,5 +17,5 @@ public interface PCollection {
      * @param item item to check for.
      * @return true if the collection contains the item, otherwise false
      */
-    public abstract PBool contains(PValue<?> item);
+    PBool contains(PValue<?> item);
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
@@ -3,7 +3,7 @@ package pexplicit.values;
 /**
  * Represents the base class for PValues that are collections.
  */
-public abstract class PCollection<T> extends PValue<PCollection<T>> {
+public interface PCollection<T> {
     /**
      * Get the size of the collection.
      *

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
@@ -3,7 +3,7 @@ package pexplicit.values;
 /**
  * Represents the base class for PValues that are collections.
  */
-public interface PCollection<T> {
+public interface PCollection {
     /**
      * Get the size of the collection.
      *
@@ -17,5 +17,5 @@ public interface PCollection<T> {
      * @param item item to check for.
      * @return true if the collection contains the item, otherwise false
      */
-    public abstract PBool contains(T item);
+    public abstract PBool contains(PValue<?> item);
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PCollection.java
@@ -3,13 +3,13 @@ package pexplicit.values;
 /**
  * Represents the base class for PValues that are collections.
  */
-public abstract class PCollection extends PValue<PCollection> {
+public abstract class PCollection<T> extends PValue<PCollection<T>> {
     /**
      * Get the size of the collection.
      *
      * @return size
      */
-    public abstract int size();
+    public abstract PInt size();
 
     /**
      * Check if the collection contains the given item.
@@ -17,5 +17,5 @@ public abstract class PCollection extends PValue<PCollection> {
      * @param item item to check for.
      * @return true if the collection contains the item, otherwise false
      */
-    public abstract boolean contains(PValue<?> item);
+    public abstract PBool contains(T item);
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
@@ -36,10 +36,11 @@ public class PEnum extends PValue<PEnum> {
 
     /**
      * Convert to a PInt
+     *
      * @return PInt object
      */
     public PInt toInt() {
-        return new PInt((int) value);
+        return new PInt(value);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
@@ -7,6 +7,7 @@ import lombok.Getter;
  */
 @Getter
 public class PEnum extends PValue<PEnum> {
+    private final String type;
     private final String name;
     private final int value;
 
@@ -16,9 +17,10 @@ public class PEnum extends PValue<PEnum> {
      * @param name Name of the enum
      * @param val  integer value
      */
-    public PEnum(String name, int val) {
+    public PEnum(String type, String name, int val) {
+        this.type = type;
         this.name = name;
-        value = val;
+        this.value = val;
     }
 
     /**
@@ -27,8 +29,17 @@ public class PEnum extends PValue<PEnum> {
      * @param val PEnum value to copy from
      */
     public PEnum(PEnum val) {
+        type = val.type;
         name = val.name;
         value = val.value;
+    }
+
+    /**
+     * Convert to a PInt
+     * @return PInt object
+     */
+    public PInt toInt() {
+        return new PInt((int) value);
     }
 
     @Override
@@ -38,7 +49,7 @@ public class PEnum extends PValue<PEnum> {
 
     @Override
     public int hashCode() {
-        return name.hashCode() ^ Long.hashCode(value);
+        return Long.hashCode(value);
     }
 
     @Override
@@ -47,7 +58,7 @@ public class PEnum extends PValue<PEnum> {
         else if (!(obj instanceof PEnum)) {
             return false;
         }
-        return this.value == ((PEnum) obj).value && this.name.equals(((PEnum) obj).name);
+        return this.value == ((PEnum) obj).value;
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
@@ -129,6 +129,14 @@ public class PFloat extends PValue<PFloat> {
         return new PBool(value >= val.value);
     }
 
+    /**
+     * Convert to a PInt
+     * @return PInt object
+     */
+    public PInt toInt() {
+        return new PInt((int) value);
+    }
+
 
     @Override
     public PFloat clone() {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
@@ -42,6 +42,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Negation operation
+     *
      * @return Result after operation
      */
     public PFloat negate() {
@@ -50,6 +51,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Add operation
+     *
      * @param val value to add
      * @return Result after addition
      */
@@ -59,6 +61,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Subtract operation
+     *
      * @param val value to subtract
      * @return Result after subtraction
      */
@@ -68,6 +71,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Multiply operation
+     *
      * @param val value to multiply
      * @return Result after multiplication
      */
@@ -77,6 +81,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Divide operation
+     *
      * @param val value to divide
      * @return Result after division
      */
@@ -86,6 +91,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Modulo operation
+     *
      * @param val value to modulo
      * @return Result after modulo
      */
@@ -95,6 +101,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Less than operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -104,6 +111,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Less than or equal to operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -113,6 +121,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Greater than operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -122,6 +131,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Greater than or equal to operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -131,6 +141,7 @@ public class PFloat extends PValue<PFloat> {
 
     /**
      * Convert to a PInt
+     *
      * @return PInt object
      */
     public PInt toInt() {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
@@ -40,6 +40,96 @@ public class PFloat extends PValue<PFloat> {
         value = val.value;
     }
 
+    /**
+     * Negation operation
+     * @return Result after operation
+     */
+    public PFloat negate() {
+        return new PFloat(-value);
+    }
+
+    /**
+     * Add operation
+     * @param val value to add
+     * @return Result after addition
+     */
+    public PFloat add(PFloat val) {
+        return new PFloat(value + val.value);
+    }
+
+    /**
+     * Subtract operation
+     * @param val value to subtract
+     * @return Result after subtraction
+     */
+    public PFloat sub(PFloat val) {
+        return new PFloat(value - val.value);
+    }
+
+    /**
+     * Multiply operation
+     * @param val value to multiply
+     * @return Result after multiplication
+     */
+    public PFloat mul(PFloat val) {
+        return new PFloat(value * val.value);
+    }
+
+    /**
+     * Divide operation
+     * @param val value to divide
+     * @return Result after division
+     */
+    public PFloat div(PFloat val) {
+        return new PFloat(value / val.value);
+    }
+
+    /**
+     * Modulo operation
+     * @param val value to modulo
+     * @return Result after modulo
+     */
+    public PFloat mod(PFloat val) {
+        return new PFloat(value % val.value);
+    }
+
+    /**
+     * Less than operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool lt(PFloat val) {
+        return new PBool(value < val.value);
+    }
+
+    /**
+     * Less than or equal to operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool le(PFloat val) {
+        return new PBool(value <= val.value);
+    }
+
+    /**
+     * Greater than operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool gt(PFloat val) {
+        return new PBool(value > val.value);
+    }
+
+    /**
+     * Greater than or equal to operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool ge(PFloat val) {
+        return new PBool(value >= val.value);
+    }
+
+
     @Override
     public PFloat clone() {
         return new PFloat(value);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -39,6 +39,87 @@ public class PInt extends PValue<PInt> {
         value = val.value;
     }
 
+    /**
+     * Add operation
+     * @param val value to add
+     * @return PInt object after addition
+     */
+    public PInt add(PInt val) {
+        return new PInt(value + val.value);
+    }
+
+    /**
+     * Subtract operation
+     * @param val value to subtract
+     * @return PInt object after subtraction
+     */
+    public PInt sub(PInt val) {
+        return new PInt(value - val.value);
+    }
+
+    /**
+     * Multiply operation
+     * @param val value to multiply
+     * @return PInt object after multiplication
+     */
+    public PInt mul(PInt val) {
+        return new PInt(value * val.value);
+    }
+
+    /**
+     * Divide operation
+     * @param val value to divide
+     * @return PInt object after division
+     */
+    public PInt div(PInt val) {
+        return new PInt(value / val.value);
+    }
+
+    /**
+     * Modulo operation
+     * @param val value to modulo
+     * @return PInt object after modulo
+     */
+    public PInt mod(PInt val) {
+        return new PInt(value % val.value);
+    }
+
+    /**
+     * Less than operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool lt(PInt val) {
+        return new PBool(value < val.value);
+    }
+
+    /**
+     * Less than or equal to operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool le(PInt val) {
+        return new PBool(value <= val.value);
+    }
+
+    /**
+     * Greater than operation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool gt(PInt val) {
+        return new PBool(value > val.value);
+    }
+
+    /**
+     * Greater than or equal toperation
+     * @param val value to compare to
+     * @return PBool object after operation
+     */
+    public PBool ge(PInt val) {
+        return new PBool(value >= val.value);
+    }
+
     @Override
     public PInt clone() {
         return new PInt(value);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -120,6 +120,14 @@ public class PInt extends PValue<PInt> {
     }
 
     /**
+     * Convert to a PFloat
+     * @return PFloat object
+     */
+    public PFloat toFloat() {
+        return new PFloat(value);
+    }
+
+    /**
      * Greater than or equal to operation
      * @param val value to compare to
      * @return PBool object after operation

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -41,6 +41,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Negation operation
+     *
      * @return Result after operation
      */
     public PInt negate() {
@@ -49,6 +50,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Add operation
+     *
      * @param val value to add
      * @return Result after addition
      */
@@ -58,6 +60,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Subtract operation
+     *
      * @param val value to subtract
      * @return Result after subtraction
      */
@@ -67,6 +70,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Multiply operation
+     *
      * @param val value to multiply
      * @return Result after multiplication
      */
@@ -76,6 +80,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Divide operation
+     *
      * @param val value to divide
      * @return Result after division
      */
@@ -85,6 +90,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Modulo operation
+     *
      * @param val value to modulo
      * @return Result after modulo
      */
@@ -94,6 +100,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Less than operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -103,6 +110,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Less than or equal to operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -112,6 +120,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Greater than operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */
@@ -121,6 +130,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Convert to a PFloat
+     *
      * @return PFloat object
      */
     public PFloat toFloat() {
@@ -129,6 +139,7 @@ public class PInt extends PValue<PInt> {
 
     /**
      * Greater than or equal to operation
+     *
      * @param val value to compare to
      * @return PBool object after operation
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -40,9 +40,17 @@ public class PInt extends PValue<PInt> {
     }
 
     /**
+     * Negation operation
+     * @return Result after operation
+     */
+    public PInt negate() {
+        return new PInt(-value);
+    }
+
+    /**
      * Add operation
      * @param val value to add
-     * @return PInt object after addition
+     * @return Result after addition
      */
     public PInt add(PInt val) {
         return new PInt(value + val.value);
@@ -51,7 +59,7 @@ public class PInt extends PValue<PInt> {
     /**
      * Subtract operation
      * @param val value to subtract
-     * @return PInt object after subtraction
+     * @return Result after subtraction
      */
     public PInt sub(PInt val) {
         return new PInt(value - val.value);
@@ -60,7 +68,7 @@ public class PInt extends PValue<PInt> {
     /**
      * Multiply operation
      * @param val value to multiply
-     * @return PInt object after multiplication
+     * @return Result after multiplication
      */
     public PInt mul(PInt val) {
         return new PInt(value * val.value);
@@ -69,7 +77,7 @@ public class PInt extends PValue<PInt> {
     /**
      * Divide operation
      * @param val value to divide
-     * @return PInt object after division
+     * @return Result after division
      */
     public PInt div(PInt val) {
         return new PInt(value / val.value);
@@ -78,7 +86,7 @@ public class PInt extends PValue<PInt> {
     /**
      * Modulo operation
      * @param val value to modulo
-     * @return PInt object after modulo
+     * @return Result after modulo
      */
     public PInt mod(PInt val) {
         return new PInt(value % val.value);
@@ -112,7 +120,7 @@ public class PInt extends PValue<PInt> {
     }
 
     /**
-     * Greater than or equal toperation
+     * Greater than or equal to operation
      * @param val value to compare to
      * @return PBool object after operation
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
@@ -20,26 +20,6 @@ public class PMachineValue extends PValue<PMachineValue> {
     }
 
     /**
-     * Constructor
-     *
-     * @param val object from where value to set to
-     */
-
-    public PMachineValue(Object val) {
-        if (val instanceof PMachineValue) value = ((PMachineValue) val).value;
-        else value = (PMachine) val;
-    }
-
-    /**
-     * Copy constructor
-     *
-     * @param val value to copy from
-     */
-    public PMachineValue(PMachineValue val) {
-        value = val.value;
-    }
-
-    /**
      * Get the unique machine identifier
      *
      * @return unique machine instance id

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -2,7 +2,10 @@ package pexplicit.values;
 
 import pexplicit.values.exceptions.KeyNotFoundException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the PValue for P map
@@ -46,7 +49,7 @@ public class PMap extends PValue<PMap> implements PCollection {
      * @throws KeyNotFoundException
      */
     public PValue<?> get(PValue<?> key) throws KeyNotFoundException {
-        if (!map.containsKey(key)) throw new KeyNotFoundException(key, (Map<PValue<?>, PValue<?>>) map);
+        if (!map.containsKey(key)) throw new KeyNotFoundException(key, map);
         return map.get(key);
     }
 
@@ -154,16 +157,15 @@ public class PMap extends PValue<PMap> implements PCollection {
 
     @Override
     public int hashCode() {
-        return ComputeHash.getHashCode((Collection<PValue<?>>) map.values()) ^ ComputeHash.getHashCode((Collection<PValue<?>>) map.keySet());
+        return ComputeHash.getHashCode(map.values()) ^ ComputeHash.getHashCode(map.keySet());
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 
-        if (!(obj instanceof PMap)) return false;
+        if (!(obj instanceof PMap other)) return false;
 
-        PMap other = (PMap) obj;
         if (map.size() != other.map.size()) {
             return false;
         }
@@ -171,7 +173,7 @@ public class PMap extends PValue<PMap> implements PCollection {
         for (PValue<?> key : map.keySet()) {
             if (!other.map.containsKey(key)) {
                 return false;
-            } else if (PValue.notEqual((PValue<?>) other.map.get(key), this.map.get(key))) {
+            } else if (PValue.notEqual(other.map.get(key), this.map.get(key))) {
                 return false;
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -141,7 +141,7 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PCollection<
         for (PValue<?> key : map.keySet()) {
             if (!other.map.containsKey(key)) {
                 return false;
-            } else if (!PValue.equals((PValue<?>) other.map.get(key), this.map.get(key))) {
+            } else if (PValue.notEqual((PValue<?>) other.map.get(key), this.map.get(key))) {
                 return false;
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -2,25 +2,22 @@ package pexplicit.values;
 
 import pexplicit.values.exceptions.KeyNotFoundException;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents the PValue for P map
  */
-public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<K, V>> implements PCollection<K> {
-    private final Map<K, V> map;
+public class PMap extends PValue<PMap> implements PCollection {
+    private final Map<PValue<?>, PValue<?>> map;
 
     /**
      * Constructor
      *
      * @param input_map input map to set to
      */
-    public PMap(Map<K, V> input_map) {
+    public PMap(Map<PValue<?>, PValue<?>> input_map) {
         map = new HashMap<>();
-        for (Map.Entry<K, V> entry : input_map.entrySet()) {
+        for (Map.Entry<PValue<?>, PValue<?>> entry : input_map.entrySet()) {
             map.put(PValue.clone(entry.getKey()), PValue.clone(entry.getValue()));
         }
     }
@@ -30,7 +27,7 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      *
      * @param other Value to copy from
      */
-    public PMap(PMap<K, V> other) {
+    public PMap(PMap other) {
         this(other.map);
     }
 
@@ -48,7 +45,7 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      * @return value corresponding to the key
      * @throws KeyNotFoundException
      */
-    public V get(K key) throws KeyNotFoundException {
+    public PValue<?> get(PValue<?> key) throws KeyNotFoundException {
         if (!map.containsKey(key)) throw new KeyNotFoundException(key, (Map<PValue<?>, PValue<?>>) map);
         return map.get(key);
     }
@@ -59,8 +56,8 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      * @param key input key
      * @param val value to set
      */
-    public PMap<K, V> put(K key, V val) {
-        Map<K, V> newMap = new HashMap<>(map);
+    public PMap put(PValue<?> key, PValue<?> val) {
+        Map<PValue<?>, PValue<?>> newMap = new HashMap<>(map);
         newMap.put(key, val);
         return new PMap(newMap);
     }
@@ -71,7 +68,7 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      * @param key input key
      * @param val value to set
      */
-    public PMap<K, V> add(K key, V val) {
+    public PMap add(PValue<?> key, PValue<?> val) {
         return put(key, val);
     }
 
@@ -80,11 +77,11 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      *
      * @param key input key
      */
-    public PMap<K, V> remove(K key) {
+    public PMap remove(PValue<?> key) {
         if (!map.containsKey(key)) {
             return this;
         }
-        Map<K, V> newMap = new HashMap<>(map);
+        Map<PValue<?>, PValue<?>> newMap = new HashMap<>(map);
         newMap.remove(key);
         return new PMap(newMap);
     }
@@ -94,8 +91,17 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      *
      * @return List of keys as a PSeq object
      */
-    public PSeq<K> getKeys() {
+    public PSeq getKeys() {
         return new PSeq(new ArrayList<>(map.keySet()));
+    }
+
+    /**
+     * Convert the PMap to a List of PValues representing map keys.
+     *
+     * @return List of PValues corresponding to the PMap keys.
+     */
+    public List<PValue<?>> toList() {
+        return new ArrayList<>(map.keySet());
     }
 
     /**
@@ -113,12 +119,12 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
      * @param item item to check for.
      * @return true if key is present, false otherwise
      */
-    public PBool contains(K item) {
+    public PBool contains(PValue<?> item) {
         return new PBool(map.containsKey(item));
     }
 
     @Override
-    public PMap<K, V> clone() {
+    public PMap clone() {
         return new PMap(map);
     }
 
@@ -153,7 +159,7 @@ public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<
         StringBuilder sb = new StringBuilder();
         sb.append("(");
         boolean hadElements = false;
-        for (K key : map.keySet()) {
+        for (PValue<?> key : map.keySet()) {
             if (hadElements) {
                 sb.append(", ");
             }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -10,7 +10,7 @@ import java.util.Map;
 /**
  * Represents the PValue for P map
  */
-public class PMap<K extends PValue<K>, V extends PValue<V>> extends PCollection<K> {
+public class PMap<K extends PValue<K>, V extends PValue<V>> extends PValue<PMap<K, V>> implements PCollection<K> {
     private final Map<K, V> map;
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -51,6 +51,21 @@ public class PMap extends PValue<PMap> implements PCollection {
     }
 
     /**
+     * Get the mapped value corresponding to a key or a given default value if key doesn't exists
+     *
+     * @param key input key
+     * @param def input default value
+     * @return value corresponding to the key or default value if key does not exists
+     */
+    public PValue<?> getOrDefault(PValue<?> key, PValue<?> def) {
+        try {
+            return get(key);
+        } catch (KeyNotFoundException e) {
+            return def;
+        }
+    }
+
+    /**
      * Set the mapped value corresponding to a key
      *
      * @param key input key

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -96,6 +96,15 @@ public class PMap extends PValue<PMap> implements PCollection {
     }
 
     /**
+     * Get the list of values in the map
+     *
+     * @return List of values as a PSeq object
+     */
+    public PSeq getValues() {
+        return new PSeq(new ArrayList<>(map.values()));
+    }
+
+    /**
      * Convert the PMap to a List of PValues representing map keys.
      *
      * @return List of PValues corresponding to the PMap keys.

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
@@ -82,9 +82,11 @@ public class PNamedTuple extends PValue<PNamedTuple> {
      * @param val  value to set
      * @throws NamedTupleFieldNameException
      */
-    public void setField(String name, PValue<?> val) throws NamedTupleFieldNameException {
+    public PNamedTuple setField(String name, PValue<?> val) throws NamedTupleFieldNameException {
         if (!values.containsKey(name)) throw new NamedTupleFieldNameException(this, name);
-        values.put(name, val);
+        Map<String, PValue<?>> newValues = new HashMap<>(values);
+        newValues.put(name, val);
+        return new PNamedTuple(newValues);
     }
 
     /**
@@ -96,8 +98,8 @@ public class PNamedTuple extends PValue<PNamedTuple> {
      * @param val  value to set
      * @throws NamedTupleFieldNameException
      */
-    public void setField(PString name, PValue<?> val) throws NamedTupleFieldNameException {
-        setField(name.toString(), val);
+    public PNamedTuple setField(PString name, PValue<?> val) throws NamedTupleFieldNameException {
+        return setField(name.toString(), val);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
@@ -126,7 +126,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
         for (String name : values.keySet()) {
             if (!other.values.containsKey(name)) {
                 throw new ComparingPValuesException(other, this);
-            } else if (!PValue.equals(other.values.get(name), this.values.get(name))) {
+            } else if (PValue.notEqual(other.values.get(name), this.values.get(name))) {
                 return false;
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
@@ -24,7 +24,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
     public PNamedTuple(List<String> input_fields, List<PValue<?>> input_values) {
         assert (input_fields.size() == input_values.size());
         values = new HashMap<>();
-        for (int i=0; i<input_fields.size(); i++) {
+        for (int i = 0; i < input_fields.size(); i++) {
             values.put(input_fields.get(i), input_values.get(i));
         }
     }
@@ -116,11 +116,10 @@ public class PNamedTuple extends PValue<PNamedTuple> {
     public boolean equals(Object obj) {
         if (obj == this) return true;
 
-        if (!(obj instanceof PNamedTuple)) {
+        if (!(obj instanceof PNamedTuple other)) {
             return false;
         }
 
-        PNamedTuple other = (PNamedTuple) obj;
         if (values.size() != other.values.size()) {
             return false;
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -3,36 +3,41 @@ package pexplicit.values;
 import pexplicit.values.exceptions.InvalidIndexException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
  * Represents the PValue for P list/sequence
  */
-public class PSeq extends PCollection {
-    private final List<PValue<?>> seq;
+public class PSeq<T extends PValue<T>> extends PCollection<T> {
+    private final List<T> seq;
 
     /**
      * Constructor
      *
      * @param input_seq list of elements
      */
-    public PSeq(List<PValue<?>> input_seq) {
+    public PSeq(List<T> input_seq) {
         seq = new ArrayList<>();
-        for (PValue<?> entry : input_seq) {
+        for (T entry : input_seq) {
             seq.add(PValue.clone(entry));
         }
     }
 
     /**
-     * COpy constructor
+     * Copy constructor
      *
      * @param other Value to copy from.
      */
-    public PSeq(PSeq other) {
-        seq = new ArrayList<>();
-        for (PValue<?> entry : other.seq) {
-            seq.add(PValue.clone(entry));
-        }
+    public PSeq(PSeq<T> other) {
+        this(other.seq);
+    }
+
+    /**
+     * Empty constructor
+     */
+    public PSeq() {
+        this(new ArrayList<>());
     }
 
     /**
@@ -42,9 +47,9 @@ public class PSeq extends PCollection {
      * @return value at the index
      * @throws InvalidIndexException
      */
-    public PValue<?> getValue(int index) throws InvalidIndexException {
-        if (index >= seq.size() || index < 0) throw new InvalidIndexException(index, this);
-        return seq.get(index);
+    public T get(PInt index) throws InvalidIndexException {
+        if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        return seq.get(index.getValue());
     }
 
     /**
@@ -54,9 +59,11 @@ public class PSeq extends PCollection {
      * @param val   value to set to
      * @throws InvalidIndexException
      */
-    public void setValue(int index, PValue<?> val) throws InvalidIndexException {
-        if (index >= seq.size() || index < 0) throw new InvalidIndexException(index, this);
-        seq.set(index, val);
+    public PSeq<T> set(PInt index, T val) throws InvalidIndexException {
+        if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        List<T> newSeq = new ArrayList<>(seq);
+        newSeq.set(index.getValue(), val);
+        return new PSeq<>(newSeq);
     }
 
     /**
@@ -66,9 +73,24 @@ public class PSeq extends PCollection {
      * @param val   value to insert at the index.
      * @throws InvalidIndexException
      */
-    public void insertValue(int index, PValue<?> val) throws InvalidIndexException {
-        if (index > seq.size() || index < 0) throw new InvalidIndexException(index, this);
-        seq.add(index, val);
+    public PSeq<T> add(PInt index, T val) throws InvalidIndexException {
+        if (index.getValue() > seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        List<T> newSeq = new ArrayList<>(seq);
+        newSeq.add(index.getValue(), val);
+        return new PSeq<>(newSeq);
+    }
+
+    /**
+     * Remove a value at a given index.
+     *
+     * @param index index to remove the value at.
+     * @throws InvalidIndexException
+     */
+    public PSeq<T> removeAt(PInt index) throws InvalidIndexException {
+        if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        List<T> newSeq = new ArrayList<>(seq);
+        newSeq.remove(index.getValue());
+        return new PSeq<>(newSeq);
     }
 
     /**
@@ -76,18 +98,18 @@ public class PSeq extends PCollection {
      *
      * @return List of PValues corresponding to the PSeq.
      */
-    public List<PValue<?>> toList() {
+    public List<T> toList() {
         return seq;
     }
 
     @Override
-    public PSeq clone() {
+    public PSeq<T> clone() {
         return new PSeq(seq);
     }
 
     @Override
     public int hashCode() {
-        return ComputeHash.getHashCode(seq);
+        return ComputeHash.getHashCode((Collection<PValue<?>>) seq);
     }
 
     @Override
@@ -98,13 +120,13 @@ public class PSeq extends PCollection {
             return false;
         }
 
-        PSeq other = (PSeq) obj;
+        PSeq<T> other = (PSeq) obj;
         if (seq.size() != other.seq.size()) {
             return false;
         }
 
         for (int i = 0; i < seq.size(); i++) {
-            if (PValue.equals(other.seq.get(i), this.seq.get(i))) {
+            if (!PValue.equals((PValue<?>) other.seq.get(i), (PValue<?>) this.seq.get(i))) {
                 return false;
             }
         }
@@ -116,7 +138,7 @@ public class PSeq extends PCollection {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         String sep = "";
-        for (PValue<?> item : seq) {
+        for (T item : seq) {
             sb.append(sep);
             sb.append(item);
             sep = ", ";
@@ -126,12 +148,12 @@ public class PSeq extends PCollection {
     }
 
     @Override
-    public int size() {
-        return seq.size();
+    public PInt size() {
+        return new PInt(seq.size());
     }
 
     @Override
-    public boolean contains(PValue<?> item) {
-        return seq.contains(item);
+    public PBool contains(T item) {
+        return new PBool(seq.contains(item));
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -9,17 +9,17 @@ import java.util.List;
 /**
  * Represents the PValue for P list/sequence
  */
-public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PCollection<T> {
-    private final List<T> seq;
+public class PSeq extends PValue<PSeq> implements PCollection {
+    private final List<PValue<?>> seq;
 
     /**
      * Constructor
      *
      * @param input_seq list of elements
      */
-    public PSeq(List<T> input_seq) {
+    public PSeq(List<PValue<?>> input_seq) {
         seq = new ArrayList<>();
-        for (T entry : input_seq) {
+        for (PValue<?> entry : input_seq) {
             seq.add(PValue.clone(entry));
         }
     }
@@ -29,7 +29,7 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
      *
      * @param other Value to copy from.
      */
-    public PSeq(PSeq<T> other) {
+    public PSeq(PSeq other) {
         this(other.seq);
     }
 
@@ -47,7 +47,7 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
      * @return value at the index
      * @throws InvalidIndexException
      */
-    public T get(PInt index) throws InvalidIndexException {
+    public PValue<?> get(PInt index) throws InvalidIndexException {
         if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
         return seq.get(index.getValue());
     }
@@ -59,11 +59,11 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
      * @param val   value to set to
      * @throws InvalidIndexException
      */
-    public PSeq<T> set(PInt index, T val) throws InvalidIndexException {
+    public PSeq set(PInt index, PValue<?> val) throws InvalidIndexException {
         if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
-        List<T> newSeq = new ArrayList<>(seq);
+        List<PValue<?>> newSeq = new ArrayList<>(seq);
         newSeq.set(index.getValue(), val);
-        return new PSeq<>(newSeq);
+        return new PSeq(newSeq);
     }
 
     /**
@@ -73,11 +73,11 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
      * @param val   value to insert at the index.
      * @throws InvalidIndexException
      */
-    public PSeq<T> add(PInt index, T val) throws InvalidIndexException {
+    public PSeq add(PInt index, PValue<?> val) throws InvalidIndexException {
         if (index.getValue() > seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
-        List<T> newSeq = new ArrayList<>(seq);
+        List newSeq = new ArrayList<>(seq);
         newSeq.add(index.getValue(), val);
-        return new PSeq<>(newSeq);
+        return new PSeq(newSeq);
     }
 
     /**
@@ -86,11 +86,11 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
      * @param index index to remove the value at.
      * @throws InvalidIndexException
      */
-    public PSeq<T> removeAt(PInt index) throws InvalidIndexException {
+    public PSeq removeAt(PInt index) throws InvalidIndexException {
         if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
-        List<T> newSeq = new ArrayList<>(seq);
+        List newSeq = new ArrayList<>(seq);
         newSeq.remove(index.getValue());
-        return new PSeq<>(newSeq);
+        return new PSeq(newSeq);
     }
 
     /**
@@ -98,12 +98,12 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
      *
      * @return List of PValues corresponding to the PSeq.
      */
-    public List<T> toList() {
-        return seq;
+    public List<PValue<?>> toList() {
+        return new ArrayList<>(seq);
     }
 
     @Override
-    public PSeq<T> clone() {
+    public PSeq clone() {
         return new PSeq(seq);
     }
 
@@ -120,7 +120,7 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
             return false;
         }
 
-        PSeq<T> other = (PSeq) obj;
+        PSeq other = (PSeq) obj;
         if (seq.size() != other.seq.size()) {
             return false;
         }
@@ -138,7 +138,7 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         String sep = "";
-        for (T item : seq) {
+        for (PValue<?> item : seq) {
             sb.append(sep);
             sb.append(item);
             sep = ", ";
@@ -153,7 +153,7 @@ public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PColle
     }
 
     @Override
-    public PBool contains(T item) {
+    public PBool contains(PValue<?> item) {
         return new PBool(seq.contains(item));
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -3,7 +3,6 @@ package pexplicit.values;
 import pexplicit.values.exceptions.InvalidIndexException;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -48,7 +47,8 @@ public class PSeq extends PValue<PSeq> implements PCollection {
      * @throws InvalidIndexException
      */
     public PValue<?> get(PInt index) throws InvalidIndexException {
-        if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        if (index.getValue() >= seq.size() || index.getValue() < 0)
+            throw new InvalidIndexException(index.getValue(), this);
         return seq.get(index.getValue());
     }
 
@@ -60,7 +60,8 @@ public class PSeq extends PValue<PSeq> implements PCollection {
      * @throws InvalidIndexException
      */
     public PSeq set(PInt index, PValue<?> val) throws InvalidIndexException {
-        if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        if (index.getValue() >= seq.size() || index.getValue() < 0)
+            throw new InvalidIndexException(index.getValue(), this);
         List<PValue<?>> newSeq = new ArrayList<>(seq);
         newSeq.set(index.getValue(), val);
         return new PSeq(newSeq);
@@ -74,7 +75,8 @@ public class PSeq extends PValue<PSeq> implements PCollection {
      * @throws InvalidIndexException
      */
     public PSeq add(PInt index, PValue<?> val) throws InvalidIndexException {
-        if (index.getValue() > seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        if (index.getValue() > seq.size() || index.getValue() < 0)
+            throw new InvalidIndexException(index.getValue(), this);
         List newSeq = new ArrayList<>(seq);
         newSeq.add(index.getValue(), val);
         return new PSeq(newSeq);
@@ -87,7 +89,8 @@ public class PSeq extends PValue<PSeq> implements PCollection {
      * @throws InvalidIndexException
      */
     public PSeq removeAt(PInt index) throws InvalidIndexException {
-        if (index.getValue() >= seq.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        if (index.getValue() >= seq.size() || index.getValue() < 0)
+            throw new InvalidIndexException(index.getValue(), this);
         List newSeq = new ArrayList<>(seq);
         newSeq.remove(index.getValue());
         return new PSeq(newSeq);
@@ -109,18 +112,17 @@ public class PSeq extends PValue<PSeq> implements PCollection {
 
     @Override
     public int hashCode() {
-        return ComputeHash.getHashCode((Collection<PValue<?>>) seq);
+        return ComputeHash.getHashCode(seq);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 
-        if (!(obj instanceof PSeq)) {
+        if (!(obj instanceof PSeq other)) {
             return false;
         }
 
-        PSeq other = (PSeq) obj;
         if (seq.size() != other.seq.size()) {
             return false;
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -126,7 +126,7 @@ public class PSeq<T extends PValue<T>> extends PCollection<T> {
         }
 
         for (int i = 0; i < seq.size(); i++) {
-            if (!PValue.equals((PValue<?>) other.seq.get(i), (PValue<?>) this.seq.get(i))) {
+            if (PValue.notEqual(other.seq.get(i), this.seq.get(i))) {
                 return false;
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Represents the PValue for P list/sequence
  */
-public class PSeq<T extends PValue<T>> extends PCollection<T> {
+public class PSeq<T extends PValue<T>> extends PValue<PSeq<T>> implements PCollection<T> {
     private final List<T> seq;
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
@@ -8,16 +8,16 @@ import java.util.*;
 /**
  * Represents the PValue for P set
  */
-public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PCollection<T> {
-    private final List<T> entries;
-    private final Set<T> unique_entries;
+public class PSet extends PValue<PSet> implements PCollection {
+    private final List<PValue<?>> entries;
+    private final Set<PValue<?>> unique_entries;
 
     /**
      * Constructor
      *
      * @param input_set the list of PValues to be added in this PSet.
      */
-    public PSet(List<T> input_set) {
+    public PSet(List<PValue<?>> input_set) {
         entries = new ArrayList<>(input_set);
         unique_entries = new HashSet<>(input_set);
     }
@@ -27,7 +27,7 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
      *
      * @param other value to copy from.
      */
-    public PSet(PSet<T> other) {
+    public PSet(PSet other) {
         this(other.entries);
     }
 
@@ -45,7 +45,7 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
      * @return value at the index.
      * @throws InvalidIndexException
      */
-    public T get(PInt index) throws InvalidIndexException {
+    public PValue<?> get(PInt index) throws InvalidIndexException {
         if (index.getValue() >= entries.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
         return entries.get(index.getValue());
     }
@@ -57,7 +57,7 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
      * @param val
      * @throws PExplicitRuntimeException
      */
-    public PSet<T> set(PInt index, T val) throws PExplicitRuntimeException {
+    public PSet set(PInt index, PValue<?> val) throws PExplicitRuntimeException {
         throw new PExplicitRuntimeException("Set value of a set is not allowed!");
     }
 
@@ -66,13 +66,13 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
      *
      * @param val Value to insert at.
      */
-    public PSet<T> add(T val) {
+    public PSet add(PValue<?> val) {
         if (unique_entries.contains(val)) {
             return this;
         }
-        List<T> newEntries = new ArrayList<>(entries);
+        List<PValue<?>> newEntries = new ArrayList<>(entries);
         newEntries.add(val);
-        return new PSet<>(newEntries);
+        return new PSet(newEntries);
     }
 
     /**
@@ -80,13 +80,13 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
      *
      * @param val Value to remove.
      */
-    public PSet<T> remove(T val) {
+    public PSet remove(PValue<?> val) {
         if (!unique_entries.contains(val)) {
             return this;
         }
-        List<T> newEntries = new ArrayList<>(entries);
+        List<PValue<?>> newEntries = new ArrayList<>(entries);
         newEntries.remove(val);
-        return new PSet<>(newEntries);
+        return new PSet(newEntries);
     }
 
     /**
@@ -94,12 +94,12 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
      *
      * @return List of values
      */
-    public List<T> toList() {
-        return entries;
+    public List<PValue<?>> toList() {
+        return new ArrayList<>(entries);
     }
 
     @Override
-    public PSet<T> clone() {
+    public PSet clone() {
         return new PSet(entries);
     }
 
@@ -134,7 +134,7 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
         StringBuilder sb = new StringBuilder();
         sb.append("(");
         String sep = "";
-        for (T item : entries) {
+        for (PValue<?> item : entries) {
             sb.append(sep);
             sb.append(item);
             sep = ", ";
@@ -149,7 +149,7 @@ public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PColle
     }
 
     @Override
-    public PBool contains(T item) {
+    public PBool contains(PValue<?> item) {
         return new PBool(unique_entries.contains(item));
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
@@ -3,7 +3,10 @@ package pexplicit.values;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.exceptions.InvalidIndexException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Represents the PValue for P set
@@ -46,7 +49,8 @@ public class PSet extends PValue<PSet> implements PCollection {
      * @throws InvalidIndexException
      */
     public PValue<?> get(PInt index) throws InvalidIndexException {
-        if (index.getValue() >= entries.size() || index.getValue() < 0) throw new InvalidIndexException(index.getValue(), this);
+        if (index.getValue() >= entries.size() || index.getValue() < 0)
+            throw new InvalidIndexException(index.getValue(), this);
         return entries.get(index.getValue());
     }
 
@@ -105,18 +109,17 @@ public class PSet extends PValue<PSet> implements PCollection {
 
     @Override
     public int hashCode() {
-        return ComputeHash.getHashCode((Collection<PValue<?>>) unique_entries);
+        return ComputeHash.getHashCode(unique_entries);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 
-        if (!(obj instanceof PSet)) {
+        if (!(obj instanceof PSet other)) {
             return false;
         }
 
-        PSet other = (PSet) obj;
         if (unique_entries.size() != other.unique_entries.size()) {
             return false;
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
@@ -8,7 +8,7 @@ import java.util.*;
 /**
  * Represents the PValue for P set
  */
-public class PSet<T extends PValue<T>> extends PCollection<T> {
+public class PSet<T extends PValue<T>> extends PValue<PSet<T>> implements PCollection<T> {
     private final List<T> entries;
     private final Set<T> unique_entries;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
@@ -22,7 +22,7 @@ public class PString extends PValue<PString> {
      */
     public PString(String base, PValue<?> ... args) {
         this.base = base;
-        if (args.length == 0) {
+        if (args == null || args.length == 0) {
             this.args = null;
             this.value = base;
         } else {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
@@ -1,6 +1,7 @@
 package pexplicit.values;
 
 import lombok.Getter;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.text.MessageFormat;
 
@@ -40,6 +41,58 @@ public class PString extends PValue<PString> {
      */
     public PString(PString val) {
         this(val.base, val.args);
+    }
+
+    /**
+     * Concatenation operation
+
+     * @param val PString value to concatenate
+     * @return PString object after operation
+     */
+    public PString add(PString val) {
+        String newBase = this.base.concat(val.base);
+        PValue<?>[] newArgs = ArrayUtils.addAll(this.args, val.args);
+        return new PString(newBase, newArgs);
+    }
+
+    /**
+     * Less than operation
+
+     * @param val PString value to compare to
+     * @return PBool object after operation
+     */
+    public PBool lt(PString val) {
+        return new PBool(this.value.compareTo(val.value) < 0);
+    }
+
+    /**
+     * Less than or equal to operation
+
+     * @param val PString value to compare to
+     * @return PBool object after operation
+     */
+    public PBool le(PString val) {
+        return new PBool(this.value.compareTo(val.value) <= 0);
+    }
+
+    /**
+     * Greater than operation
+
+     * @param val PString value to compare to
+     * @return PBool object after operation
+     */
+    public PBool gt(PString val) {
+        return new PBool(this.value.compareTo(val.value) > 0);
+    }
+
+    /**
+     * Greater than or equal to operation
+
+     * @param val PString value to compare to
+     * @return PBool object after operation
+     */
+    public PBool ge(PString val) {
+        return new PBool(this.value.compareTo(val.value) >= 0);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
@@ -20,7 +20,7 @@ public class PString extends PValue<PString> {
      * @param base Base string.
      * @param args Arguments, if any.
      */
-    public PString(String base, PValue<?> ... args) {
+    public PString(String base, PValue<?>... args) {
         this.base = base;
         if (args == null || args.length == 0) {
             this.args = null;
@@ -45,7 +45,7 @@ public class PString extends PValue<PString> {
 
     /**
      * Concatenation operation
-
+     *
      * @param val PString value to concatenate
      * @return PString object after operation
      */
@@ -57,7 +57,7 @@ public class PString extends PValue<PString> {
 
     /**
      * Less than operation
-
+     *
      * @param val PString value to compare to
      * @return PBool object after operation
      */
@@ -67,7 +67,7 @@ public class PString extends PValue<PString> {
 
     /**
      * Less than or equal to operation
-
+     *
      * @param val PString value to compare to
      * @return PBool object after operation
      */
@@ -77,7 +77,7 @@ public class PString extends PValue<PString> {
 
     /**
      * Greater than operation
-
+     *
      * @param val PString value to compare to
      * @return PBool object after operation
      */
@@ -87,7 +87,7 @@ public class PString extends PValue<PString> {
 
     /**
      * Greater than or equal to operation
-
+     *
      * @param val PString value to compare to
      * @return PBool object after operation
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -3,8 +3,6 @@ package pexplicit.values;
 import pexplicit.values.exceptions.TupleInvalidIndexException;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Represents the PValue for P unnamed tuple
@@ -15,7 +13,7 @@ public class PTuple extends PValue<PTuple> {
     /**
      * Creates a new PTuple with the given fields
      */
-    public PTuple(PValue<?> ... input_fields) {
+    public PTuple(PValue<?>... input_fields) {
         this.fields = new PValue<?>[input_fields.length];
         for (int i = 0; i < input_fields.length; i++) {
             this.fields[i] = PValue.clone(input_fields[i]);
@@ -71,11 +69,10 @@ public class PTuple extends PValue<PTuple> {
     public boolean equals(Object obj) {
         if (obj == this) return true;
 
-        if (!(obj instanceof PTuple)) {
+        if (!(obj instanceof PTuple other)) {
             return false;
         }
 
-        PTuple other = (PTuple) obj;
         if (fields.length != other.fields.length) {
             return false;
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -77,7 +77,7 @@ public class PTuple extends PValue<PTuple> {
         }
 
         for (int i = 0; i < fields.length; i++) {
-            if (PValue.equals(fields[i], other.fields[i])) {
+            if (!PValue.equals(fields[i], other.fields[i])) {
                 return false;
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -13,7 +13,7 @@ public class PTuple extends PValue<PTuple> {
     /**
      * Creates a new PTuple with the given fields
      */
-    public PTuple(PValue<?>[] input_fields) {
+    public PTuple(PValue<?> ... input_fields) {
         this.fields = new PValue<?>[input_fields.length];
         for (int i = 0; i < input_fields.length; i++) {
             this.fields[i] = PValue.clone(input_fields[i]);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -3,6 +3,8 @@ package pexplicit.values;
 import pexplicit.values.exceptions.TupleInvalidIndexException;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents the PValue for P unnamed tuple
@@ -48,9 +50,11 @@ public class PTuple extends PValue<PTuple> {
     /**
      * Sets the field at the given index. Throws an exception if the index is invalid.
      */
-    public void setField(int index, PValue<?> val) throws TupleInvalidIndexException {
+    public PTuple setField(int index, PValue<?> val) throws TupleInvalidIndexException {
         if (index >= fields.length) throw new TupleInvalidIndexException(this, index);
-        fields[index] = val;
+        PValue<?>[] newFields = fields.clone();
+        newFields[index] = val;
+        return new PTuple(newFields);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -77,7 +77,7 @@ public class PTuple extends PValue<PTuple> {
         }
 
         for (int i = 0; i < fields.length; i++) {
-            if (!PValue.equals(fields[i], other.fields[i])) {
+            if (PValue.notEqual(fields[i], other.fields[i])) {
                 return false;
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -30,11 +30,11 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      * @param val2 second PValue
      * @return true if the two values are equal and false otherwise
      */
-    static boolean equals(PValue<?> val1, PValue<?> val2) {
+    static boolean notEqual(PValue<?> val1, PValue<?> val2) {
         if (val1 == null) {
-            return val2 == null;
+            return val2 != null;
         }
-        return val1.equals(val2);
+        return !val1.equals(val2);
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -30,11 +30,22 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      * @param val2 second PValue
      * @return true if the two values are equal and false otherwise
      */
-    static boolean notEqual(PValue<?> val1, PValue<?> val2) {
+    public static boolean isEqual(PValue<?> val1, PValue<?> val2) {
         if (val1 == null) {
-            return val2 != null;
+            return val2 == null;
         }
-        return !val1.equals(val2);
+        return val1.equals(val2);
+    }
+
+    /**
+     * Checks whether two PValues are not equal
+     *
+     * @param val1 first PValue
+     * @param val2 second PValue
+     * @return true if the two values are not equal and false otherwise
+     */
+    public static boolean notEqual(PValue<?> val1, PValue<?> val2) {
+        return !isEqual(val1, val2);
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -32,9 +32,9 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      */
     static boolean equals(PValue<?> val1, PValue<?> val2) {
         if (val1 == null) {
-            return val2 != null;
+            return val2 == null;
         }
-        return !val1.equals(val2);
+        return val1.equals(val2);
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/ComparingPValuesException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/ComparingPValuesException.java
@@ -1,7 +1,6 @@
 package pexplicit.values.exceptions;
 
 import pexplicit.utils.exceptions.BugFoundException;
-import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PValue;
 
 /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/ComparingPValuesException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/ComparingPValuesException.java
@@ -1,12 +1,13 @@
 package pexplicit.values.exceptions;
 
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PValue;
 
 /**
  * Thrown when trying to compare two incompatible PValues.
  */
-public class ComparingPValuesException extends PExplicitRuntimeException {
+public class ComparingPValuesException extends BugFoundException {
     /**
      * Constructor.
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/InvalidIndexException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/InvalidIndexException.java
@@ -1,7 +1,6 @@
 package pexplicit.values.exceptions;
 
 import pexplicit.utils.exceptions.BugFoundException;
-import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PSeq;
 import pexplicit.values.PSet;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/InvalidIndexException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/InvalidIndexException.java
@@ -1,5 +1,6 @@
 package pexplicit.values.exceptions;
 
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PSeq;
 import pexplicit.values.PSet;
@@ -7,7 +8,7 @@ import pexplicit.values.PSet;
 /**
  * Thrown when trying to index into a PSeq/PSet with an invalid index.
  */
-public class InvalidIndexException extends PExplicitRuntimeException {
+public class InvalidIndexException extends BugFoundException {
     /**
      * Constructs a new InvalidIndexException with the specified message.
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/KeyNotFoundException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/KeyNotFoundException.java
@@ -1,7 +1,6 @@
 package pexplicit.values.exceptions;
 
 import pexplicit.utils.exceptions.BugFoundException;
-import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PValue;
 
 import java.util.Map;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/KeyNotFoundException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/KeyNotFoundException.java
@@ -1,5 +1,6 @@
 package pexplicit.values.exceptions;
 
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PValue;
 
@@ -8,7 +9,7 @@ import java.util.Map;
 /**
  * Thrown when a key is not found in a PMap
  */
-public class KeyNotFoundException extends PExplicitRuntimeException {
+public class KeyNotFoundException extends BugFoundException {
 
     /**
      * Constructs a new KeyNotFoundException with the given key and map.

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/NamedTupleFieldNameException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/NamedTupleFieldNameException.java
@@ -1,12 +1,13 @@
 package pexplicit.values.exceptions;
 
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PNamedTuple;
 
 /**
  * Exception to capture the invalid field access for NamedTuples
  */
-public class NamedTupleFieldNameException extends PExplicitRuntimeException {
+public class NamedTupleFieldNameException extends BugFoundException {
 
     /**
      * Constructor for the exception

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/NamedTupleFieldNameException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/NamedTupleFieldNameException.java
@@ -1,7 +1,6 @@
 package pexplicit.values.exceptions;
 
 import pexplicit.utils.exceptions.BugFoundException;
-import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PNamedTuple;
 
 /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/TupleInvalidIndexException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/TupleInvalidIndexException.java
@@ -1,7 +1,6 @@
 package pexplicit.values.exceptions;
 
 import pexplicit.utils.exceptions.BugFoundException;
-import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PTuple;
 
 /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/TupleInvalidIndexException.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/exceptions/TupleInvalidIndexException.java
@@ -1,12 +1,13 @@
 package pexplicit.values.exceptions;
 
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.values.PTuple;
 
 /**
  * Thrown when trying to access a field at an invalid index in a tuple.
  */
-public class TupleInvalidIndexException extends PExplicitRuntimeException {
+public class TupleInvalidIndexException extends BugFoundException {
 
     /**
      * Constructor.

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/PExplicitTestLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/PExplicitTestLogger.java
@@ -1,9 +1,5 @@
 package pexplicit;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Date;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,61 +11,66 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import pexplicit.runtime.logger.Log4JConfig;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+
 /**
  * Represents the logger for mvn test
  */
 public class PExplicitTestLogger {
-  static Logger log = null;
-  static LoggerContext context = null;
+    static Logger log = null;
+    static LoggerContext context = null;
 
-  public static void Initialize(String outputFolder) {
-    log = Log4JConfig.getContext().getLogger(pexplicit.PExplicitTestLogger.class.getName());
-    org.apache.logging.log4j.core.Logger coreLogger =
-        (org.apache.logging.log4j.core.Logger) LogManager.getLogger(pexplicit.PExplicitTestLogger.class.getName());
-    context = coreLogger.getContext();
+    public static void Initialize(String outputFolder) {
+        log = Log4JConfig.getContext().getLogger(pexplicit.PExplicitTestLogger.class.getName());
+        org.apache.logging.log4j.core.Logger coreLogger =
+                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(pexplicit.PExplicitTestLogger.class.getName());
+        context = coreLogger.getContext();
 
-    try {
-      // get new file name
-      Date date = new Date();
-      String fileName = outputFolder + "/test-" + date + ".log";
-      File file = new File(fileName);
-      file.getParentFile().mkdirs();
-      file.createNewFile();
+        try {
+            // get new file name
+            Date date = new Date();
+            String fileName = outputFolder + "/test-" + date + ".log";
+            File file = new File(fileName);
+            file.getParentFile().mkdirs();
+            file.createNewFile();
 
-      // Define new file printer
-      FileOutputStream fout = new FileOutputStream(fileName, false);
+            // Define new file printer
+            FileOutputStream fout = new FileOutputStream(fileName, false);
 
-      PatternLayout layout = Log4JConfig.getPatternLayout();
-      Appender fileAppender =
-          OutputStreamAppender.createAppender(layout, null, fout, fileName, false, true);
-      ConsoleAppender consoleAppender = ConsoleAppender.createDefaultAppenderForLayout(layout);
-      fileAppender.start();
-      consoleAppender.start();
+            PatternLayout layout = Log4JConfig.getPatternLayout();
+            Appender fileAppender =
+                    OutputStreamAppender.createAppender(layout, null, fout, fileName, false, true);
+            ConsoleAppender consoleAppender = ConsoleAppender.createDefaultAppenderForLayout(layout);
+            fileAppender.start();
+            consoleAppender.start();
 
-      context.getConfiguration().addLoggerAppender(coreLogger, fileAppender);
-      context.getConfiguration().addLoggerAppender(coreLogger, consoleAppender);
-    } catch (IOException e) {
-      System.out.println("Failed to set printer to the PSymTestLogger!!");
+            context.getConfiguration().addLoggerAppender(coreLogger, fileAppender);
+            context.getConfiguration().addLoggerAppender(coreLogger, consoleAppender);
+        } catch (IOException e) {
+            System.out.println("Failed to set printer to the PSymTestLogger!!");
+        }
     }
-  }
 
-  public static void disable() {
-    Configurator.setLevel(pexplicit.PExplicitTestLogger.class.getName(), Level.OFF);
-  }
+    public static void disable() {
+        Configurator.setLevel(pexplicit.PExplicitTestLogger.class.getName(), Level.OFF);
+    }
 
-  public static void enable() {
-    Configurator.setLevel(pexplicit.PExplicitTestLogger.class.getName(), Level.ALL);
-  }
+    public static void enable() {
+        Configurator.setLevel(pexplicit.PExplicitTestLogger.class.getName(), Level.ALL);
+    }
 
-  public static void log(String message) {
-    log.info(message);
-  }
+    public static void log(String message) {
+        log.info(message);
+    }
 
-  public static void warn(String message) {
-    log.warn(message);
-  }
+    public static void warn(String message) {
+        log.warn(message);
+    }
 
-  public static void error(String message) {
-    log.error(message);
-  }
+    public static void error(String message) {
+        log.error(message);
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/PExplicitTestLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/PExplicitTestLogger.java
@@ -1,0 +1,75 @@
+package pexplicit;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.OutputStreamAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import pexplicit.runtime.logger.Log4JConfig;
+
+/**
+ * Represents the logger for mvn test
+ */
+public class PExplicitTestLogger {
+  static Logger log = null;
+  static LoggerContext context = null;
+
+  public static void Initialize(String outputFolder) {
+    log = Log4JConfig.getContext().getLogger(pexplicit.PExplicitTestLogger.class.getName());
+    org.apache.logging.log4j.core.Logger coreLogger =
+        (org.apache.logging.log4j.core.Logger) LogManager.getLogger(pexplicit.PExplicitTestLogger.class.getName());
+    context = coreLogger.getContext();
+
+    try {
+      // get new file name
+      Date date = new Date();
+      String fileName = outputFolder + "/test-" + date + ".log";
+      File file = new File(fileName);
+      file.getParentFile().mkdirs();
+      file.createNewFile();
+
+      // Define new file printer
+      FileOutputStream fout = new FileOutputStream(fileName, false);
+
+      PatternLayout layout = Log4JConfig.getPatternLayout();
+      Appender fileAppender =
+          OutputStreamAppender.createAppender(layout, null, fout, fileName, false, true);
+      ConsoleAppender consoleAppender = ConsoleAppender.createDefaultAppenderForLayout(layout);
+      fileAppender.start();
+      consoleAppender.start();
+
+      context.getConfiguration().addLoggerAppender(coreLogger, fileAppender);
+      context.getConfiguration().addLoggerAppender(coreLogger, consoleAppender);
+    } catch (IOException e) {
+      System.out.println("Failed to set printer to the PSymTestLogger!!");
+    }
+  }
+
+  public static void disable() {
+    Configurator.setLevel(pexplicit.PExplicitTestLogger.class.getName(), Level.OFF);
+  }
+
+  public static void enable() {
+    Configurator.setLevel(pexplicit.PExplicitTestLogger.class.getName(), Level.ALL);
+  }
+
+  public static void log(String message) {
+    log.info(message);
+  }
+
+  public static void warn(String message) {
+    log.warn(message);
+  }
+
+  public static void error(String message) {
+    log.error(message);
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestCaseExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestCaseExecutor.java
@@ -1,0 +1,207 @@
+package pexplicit;
+
+import java.io.*;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+
+public class TestCaseExecutor {
+  private static int testCounter = 0;
+
+  /**
+   * @param testCasePaths paths to test case; only accepts list of p files
+   * @return 0 = successful, 1 = compile error, 2 = dynamic error
+   */
+  static int runTestCase(
+      List<String> testCasePaths,
+      String testCasePathPrefix,
+      String runArgs,
+      String mainOutputDirectory,
+      int expected) {
+    int resultCode;
+
+    testCounter++;
+
+    // Invoke the P compiler to compile the test Case
+    boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+    String compilerDirectory = "../../../Bld/Drops/Release/Binaries/net8.0/p.dll";
+
+    assert testCasePaths.stream().allMatch(p -> p.contains(testCasePathPrefix));
+    String testName = testCasePathPrefix.substring(testCasePathPrefix.lastIndexOf("/") + 1);
+    if (testName.isEmpty()) {
+      List<String> testCaseRelPaths =
+          testCasePaths.stream()
+              .map(p -> p.substring(p.indexOf(testCasePathPrefix) + testCasePathPrefix.length()))
+              .collect(Collectors.toList());
+      testName = Paths.get(testCaseRelPaths.get(0)).getFileName().toString();
+    }
+    testName = testName.replaceAll("_", "");
+    testName = testName.replaceAll("-", "");
+
+    String outputDirectory = mainOutputDirectory + "/" + testName;
+    recreateDirectory(outputDirectory);
+    PExplicitTestLogger.log(String.format("  [%d] %s", testCounter, testName));
+
+    List<String> pTestCasePaths =
+        testCasePaths.stream().filter(p -> p.contains(".p")).collect(Collectors.toList());
+    String testCasePathsString = String.join(" ", pTestCasePaths);
+
+    Process process;
+    try {
+      String pCompileCommand =
+          String.format(
+              "dotnet %s compile --mode explicit --projname %s --outdir %s --pfiles %s",
+              compilerDirectory, testName, outputDirectory, testCasePathsString);
+      PExplicitTestLogger.log("      compiling");
+      process = buildCompileProcess(pCompileCommand, outputDirectory);
+
+      StreamGobbler errorStreamGobbler =
+          new StreamGobbler(process.getErrorStream(), System.out::println);
+      Executors.newSingleThreadExecutor().submit(errorStreamGobbler);
+      StreamGobbler streamGobbler =
+          new StreamGobbler(process.getInputStream(), System.out::println);
+      Executors.newSingleThreadExecutor().submit(streamGobbler);
+      resultCode = process.waitFor();
+    } catch (IOException | InterruptedException e) {
+      e.printStackTrace();
+      resultCode = -1;
+    }
+
+    String pathToJar =
+        outputDirectory + "/PExplicit/target/" + testName + "-jar-with-dependencies.jar";
+
+    File jarFile = new File(pathToJar);
+    if (!jarFile.exists() || jarFile.isDirectory()) {
+      resultCode = 1;
+    }
+
+    if (resultCode != 0) {
+      PExplicitTestLogger.log("      compile-fail");
+      if (resultCode != expected) {
+        PExplicitTestLogger.log(
+            String.format(
+                "      unexpected result for %s (expected: %d, got: %d)",
+                testCasePathPrefix, expected, resultCode));
+      }
+      return resultCode;
+    }
+
+    // Next, try to dynamically load and compile this file
+    try {
+      int seed = Math.abs((new Random()).nextInt());
+      String runJarCommand =
+          String.format(
+              "dotnet %s check %s --mode explicit --outdir %s --seed %d %s",
+              compilerDirectory, pathToJar, outputDirectory, seed, runArgs);
+      PExplicitTestLogger.log(String.format("      running with seed %d", seed));
+      process = buildRunProcess(runJarCommand, outputDirectory);
+
+      StreamGobbler streamGobbler =
+          new StreamGobbler(process.getErrorStream(), System.out::println);
+      Executors.newSingleThreadExecutor().submit(streamGobbler);
+      StreamGobbler outstreamGobbler =
+          new StreamGobbler(process.getInputStream(), System.out::println);
+      Executors.newSingleThreadExecutor().submit(outstreamGobbler);
+      resultCode = process.waitFor();
+
+      if (resultCode == 0) {
+        PExplicitTestLogger.log("      ok");
+      } else if (resultCode == 2) {
+        PExplicitTestLogger.log("      bug");
+      } else if (resultCode == 3) {
+        PExplicitTestLogger.log("      timeout");
+      } else if (resultCode == 4) {
+        PExplicitTestLogger.log("      memout");
+      } else {
+        PExplicitTestLogger.log("      error");
+      }
+    } catch (IOException | InterruptedException e) {
+      PExplicitTestLogger.error("      fail");
+      e.printStackTrace();
+      resultCode = -1;
+    }
+    if (resultCode != expected) {
+      PExplicitTestLogger.log(
+          String.format(
+              "      unexpected result for %s (expected: %d, got: %d)",
+              testCasePathPrefix, expected, resultCode));
+    }
+    return resultCode;
+  }
+
+  /**
+   * A method to build a new Process object for given compile command.
+   *
+   * @param cmd Jar command as string
+   * @param outFolder output folder
+   * @return A new process for the given task
+   * @throws IOException
+   */
+  private static Process buildCompileProcess(String cmd, String outFolder) throws IOException {
+    ProcessBuilder builder = new ProcessBuilder(cmd.split(" "));
+    File outFile = new File(outFolder + "/compile.out");
+    outFile.getParentFile().mkdirs();
+    outFile.createNewFile();
+    builder.redirectOutput(outFile);
+
+    File errFile = new File(outFolder + "/compiler.err");
+    errFile.getParentFile().mkdirs();
+    errFile.createNewFile();
+    builder.redirectError(errFile);
+    return builder.start();
+  }
+
+  /**
+   * A method to build a new Process object for given run command.
+   *
+   * @param cmd Jar command as string
+   * @param outFolder output folder
+   * @return A new process for the given task
+   * @throws IOException
+   */
+  private static Process buildRunProcess(String cmd, String outFolder) throws IOException {
+    ProcessBuilder builder = new ProcessBuilder(cmd.split("\\s+"));
+    File outFile = new File(outFolder + "/run.out");
+    outFile.getParentFile().mkdirs();
+    outFile.createNewFile();
+    builder.redirectOutput(outFile);
+
+    File errFile = new File(outFolder + "/run.err");
+    errFile.getParentFile().mkdirs();
+    errFile.createNewFile();
+    builder.redirectError(errFile);
+    return builder.start();
+  }
+
+  private static void recreateDirectory(String dir) {
+    try {
+      File f = new File(dir);
+      if (f.isDirectory()) {
+        FileUtils.cleanDirectory(f); // clean out directory (this is optional -- but good know)
+        FileUtils.forceDelete(f); // delete directory
+      }
+      FileUtils.forceMkdir(f); // create directory
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static class StreamGobbler implements Runnable {
+    private final InputStream inputStream;
+    private final Consumer<String> consumer;
+
+    StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
+      this.inputStream = inputStream;
+      this.consumer = consumer;
+    }
+
+    @Override
+    public void run() {
+      new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
+    }
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestCaseExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestCaseExecutor.java
@@ -114,6 +114,7 @@ public class TestCaseExecutor {
         PExplicitTestLogger.log("      bug");
       } else if (resultCode == 3) {
         PExplicitTestLogger.log("      timeout");
+        resultCode = 0;
       } else if (resultCode == 4) {
         PExplicitTestLogger.log("      memout");
       } else {

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestCaseExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestCaseExecutor.java
@@ -1,5 +1,7 @@
 package pexplicit;
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.*;
 import java.nio.file.Paths;
 import java.util.List;
@@ -7,202 +9,201 @@ import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.apache.commons.io.FileUtils;
 
 public class TestCaseExecutor {
-  private static int testCounter = 0;
+    private static int testCounter = 0;
 
-  /**
-   * @param testCasePaths paths to test case; only accepts list of p files
-   * @return 0 = successful, 1 = compile error, 2 = dynamic error
-   */
-  static int runTestCase(
-      List<String> testCasePaths,
-      String testCasePathPrefix,
-      String runArgs,
-      String mainOutputDirectory,
-      int expected) {
-    int resultCode;
+    /**
+     * @param testCasePaths paths to test case; only accepts list of p files
+     * @return 0 = successful, 1 = compile error, 2 = dynamic error
+     */
+    static int runTestCase(
+            List<String> testCasePaths,
+            String testCasePathPrefix,
+            String runArgs,
+            String mainOutputDirectory,
+            int expected) {
+        int resultCode;
 
-    testCounter++;
+        testCounter++;
 
-    // Invoke the P compiler to compile the test Case
-    boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
-    String compilerDirectory = "../../../Bld/Drops/Release/Binaries/net8.0/p.dll";
+        // Invoke the P compiler to compile the test Case
+        boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        String compilerDirectory = "../../../Bld/Drops/Release/Binaries/net8.0/p.dll";
 
-    assert testCasePaths.stream().allMatch(p -> p.contains(testCasePathPrefix));
-    String testName = testCasePathPrefix.substring(testCasePathPrefix.lastIndexOf("/") + 1);
-    if (testName.isEmpty()) {
-      List<String> testCaseRelPaths =
-          testCasePaths.stream()
-              .map(p -> p.substring(p.indexOf(testCasePathPrefix) + testCasePathPrefix.length()))
-              .collect(Collectors.toList());
-      testName = Paths.get(testCaseRelPaths.get(0)).getFileName().toString();
-    }
-    testName = testName.replaceAll("_", "");
-    testName = testName.replaceAll("-", "");
+        assert testCasePaths.stream().allMatch(p -> p.contains(testCasePathPrefix));
+        String testName = testCasePathPrefix.substring(testCasePathPrefix.lastIndexOf("/") + 1);
+        if (testName.isEmpty()) {
+            List<String> testCaseRelPaths =
+                    testCasePaths.stream()
+                            .map(p -> p.substring(p.indexOf(testCasePathPrefix) + testCasePathPrefix.length()))
+                            .collect(Collectors.toList());
+            testName = Paths.get(testCaseRelPaths.get(0)).getFileName().toString();
+        }
+        testName = testName.replaceAll("_", "");
+        testName = testName.replaceAll("-", "");
 
-    String outputDirectory = mainOutputDirectory + "/" + testName;
-    recreateDirectory(outputDirectory);
-    PExplicitTestLogger.log(String.format("  [%d] %s", testCounter, testName));
+        String outputDirectory = mainOutputDirectory + "/" + testName;
+        recreateDirectory(outputDirectory);
+        PExplicitTestLogger.log(String.format("  [%d] %s", testCounter, testName));
 
-    List<String> pTestCasePaths =
-        testCasePaths.stream().filter(p -> p.contains(".p")).collect(Collectors.toList());
-    String testCasePathsString = String.join(" ", pTestCasePaths);
+        List<String> pTestCasePaths =
+                testCasePaths.stream().filter(p -> p.contains(".p")).collect(Collectors.toList());
+        String testCasePathsString = String.join(" ", pTestCasePaths);
 
-    Process process;
-    try {
-      String pCompileCommand =
-          String.format(
-              "dotnet %s compile --mode explicit --projname %s --outdir %s --pfiles %s",
-              compilerDirectory, testName, outputDirectory, testCasePathsString);
-      PExplicitTestLogger.log("      compiling");
-      process = buildCompileProcess(pCompileCommand, outputDirectory);
+        Process process;
+        try {
+            String pCompileCommand =
+                    String.format(
+                            "dotnet %s compile --mode explicit --projname %s --outdir %s --pfiles %s",
+                            compilerDirectory, testName, outputDirectory, testCasePathsString);
+            PExplicitTestLogger.log("      compiling");
+            process = buildCompileProcess(pCompileCommand, outputDirectory);
 
-      StreamGobbler errorStreamGobbler =
-          new StreamGobbler(process.getErrorStream(), System.out::println);
-      Executors.newSingleThreadExecutor().submit(errorStreamGobbler);
-      StreamGobbler streamGobbler =
-          new StreamGobbler(process.getInputStream(), System.out::println);
-      Executors.newSingleThreadExecutor().submit(streamGobbler);
-      resultCode = process.waitFor();
-    } catch (IOException | InterruptedException e) {
-      e.printStackTrace();
-      resultCode = -1;
-    }
+            StreamGobbler errorStreamGobbler =
+                    new StreamGobbler(process.getErrorStream(), System.out::println);
+            Executors.newSingleThreadExecutor().submit(errorStreamGobbler);
+            StreamGobbler streamGobbler =
+                    new StreamGobbler(process.getInputStream(), System.out::println);
+            Executors.newSingleThreadExecutor().submit(streamGobbler);
+            resultCode = process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+            resultCode = -1;
+        }
 
-    String pathToJar =
-        outputDirectory + "/PExplicit/target/" + testName + "-jar-with-dependencies.jar";
+        String pathToJar =
+                outputDirectory + "/PExplicit/target/" + testName + "-jar-with-dependencies.jar";
 
-    File jarFile = new File(pathToJar);
-    if (!jarFile.exists() || jarFile.isDirectory()) {
-      resultCode = 1;
-    }
+        File jarFile = new File(pathToJar);
+        if (!jarFile.exists() || jarFile.isDirectory()) {
+            resultCode = 1;
+        }
 
-    if (resultCode != 0) {
-      PExplicitTestLogger.log("      compile-fail");
-      if (resultCode != expected) {
-        PExplicitTestLogger.log(
-            String.format(
-                "      unexpected result for %s (expected: %d, got: %d)",
-                testCasePathPrefix, expected, resultCode));
-      }
-      return resultCode;
-    }
+        if (resultCode != 0) {
+            PExplicitTestLogger.log("      compile-fail");
+            if (resultCode != expected) {
+                PExplicitTestLogger.log(
+                        String.format(
+                                "      unexpected result for %s (expected: %d, got: %d)",
+                                testCasePathPrefix, expected, resultCode));
+            }
+            return resultCode;
+        }
 
-    // Next, try to dynamically load and compile this file
-    try {
-      int seed = Math.abs((new Random()).nextInt());
-      String runJarCommand =
-          String.format(
-              "dotnet %s check %s --mode explicit --outdir %s --seed %d %s",
-              compilerDirectory, pathToJar, outputDirectory, seed, runArgs);
-      PExplicitTestLogger.log(String.format("      running with seed %d", seed));
-      process = buildRunProcess(runJarCommand, outputDirectory);
+        // Next, try to dynamically load and compile this file
+        try {
+            int seed = Math.abs((new Random()).nextInt());
+            String runJarCommand =
+                    String.format(
+                            "dotnet %s check %s --mode explicit --outdir %s --seed %d %s",
+                            compilerDirectory, pathToJar, outputDirectory, seed, runArgs);
+            PExplicitTestLogger.log(String.format("      running with seed %d", seed));
+            process = buildRunProcess(runJarCommand, outputDirectory);
 
-      StreamGobbler streamGobbler =
-          new StreamGobbler(process.getErrorStream(), System.out::println);
-      Executors.newSingleThreadExecutor().submit(streamGobbler);
-      StreamGobbler outstreamGobbler =
-          new StreamGobbler(process.getInputStream(), System.out::println);
-      Executors.newSingleThreadExecutor().submit(outstreamGobbler);
-      resultCode = process.waitFor();
+            StreamGobbler streamGobbler =
+                    new StreamGobbler(process.getErrorStream(), System.out::println);
+            Executors.newSingleThreadExecutor().submit(streamGobbler);
+            StreamGobbler outstreamGobbler =
+                    new StreamGobbler(process.getInputStream(), System.out::println);
+            Executors.newSingleThreadExecutor().submit(outstreamGobbler);
+            resultCode = process.waitFor();
 
-      if (resultCode == 0) {
-        PExplicitTestLogger.log("      ok");
-      } else if (resultCode == 2) {
-        PExplicitTestLogger.log("      bug");
-      } else if (resultCode == 3) {
-        PExplicitTestLogger.log("      timeout");
-        resultCode = 0;
-      } else if (resultCode == 4) {
-        PExplicitTestLogger.log("      memout");
-      } else {
-        PExplicitTestLogger.log("      error");
-      }
-    } catch (IOException | InterruptedException e) {
-      PExplicitTestLogger.error("      fail");
-      e.printStackTrace();
-      resultCode = -1;
-    }
-    if (resultCode != expected) {
-      PExplicitTestLogger.log(
-          String.format(
-              "      unexpected result for %s (expected: %d, got: %d)",
-              testCasePathPrefix, expected, resultCode));
-    }
-    return resultCode;
-  }
-
-  /**
-   * A method to build a new Process object for given compile command.
-   *
-   * @param cmd Jar command as string
-   * @param outFolder output folder
-   * @return A new process for the given task
-   * @throws IOException
-   */
-  private static Process buildCompileProcess(String cmd, String outFolder) throws IOException {
-    ProcessBuilder builder = new ProcessBuilder(cmd.split(" "));
-    File outFile = new File(outFolder + "/compile.out");
-    outFile.getParentFile().mkdirs();
-    outFile.createNewFile();
-    builder.redirectOutput(outFile);
-
-    File errFile = new File(outFolder + "/compiler.err");
-    errFile.getParentFile().mkdirs();
-    errFile.createNewFile();
-    builder.redirectError(errFile);
-    return builder.start();
-  }
-
-  /**
-   * A method to build a new Process object for given run command.
-   *
-   * @param cmd Jar command as string
-   * @param outFolder output folder
-   * @return A new process for the given task
-   * @throws IOException
-   */
-  private static Process buildRunProcess(String cmd, String outFolder) throws IOException {
-    ProcessBuilder builder = new ProcessBuilder(cmd.split("\\s+"));
-    File outFile = new File(outFolder + "/run.out");
-    outFile.getParentFile().mkdirs();
-    outFile.createNewFile();
-    builder.redirectOutput(outFile);
-
-    File errFile = new File(outFolder + "/run.err");
-    errFile.getParentFile().mkdirs();
-    errFile.createNewFile();
-    builder.redirectError(errFile);
-    return builder.start();
-  }
-
-  private static void recreateDirectory(String dir) {
-    try {
-      File f = new File(dir);
-      if (f.isDirectory()) {
-        FileUtils.cleanDirectory(f); // clean out directory (this is optional -- but good know)
-        FileUtils.forceDelete(f); // delete directory
-      }
-      FileUtils.forceMkdir(f); // create directory
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-  }
-
-  private static class StreamGobbler implements Runnable {
-    private final InputStream inputStream;
-    private final Consumer<String> consumer;
-
-    StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
-      this.inputStream = inputStream;
-      this.consumer = consumer;
+            if (resultCode == 0) {
+                PExplicitTestLogger.log("      ok");
+            } else if (resultCode == 2) {
+                PExplicitTestLogger.log("      bug");
+            } else if (resultCode == 3) {
+                PExplicitTestLogger.log("      timeout");
+                resultCode = 0;
+            } else if (resultCode == 4) {
+                PExplicitTestLogger.log("      memout");
+            } else {
+                PExplicitTestLogger.log("      error");
+            }
+        } catch (IOException | InterruptedException e) {
+            PExplicitTestLogger.error("      fail");
+            e.printStackTrace();
+            resultCode = -1;
+        }
+        if (resultCode != expected) {
+            PExplicitTestLogger.log(
+                    String.format(
+                            "      unexpected result for %s (expected: %d, got: %d)",
+                            testCasePathPrefix, expected, resultCode));
+        }
+        return resultCode;
     }
 
-    @Override
-    public void run() {
-      new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
+    /**
+     * A method to build a new Process object for given compile command.
+     *
+     * @param cmd       Jar command as string
+     * @param outFolder output folder
+     * @return A new process for the given task
+     * @throws IOException
+     */
+    private static Process buildCompileProcess(String cmd, String outFolder) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(cmd.split(" "));
+        File outFile = new File(outFolder + "/compile.out");
+        outFile.getParentFile().mkdirs();
+        outFile.createNewFile();
+        builder.redirectOutput(outFile);
+
+        File errFile = new File(outFolder + "/compiler.err");
+        errFile.getParentFile().mkdirs();
+        errFile.createNewFile();
+        builder.redirectError(errFile);
+        return builder.start();
     }
-  }
+
+    /**
+     * A method to build a new Process object for given run command.
+     *
+     * @param cmd       Jar command as string
+     * @param outFolder output folder
+     * @return A new process for the given task
+     * @throws IOException
+     */
+    private static Process buildRunProcess(String cmd, String outFolder) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(cmd.split("\\s+"));
+        File outFile = new File(outFolder + "/run.out");
+        outFile.getParentFile().mkdirs();
+        outFile.createNewFile();
+        builder.redirectOutput(outFile);
+
+        File errFile = new File(outFolder + "/run.err");
+        errFile.getParentFile().mkdirs();
+        errFile.createNewFile();
+        builder.redirectError(errFile);
+        return builder.start();
+    }
+
+    private static void recreateDirectory(String dir) {
+        try {
+            File f = new File(dir);
+            if (f.isDirectory()) {
+                FileUtils.cleanDirectory(f); // clean out directory (this is optional -- but good know)
+                FileUtils.forceDelete(f); // delete directory
+            }
+            FileUtils.forceMkdir(f); // create directory
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static class StreamGobbler implements Runnable {
+        private final InputStream inputStream;
+        private final Consumer<String> consumer;
+
+        StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
+            this.inputStream = inputStream;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void run() {
+            new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
+        }
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -92,7 +92,7 @@ public class TestPExplicit {
     /**
      * TODO: Null events
      */
-    // TODO: Null actions are not supported
+    // TODO: Null events are not supported
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/BugRepro");
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/MoreThan32Events");
     excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_36");
@@ -109,6 +109,15 @@ public class TestPExplicit {
     excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_19");
     excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_9");
     excluded.add("../../../Tst/RegressionTests/Integration/Correct/openwsn1");
+    // TODO: Null events are not supported, found in a receive statement
+    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive2");
+    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive7");
+
+    /**
+     * TODO: Deadlock detected
+     */
+    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive6");
+
 
 
 

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -58,6 +58,8 @@ public class TestPExplicit {
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug4");
     // TODO: Cannot yet handle casting to variable of type (machine,machine) from value of type any
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/PingPong");
+    // TODO: Cannot yet handle casting to variable of type int from value of type any
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/two-phase-commit_1");
 
     /**
      * TODO: Null events
@@ -65,6 +67,21 @@ public class TestPExplicit {
     // TODO: Null actions are not supported
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/BugRepro");
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/MoreThan32Events");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_36");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_37");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_38");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_39");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_41");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_42");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_10");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_12");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_16");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_17");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_18");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_19");
+    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_9");
+    excluded.add("../../../Tst/RegressionTests/Integration/Correct/openwsn1");
+
 
 
 

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -70,6 +70,21 @@ public class TestPExplicit {
     excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ExprOperatorsAsserts");
     // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
     excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval");
+    // TODO: Cannot yet handle casting to variable of type int from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs1");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs2");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs3");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs4");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs5");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs6");
+    // TODO: Cannot yet handle casting to variable of type Foo from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/EnumType1");
+    // TODO: Cannot yet handle casting to variable of type event from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes");
+    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes1");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes10");
+    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes14");
 
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -50,6 +50,24 @@ public class TestPExplicit {
   }
 
   private static void createExcludeList() {
+    /**
+     * TODO: Support type casting
+     */
+    // TODO: Cannot yet handle casting to variable of type (int,int) from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug3");
+    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug4");
+    // TODO: Cannot yet handle casting to variable of type (machine,machine) from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/PingPong");
+
+    /**
+     * TODO: Null events
+     */
+    // TODO: Null actions are not supported
+    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/BugRepro");
+    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/MoreThan32Events");
+
+
+
   }
 
   private static void initialize() {

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -50,41 +50,43 @@ public class TestPExplicit {
   }
 
   private static void createExcludeList() {
-    /**
-     * TODO: Support type casting
-     */
-    // TODO: Cannot yet handle casting to variable of type (int,int) from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug3");
-    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug4");
-    // TODO: Cannot yet handle casting to variable of type (machine,machine) from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/PingPong");
-    // TODO: Cannot yet handle casting to variable of type int from value of type any
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/two-phase-commit_1");
-    // TODO: Cannot yet handle casting to variable of type int from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast1");
-    // TODO: Cannot yet handle casting to variable of type int from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast2");
-    // TODO: Cannot yet handle casting to variable of type (m1:machine,m2:machine) from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast3");
-    // TODO: Cannot yet handle casting to variable of type event from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ExprOperatorsAsserts");
-    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
-    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval");
-    // TODO: Cannot yet handle casting to variable of type int from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs1");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs2");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs3");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs4");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs5");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs6");
-    // TODO: Cannot yet handle casting to variable of type Foo from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/EnumType1");
-    // TODO: Cannot yet handle casting to variable of type event from value of type any
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes");
-    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes1");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes10");
-    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes14");
+//    /**
+//     * TODO: Support type casting
+//     */
+//    // TODO: Cannot yet handle casting to variable of type (int,int) from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug3");
+//    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug4");
+//    // TODO: Cannot yet handle casting to variable of type (machine,machine) from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/PingPong");
+//    // TODO: Cannot yet handle casting to variable of type int from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/two-phase-commit_1");
+//    // TODO: Cannot yet handle casting to variable of type int from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast1");
+//    // TODO: Cannot yet handle casting to variable of type int from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast2");
+//    // TODO: Cannot yet handle casting to variable of type (m1:machine,m2:machine) from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast3");
+//    // TODO: Cannot yet handle casting to variable of type event from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ExprOperatorsAsserts");
+//    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
+//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval");
+//    // TODO: Cannot yet handle casting to variable of type int from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs1");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs2");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs3");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs4");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs5");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs6");
+//    // TODO: Cannot yet handle casting to variable of type Foo from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/EnumType1");
+//    // TODO: Cannot yet handle casting to variable of type event from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes");
+//    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes1");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes10");
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes14");
+//    // TODO: Cannot yet handle casting to variable of type (first:int,second:int) from value of type any
+//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/typedef2");
 
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -112,13 +112,18 @@ public class TestPExplicit {
     // TODO: Null events are not supported, found in a receive statement
     excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive2");
     excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive7");
+    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive10");
+    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive11");
+    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive12");
 
     /**
      * TODO: Deadlock detected
      */
     excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive6");
 
-
+    /**
+     * TODO: Run liveness tests
+     */
 
 
 
@@ -267,9 +272,9 @@ public class TestPExplicit {
   //        return loadTests("../../../Tst/RegressionTests/Feature5ModuleSystem");
   //    }
 
-  @TestFactory
-  //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  Collection<DynamicTest>  loadLivenessTests() {
-      return loadTests("../../../Tst/RegressionTests/Liveness");
-  }
+//  @TestFactory
+//  //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+//  Collection<DynamicTest>  loadLivenessTests() {
+//      return loadTests("../../../Tst/RegressionTests/Liveness");
+//  }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -1,6 +1,10 @@
 package pexplicit;
 
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.function.Executable;
+import pexplicit.runtime.logger.Log4JConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,267 +15,223 @@ import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.api.function.Executable;
-import pexplicit.runtime.logger.Log4JConfig;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 /**
  * Runner for PExplicit regressions.
  */
 public class TestPExplicit {
-  private static final String outputDirectory = "output/testCases";
-  private static final List<String> excluded = new ArrayList<>();
-  private static String timeout = "60";
-  private static String schedules = "100";
-  private static String maxSteps = "300";
-  private static String runArgs = "--sch-coverage dfs";
-  private static boolean initialized = false;
+    private static final String outputDirectory = "output/testCases";
+    private static final List<String> excluded = new ArrayList<>();
+    private static String timeout = "60";
+    private static String schedules = "100";
+    private static String maxSteps = "300";
+    private static String runArgs = "--sch-coverage dfs";
+    private static boolean initialized = false;
 
-  private static void setRunArgs() {
-    String to = System.getProperty("timeout");
-    String it = System.getProperty("schedules");
-    String ms = System.getProperty("max.steps");
+    private static void setRunArgs() {
+        String to = System.getProperty("timeout");
+        String it = System.getProperty("schedules");
+        String ms = System.getProperty("max.steps");
 
-    if (to != null && !to.isEmpty()) {
-      timeout = to;
-    }
-    if (it != null && !it.isEmpty()) {
-      schedules = it;
-    }
-    if (ms != null && !ms.isEmpty()) {
-      maxSteps = ms;
-    }
-
-    runArgs += String.format(" --timeout %s --schedules %s --max-steps %s", timeout, schedules, maxSteps);
-
-    PExplicitTestLogger.log(String.format("Running with arguments:  %s", runArgs));
-  }
-
-  private static void createExcludeList() {
-//    /**
-//     * TODO: Support type casting
-//     */
-//    // TODO: Cannot yet handle casting to variable of type (int,int) from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug3");
-//    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/bug4");
-//    // TODO: Cannot yet handle casting to variable of type (machine,machine) from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/PingPong");
-//    // TODO: Cannot yet handle casting to variable of type int from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/two-phase-commit_1");
-//    // TODO: Cannot yet handle casting to variable of type int from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast1");
-//    // TODO: Cannot yet handle casting to variable of type int from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast2");
-//    // TODO: Cannot yet handle casting to variable of type (m1:machine,m2:machine) from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast3");
-//    // TODO: Cannot yet handle casting to variable of type event from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ExprOperatorsAsserts");
-//    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
-//    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval");
-//    // TODO: Cannot yet handle casting to variable of type int from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs1");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs2");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs3");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs4");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs5");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/CastInExprs6");
-//    // TODO: Cannot yet handle casting to variable of type Foo from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/EnumType1");
-//    // TODO: Cannot yet handle casting to variable of type event from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes");
-//    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes1");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes10");
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/nonAtomicDataTypes14");
-//    // TODO: Cannot yet handle casting to variable of type (first:int,second:int) from value of type any
-//    excluded.add("../../../Tst/RegressionTests/Feature4DataTypes/DynamicError/typedef2");
-
-
-    /**
-     * TODO: Null events
-     */
-    // TODO: Null events are not supported
-    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/BugRepro");
-    excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/MoreThan32Events");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_36");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_37");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_38");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_39");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_41");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_42");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_10");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_12");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_16");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_17");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_18");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_19");
-    excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_9");
-    excluded.add("../../../Tst/RegressionTests/Integration/Correct/openwsn1");
-    // TODO: Null events are not supported, found in a receive statement
-    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive2");
-    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive7");
-    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive10");
-    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive11");
-    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive12");
-
-    /**
-     * TODO: Deadlock detected
-     */
-    excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive6");
-
-    /**
-     * TODO: Run liveness tests
-     */
-
-
-
-  }
-
-  private static void initialize() {
-    Log4JConfig.configureLog4J();
-    PExplicitTestLogger.Initialize(outputDirectory);
-    setRunArgs();
-    createExcludeList();
-    initialized = true;
-  }
-
-  Map<String, List<String>> getFiles(String testDirPath) {
-    Map<String, List<String>> result = new HashMap<>();
-    File[] directories = new File(testDirPath).listFiles(File::isDirectory);
-    for (File dir : directories) {
-      if (excluded.stream().anyMatch(dir.toString()::equals)) {
-        continue;
-      }
-      try (Stream<Path> walk = Files.walk(Paths.get(dir.toURI()))) {
-        Stream<String> projectFilesStream =
-            walk.map(Path::toString).filter(f -> f.endsWith(".java") || f.endsWith(".p"));
-        projectFilesStream =
-            projectFilesStream.filter(f -> excluded.stream().noneMatch(f::contains));
-        List<String> projectFiles = projectFilesStream.collect(Collectors.toList());
-        if (!projectFiles.isEmpty()) result.put(dir.toString(), projectFiles);
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-    }
-    PExplicitTestLogger.log(String.format("  Found %s tests in %s", result.size(), testDirPath));
-    return result;
-  }
-
-  void runDynamicTest(
-      int expected,
-      List<String> testCasePaths,
-      String testCasePath,
-      Collection<DynamicTest> dynamicTests) {
-    Executable exec =
-        () ->
-            Assertions.assertEquals(
-                expected,
-                TestCaseExecutor.runTestCase(
-                    testCasePaths,
-                    testCasePath,
-                    TestPExplicit.runArgs,
-                    outputDirectory,
-                    expected));
-    DynamicTest dynamicTest =
-        DynamicTest.dynamicTest(
-            testCasePath, () -> assertTimeoutPreemptively(Duration.ofMinutes(60), exec));
-    dynamicTests.add(dynamicTest);
-  }
-
-  Collection<DynamicTest> loadTests(String testDirPath) {
-    if (!initialized) {
-      initialize();
-    }
-
-    Collection<DynamicTest> dynamicTests = new ArrayList<>();
-
-    List<String> testDirs = new ArrayList<>();
-
-    try (Stream<Path> walk = Files.walk(Paths.get(testDirPath))) {
-      testDirs =
-          walk.map(Path::toString)
-              .filter(
-                  f ->
-                      f.endsWith("Correct")
-                          || f.endsWith("DynamicError")
-                          || f.endsWith("StaticError"))
-              .collect(Collectors.toList());
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-
-    for (String testDir : testDirs) {
-      Map<String, List<String>> paths = getFiles(testDir);
-      List<String> pathKeys = new ArrayList<>(paths.keySet());
-      Collections.sort(pathKeys, String.CASE_INSENSITIVE_ORDER);
-
-      if (testDir.contains("Correct")) {
-        for (String key : pathKeys) {
-          runDynamicTest(0, paths.get(key), key, dynamicTests);
+        if (to != null && !to.isEmpty()) {
+            timeout = to;
         }
-      } else if (testDir.contains("DynamicError")) {
-        for (String key : pathKeys) {
-          runDynamicTest(2, paths.get(key), key, dynamicTests);
+        if (it != null && !it.isEmpty()) {
+            schedules = it;
         }
-      } else if (testDir.contains("StaticError")) {
-        for (String key : pathKeys) {
-          runDynamicTest(1, paths.get(key), key, dynamicTests);
+        if (ms != null && !ms.isEmpty()) {
+            maxSteps = ms;
         }
-      }
+
+        runArgs += String.format(" --timeout %s --schedules %s --max-steps %s", timeout, schedules, maxSteps);
+
+        PExplicitTestLogger.log(String.format("Running with arguments:  %s", runArgs));
     }
-    return dynamicTests;
-  }
 
-  @TestFactory
-  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  Collection<DynamicTest> loadSymbolicRegressionsTests() {
-    return loadTests("../PSymRuntime/SymbolicRegressionTests/Integration");
-  }
+    private static void createExcludeList() {
+        /**
+         * TODO: Null events
+         */
+        // TODO: Null events are not supported
+        excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/BugRepro");
+        excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/MoreThan32Events");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_36");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_37");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_38");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_39");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_41");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_OneMachine_42");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_10");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_12");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_16");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_17");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_18");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_19");
+        excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/SEM_TwoMachines_9");
+        excluded.add("../../../Tst/RegressionTests/Integration/Correct/openwsn1");
+        // TODO: Null events are not supported, found in a receive statement
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive2");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive7");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive10");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive11");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive12");
 
-  @TestFactory
-  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  public Collection<DynamicTest> loadIntegrationTests() {
-    return loadTests("../../../Tst/RegressionTests/Integration");
-  }
+        /**
+         * TODO: Deadlock detected
+         */
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/receive6");
 
-  @TestFactory
-  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  Collection<DynamicTest> loadCombinedTests() {
-    return loadTests("../../../Tst/RegressionTests/Combined");
-  }
+        /**
+         * TODO: Run liveness tests
+         */
+    }
 
-  @TestFactory
-  Collection<DynamicTest> loadSMLevelDeclsTests() {
-    return loadTests("../../../Tst/RegressionTests/Feature1SMLevelDecls");
-  }
+    private static void initialize() {
+        Log4JConfig.configureLog4J();
+        PExplicitTestLogger.Initialize(outputDirectory);
+        setRunArgs();
+        createExcludeList();
+        initialized = true;
+    }
 
-  @TestFactory
-  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  Collection<DynamicTest> loadStmtsTests() {
-    return loadTests("../../../Tst/RegressionTests/Feature2Stmts");
-  }
+    Map<String, List<String>> getFiles(String testDirPath) {
+        Map<String, List<String>> result = new HashMap<>();
+        File[] directories = new File(testDirPath).listFiles(File::isDirectory);
+        for (File dir : directories) {
+            if (excluded.stream().anyMatch(dir.toString()::equals)) {
+                continue;
+            }
+            try (Stream<Path> walk = Files.walk(Paths.get(dir.toURI()))) {
+                Stream<String> projectFilesStream =
+                        walk.map(Path::toString).filter(f -> f.endsWith(".java") || f.endsWith(".p"));
+                projectFilesStream =
+                        projectFilesStream.filter(f -> excluded.stream().noneMatch(f::contains));
+                List<String> projectFiles = projectFilesStream.collect(Collectors.toList());
+                if (!projectFiles.isEmpty()) result.put(dir.toString(), projectFiles);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        PExplicitTestLogger.log(String.format("  Found %s tests in %s", result.size(), testDirPath));
+        return result;
+    }
 
-  @TestFactory
-  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  Collection<DynamicTest> loadExpressionTests() {
-    return loadTests("../../../Tst/RegressionTests/Feature3Exprs");
-  }
+    void runDynamicTest(
+            int expected,
+            List<String> testCasePaths,
+            String testCasePath,
+            Collection<DynamicTest> dynamicTests) {
+        Executable exec =
+                () ->
+                        Assertions.assertEquals(
+                                expected,
+                                TestCaseExecutor.runTestCase(
+                                        testCasePaths,
+                                        testCasePath,
+                                        TestPExplicit.runArgs,
+                                        outputDirectory,
+                                        expected));
+        DynamicTest dynamicTest =
+                DynamicTest.dynamicTest(
+                        testCasePath, () -> assertTimeoutPreemptively(Duration.ofMinutes(60), exec));
+        dynamicTests.add(dynamicTest);
+    }
 
-  @TestFactory
-  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  Collection<DynamicTest> loadDataTypeTests() {
-    return loadTests("../../../Tst/RegressionTests/Feature4DataTypes");
-  }
+    Collection<DynamicTest> loadTests(String testDirPath) {
+        if (!initialized) {
+            initialize();
+        }
 
-  // TODO Unsupported: module system
-  //    @TestFactory
-  //        //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
-  //    Collection<DynamicTest>  loadModuleSystemTests() {
-  //        return loadTests("../../../Tst/RegressionTests/Feature5ModuleSystem");
-  //    }
+        Collection<DynamicTest> dynamicTests = new ArrayList<>();
 
+        List<String> testDirs = new ArrayList<>();
+
+        try (Stream<Path> walk = Files.walk(Paths.get(testDirPath))) {
+            testDirs =
+                    walk.map(Path::toString)
+                            .filter(
+                                    f ->
+                                            f.endsWith("Correct")
+                                                    || f.endsWith("DynamicError")
+                                                    || f.endsWith("StaticError"))
+                            .collect(Collectors.toList());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        for (String testDir : testDirs) {
+            Map<String, List<String>> paths = getFiles(testDir);
+            List<String> pathKeys = new ArrayList<>(paths.keySet());
+            Collections.sort(pathKeys, String.CASE_INSENSITIVE_ORDER);
+
+            if (testDir.contains("Correct")) {
+                for (String key : pathKeys) {
+                    runDynamicTest(0, paths.get(key), key, dynamicTests);
+                }
+            } else if (testDir.contains("DynamicError")) {
+                for (String key : pathKeys) {
+                    runDynamicTest(2, paths.get(key), key, dynamicTests);
+                }
+            } else if (testDir.contains("StaticError")) {
+                for (String key : pathKeys) {
+                    runDynamicTest(1, paths.get(key), key, dynamicTests);
+                }
+            }
+        }
+        return dynamicTests;
+    }
+
+    @TestFactory
+        // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    Collection<DynamicTest> loadSymbolicRegressionsTests() {
+        return loadTests("../PSymRuntime/SymbolicRegressionTests/Integration");
+    }
+
+    @TestFactory
+    // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    public Collection<DynamicTest> loadIntegrationTests() {
+        return loadTests("../../../Tst/RegressionTests/Integration");
+    }
+
+    @TestFactory
+        // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    Collection<DynamicTest> loadCombinedTests() {
+        return loadTests("../../../Tst/RegressionTests/Combined");
+    }
+
+    @TestFactory
+    Collection<DynamicTest> loadSMLevelDeclsTests() {
+        return loadTests("../../../Tst/RegressionTests/Feature1SMLevelDecls");
+    }
+
+    @TestFactory
+        // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    Collection<DynamicTest> loadStmtsTests() {
+        return loadTests("../../../Tst/RegressionTests/Feature2Stmts");
+    }
+
+    @TestFactory
+        // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    Collection<DynamicTest> loadExpressionTests() {
+        return loadTests("../../../Tst/RegressionTests/Feature3Exprs");
+    }
+
+    @TestFactory
+        // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    Collection<DynamicTest> loadDataTypeTests() {
+        return loadTests("../../../Tst/RegressionTests/Feature4DataTypes");
+    }
+
+    // TODO Unsupported: module system
+    //    @TestFactory
+    //        //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+    //    Collection<DynamicTest>  loadModuleSystemTests() {
+    //        return loadTests("../../../Tst/RegressionTests/Feature5ModuleSystem");
+    //    }
+
+    // TODO Unsupported: liveness checking
 //  @TestFactory
 //  //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
 //  Collection<DynamicTest>  loadLivenessTests() {

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -1,0 +1,203 @@
+package pexplicit;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.function.Executable;
+import pexplicit.runtime.logger.Log4JConfig;
+
+/**
+ * Runner for PExplicit regressions.
+ */
+public class TestPExplicit {
+  private static final String outputDirectory = "output/testCases";
+  private static final List<String> excluded = new ArrayList<>();
+  private static String timeout = "60";
+  private static String schedules = "100";
+  private static String maxSteps = "300";
+  private static String runArgs = "--sch-coverage dfs";
+  private static boolean initialized = false;
+
+  private static void setRunArgs() {
+    String to = System.getProperty("timeout");
+    String it = System.getProperty("schedules");
+    String ms = System.getProperty("max.steps");
+
+    if (to != null && !to.isEmpty()) {
+      timeout = to;
+    }
+    if (it != null && !it.isEmpty()) {
+      schedules = it;
+    }
+    if (ms != null && !ms.isEmpty()) {
+      maxSteps = ms;
+    }
+
+    runArgs += String.format(" --timeout %s --schedules %s --max-steps %s", timeout, schedules, maxSteps);
+
+    PExplicitTestLogger.log(String.format("Running with arguments:  %s", runArgs));
+  }
+
+  private static void createExcludeList() {
+  }
+
+  private static void initialize() {
+    Log4JConfig.configureLog4J();
+    PExplicitTestLogger.Initialize(outputDirectory);
+    setRunArgs();
+    createExcludeList();
+    initialized = true;
+  }
+
+  Map<String, List<String>> getFiles(String testDirPath) {
+    Map<String, List<String>> result = new HashMap<>();
+    File[] directories = new File(testDirPath).listFiles(File::isDirectory);
+    for (File dir : directories) {
+      if (excluded.stream().anyMatch(dir.toString()::equals)) {
+        continue;
+      }
+      try (Stream<Path> walk = Files.walk(Paths.get(dir.toURI()))) {
+        Stream<String> projectFilesStream =
+            walk.map(Path::toString).filter(f -> f.endsWith(".java") || f.endsWith(".p"));
+        projectFilesStream =
+            projectFilesStream.filter(f -> excluded.stream().noneMatch(f::contains));
+        List<String> projectFiles = projectFilesStream.collect(Collectors.toList());
+        if (!projectFiles.isEmpty()) result.put(dir.toString(), projectFiles);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    PExplicitTestLogger.log(String.format("  Found %s tests in %s", result.size(), testDirPath));
+    return result;
+  }
+
+  void runDynamicTest(
+      int expected,
+      List<String> testCasePaths,
+      String testCasePath,
+      Collection<DynamicTest> dynamicTests) {
+    Executable exec =
+        () ->
+            Assertions.assertEquals(
+                expected,
+                TestCaseExecutor.runTestCase(
+                    testCasePaths,
+                    testCasePath,
+                    TestPExplicit.runArgs,
+                    outputDirectory,
+                    expected));
+    DynamicTest dynamicTest =
+        DynamicTest.dynamicTest(
+            testCasePath, () -> assertTimeoutPreemptively(Duration.ofMinutes(60), exec));
+    dynamicTests.add(dynamicTest);
+  }
+
+  Collection<DynamicTest> loadTests(String testDirPath) {
+    if (!initialized) {
+      initialize();
+    }
+
+    Collection<DynamicTest> dynamicTests = new ArrayList<>();
+
+    List<String> testDirs = new ArrayList<>();
+
+    try (Stream<Path> walk = Files.walk(Paths.get(testDirPath))) {
+      testDirs =
+          walk.map(Path::toString)
+              .filter(
+                  f ->
+                      f.endsWith("Correct")
+                          || f.endsWith("DynamicError")
+                          || f.endsWith("StaticError"))
+              .collect(Collectors.toList());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    for (String testDir : testDirs) {
+      Map<String, List<String>> paths = getFiles(testDir);
+      List<String> pathKeys = new ArrayList<>(paths.keySet());
+      Collections.sort(pathKeys, String.CASE_INSENSITIVE_ORDER);
+
+      if (testDir.contains("Correct")) {
+        for (String key : pathKeys) {
+          runDynamicTest(0, paths.get(key), key, dynamicTests);
+        }
+      } else if (testDir.contains("DynamicError")) {
+        for (String key : pathKeys) {
+          runDynamicTest(2, paths.get(key), key, dynamicTests);
+        }
+      } else if (testDir.contains("StaticError")) {
+        for (String key : pathKeys) {
+          runDynamicTest(1, paths.get(key), key, dynamicTests);
+        }
+      }
+    }
+    return dynamicTests;
+  }
+
+  @TestFactory
+  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  Collection<DynamicTest> loadSymbolicRegressionsTests() {
+    return loadTests("../PSymRuntime/SymbolicRegressionTests/Integration");
+  }
+
+  @TestFactory
+  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  public Collection<DynamicTest> loadIntegrationTests() {
+    return loadTests("../../../Tst/RegressionTests/Integration");
+  }
+
+  @TestFactory
+  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  Collection<DynamicTest> loadCombinedTests() {
+    return loadTests("../../../Tst/RegressionTests/Combined");
+  }
+
+  @TestFactory
+  Collection<DynamicTest> loadSMLevelDeclsTests() {
+    return loadTests("../../../Tst/RegressionTests/Feature1SMLevelDecls");
+  }
+
+  @TestFactory
+  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  Collection<DynamicTest> loadStmtsTests() {
+    return loadTests("../../../Tst/RegressionTests/Feature2Stmts");
+  }
+
+  @TestFactory
+  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  Collection<DynamicTest> loadExpressionTests() {
+    return loadTests("../../../Tst/RegressionTests/Feature3Exprs");
+  }
+
+  @TestFactory
+  // @Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  Collection<DynamicTest> loadDataTypeTests() {
+    return loadTests("../../../Tst/RegressionTests/Feature4DataTypes");
+  }
+
+  // TODO Unsupported: module system
+  //    @TestFactory
+  //        //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  //    Collection<DynamicTest>  loadModuleSystemTests() {
+  //        return loadTests("../../../Tst/RegressionTests/Feature5ModuleSystem");
+  //    }
+
+  @TestFactory
+  //@Timeout(value = 1, unit = TimeUnit.MILLISECONDS)
+  Collection<DynamicTest>  loadLivenessTests() {
+      return loadTests("../../../Tst/RegressionTests/Liveness");
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -60,6 +60,17 @@ public class TestPExplicit {
     excluded.add("../../../Tst/RegressionTests/Feature1SMLevelDecls/Correct/PingPong");
     // TODO: Cannot yet handle casting to variable of type int from value of type any
     excluded.add("../../../Tst/RegressionTests/Integration/DynamicError/two-phase-commit_1");
+    // TODO: Cannot yet handle casting to variable of type int from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast1");
+    // TODO: Cannot yet handle casting to variable of type int from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast2");
+    // TODO: Cannot yet handle casting to variable of type (m1:machine,m2:machine) from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/cast3");
+    // TODO: Cannot yet handle casting to variable of type event from value of type any
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ExprOperatorsAsserts");
+    // TODO: Cannot yet handle casting to variable of type seq[any] from value of type seq[int]
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/Correct/ShortCircuitEval");
+
 
     /**
      * TODO: Null events


### PR DESCRIPTION
This PR adds several changes to fully implement vanilla stateless depth-first style search with all P language constructs supported. Added GitHub CI action for PExplicit to run regression tests.

Updates include:
- Support loops and related statements (break, continue)
- Support receive statement completely, including:
  - receive inside a loop
  - receive inside a receive
  - receive during state transitions, exit functions, and goto functions
- Revamps PValues to support dynamic type casting from any, collection<any>
- Support PEnum (including custom integer values)
- Support operations on PValues
   - Arithmetic, logical, toInt, toFLoat, etc. in primitive types
   - Add/get/put/set/remove in collection types
   - Get/set in tuple types
- Support raise statement
- Support return statement (including inside loops, receive case block)
- Correct observing events by monitors
- Updates logging
- Fully support dynamic type casting (including over collections and nested collections)
- Corrects choosing random value from a collection
- Update to Java 17
- Catch NullPointerDereference, ClassCast, InvalidCast as bug.
- Simplified PExplicit IR code generator.
- Remove generation of redundant code in IR (e.g., statements after control flow has already returned in a function).
- Adds regression testing and GitHub CI action for PExplicit:
  - Unsupported construct include: null events
  - Track list of non-supported constructs in regression runner [here](https://github.com/p-org/P/blob/d8fbfe34670f79ac714c4c6a50e37faefa928b32/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java#L54-L88)
  - TODO: deadlock and liveness checking

Updates beyond PExplicit codebase include:
- Disable running GitHub CI for PSym/PCover on dev/pexplicit_checker branch for now
- Minor change to .gitignore