### PR TITLE
[PExplicit] Improve state caching, add non-chronological backtracking

### DIFF
--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
@@ -12,6 +12,7 @@ import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.utils.monitor.TimeMonitor;
 import pexplicit.utils.random.RandomNumberGenerator;
+import pexplicit.values.ComputeHash;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
@@ -32,6 +33,7 @@ public class PExplicit {
         // parse the commandline arguments to create the configuration
         PExplicitGlobal.setConfig(PExplicitOptions.ParseCommandlineArgs(args));
         PExplicitLogger.Initialize(PExplicitGlobal.getConfig().getVerbosity());
+        ComputeHash.Initialize();
 
         // get reflections corresponding to the model
         Reflections reflections = new Reflections("pexplicit.model");

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -65,7 +65,7 @@ public class RuntimeExecutor {
     private static void preprocess() {
         PExplicitLogger.logInfo(String.format(".. Test case :: " + PExplicitGlobal.getConfig().getTestDriver()));
         PExplicitLogger.logInfo(String.format("... Checker is using '%s' strategy (seed:%s)",
-                PExplicitGlobal.getConfig().getStrategy(), PExplicitGlobal.getConfig().getRandomSeed()));
+                PExplicitGlobal.getConfig().getSearchStrategyMode(), PExplicitGlobal.getConfig().getRandomSeed()));
 
         executor = Executors.newSingleThreadExecutor();
 
@@ -74,7 +74,7 @@ public class RuntimeExecutor {
         double preSearchTime =
                 TimeMonitor.findInterval(TimeMonitor.getStart());
         StatWriter.log("project-name", String.format("%s", PExplicitGlobal.getConfig().getProjectName()));
-        StatWriter.log("strategy", String.format("%s", PExplicitGlobal.getConfig().getStrategy()));
+        StatWriter.log("strategy", String.format("%s", PExplicitGlobal.getConfig().getSearchStrategyMode()));
         StatWriter.log("time-limit-seconds", String.format("%.1f", PExplicitGlobal.getConfig().getTimeLimit()));
         StatWriter.log("memory-limit-MB", String.format("%.1f", PExplicitGlobal.getConfig().getMemLimit()));
         StatWriter.log("time-pre-seconds", String.format("%.1f", preSearchTime));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import pexplicit.runtime.machine.buffer.BufferSemantics;
 import pexplicit.runtime.scheduler.explicit.StateCachingMode;
+import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 
 /**
  * Represents the configuration for PExplicit runtime.
@@ -32,9 +33,6 @@ public class PExplicitConfig {
     // level of verbosity for the logging
     @Setter
     int verbosity = 0;
-    // strategy of exploration
-    @Setter
-    String strategy = "dfs";
     // max number of schedules bound provided by the user
     @Setter
     int maxSchedules = 1;
@@ -59,12 +57,13 @@ public class PExplicitConfig {
     // use stateful backtracking
     @Setter
     boolean statefulBacktrackEnabled = true;
-
-    public void setToDfs() {
-        this.setStrategy("dfs");
-    }
-
-    public void setToReplay() {
-        this.setStrategy("replay");
-    }
+    // search strategy mode
+    @Setter
+    SearchStrategyMode searchStrategyMode = SearchStrategyMode.Random;
+    // max number of schedules per search task
+    @Setter
+    int maxSchedulesPerTask = 100;
+    //max number of children search tasks
+    @Setter
+    int maxChildrenPerTask = 2;
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -55,7 +55,7 @@ public class PExplicitConfig {
     BufferSemantics bufferSemantics = BufferSemantics.SenderQueue;
     // state caching mode
     @Setter
-    StateCachingMode stateCachingMode = StateCachingMode.Fingerprint;
+    StateCachingMode stateCachingMode = StateCachingMode.Murmur3_128;
     // use stateful backtracking
     @Setter
     boolean statefulBacktrackEnabled = true;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -155,7 +155,7 @@ public class PExplicitOptions {
         Option stateCachingMode =
                 Option.builder()
                         .longOpt("state-caching")
-                        .desc("State caching mode: none, fingerprint, exact (default: fingerprint)")
+                        .desc("State caching mode: none, hashcode, siphash24, murmur3_128, sha256, exact (default: murmur3_128)")
                         .numberOfArgs(1)
                         .hasArg()
                         .argName("Caching Mode (string)")
@@ -312,8 +312,17 @@ public class PExplicitOptions {
                         case "none":
                             config.setStateCachingMode(StateCachingMode.None);
                             break;
-                        case "fingerprint":
-                            config.setStateCachingMode(StateCachingMode.Fingerprint);
+                        case "hashcode":
+                            config.setStateCachingMode(StateCachingMode.HashCode);
+                            break;
+                        case "siphash24":
+                            config.setStateCachingMode(StateCachingMode.SipHash24);
+                            break;
+                        case "murmur3_128":
+                            config.setStateCachingMode(StateCachingMode.Murmur3_128);
+                            break;
+                        case "sha256":
+                            config.setStateCachingMode(StateCachingMode.Sha256);
                             break;
                         case "exact":
                             config.setStateCachingMode(StateCachingMode.Exact);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -297,7 +297,7 @@ public class PExplicitOptions {
                             config.setSearchStrategyMode(SearchStrategyMode.Random);
                             break;
                         case "astar":
-                            config.setSearchStrategyMode (SearchStrategyMode.AStar);
+                            config.setSearchStrategyMode(SearchStrategyMode.AStar);
                             break;
                         default:
                             optionError(

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -99,7 +99,7 @@ public class PExplicitOptions {
         Option strategy =
                 Option.builder("st")
                         .longOpt("strategy")
-                        .desc("Exploration strategy: dfs, random, astar (default: dfs)")
+                        .desc("Exploration strategy: dfs, random, astar (default: random)")
                         .numberOfArgs(1)
                         .hasArg()
                         .argName("Strategy (string)")

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -5,7 +5,6 @@ import lombok.Setter;
 import pexplicit.commandline.PExplicitConfig;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.scheduler.Scheduler;
-import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategy;
 import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 
 import java.util.*;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/PExplicitGlobal.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import pexplicit.commandline.PExplicitConfig;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.scheduler.Scheduler;
+import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategy;
+import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 
 import java.util.*;
 
@@ -40,6 +42,9 @@ public class PExplicitGlobal {
     @Getter
     @Setter
     private static Scheduler scheduler = null;
+    @Getter
+    @Setter
+    private static SearchStrategyMode searchStrategyMode;
     /**
      * Status of the run
      **/

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -153,12 +153,6 @@ public class PExplicitLogger {
         }
     }
 
-    public static void logNextTask(SearchTask task) {
-        if (verbosity > 1) {
-            log.info(String.format("    Next task is %s", task.toStringDetailed()));
-        }
-    }
-
     /**
      * Log at the start of an iteration
      *

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -12,13 +12,13 @@ import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMonitor;
 import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PContinuation;
-import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;
 import pexplicit.runtime.scheduler.explicit.SearchStatistics;
 import pexplicit.runtime.scheduler.explicit.StateCachingMode;
 import pexplicit.runtime.scheduler.replay.ReplayScheduler;
 import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.values.PEvent;
+import pexplicit.values.PMessage;
 import pexplicit.values.PValue;
 
 import java.io.PrintWriter;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/TraceLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/TraceLogger.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.core.appender.OutputStreamAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.machine.events.PMessage;
+import pexplicit.values.PMessage;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -7,13 +7,13 @@ import pexplicit.runtime.machine.buffer.DeferQueue;
 import pexplicit.runtime.machine.buffer.SenderQueue;
 import pexplicit.runtime.machine.eventhandlers.EventHandler;
 import pexplicit.runtime.machine.events.PContinuation;
-import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.misc.Assert;
 import pexplicit.utils.serialize.SerializableBiFunction;
 import pexplicit.utils.serialize.SerializableRunnable;
 import pexplicit.values.PEvent;
 import pexplicit.values.PMachineValue;
+import pexplicit.values.PMessage;
 import pexplicit.values.PValue;
 
 import java.io.Serializable;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/State.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/State.java
@@ -3,10 +3,10 @@ package pexplicit.runtime.machine;
 import pexplicit.runtime.machine.eventhandlers.DeferEventHandler;
 import pexplicit.runtime.machine.eventhandlers.EventHandler;
 import pexplicit.runtime.machine.eventhandlers.IgnoreEventHandler;
-import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.runtime.machine.events.StateEvents;
 import pexplicit.utils.misc.Assert;
 import pexplicit.values.PEvent;
+import pexplicit.values.PMessage;
 import pexplicit.values.PValue;
 
 import java.io.Serializable;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
@@ -2,8 +2,8 @@ package pexplicit.runtime.machine.buffer;
 
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.utils.misc.Assert;
+import pexplicit.values.PMessage;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PContinuation.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PContinuation.java
@@ -6,6 +6,7 @@ import pexplicit.runtime.machine.State;
 import pexplicit.utils.serialize.SerializableBiFunction;
 import pexplicit.utils.serialize.SerializableRunnable;
 import pexplicit.values.PEvent;
+import pexplicit.values.PMessage;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Choice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Choice.java
@@ -32,6 +32,22 @@ public class Choice implements Serializable {
     public Choice() {
     }
 
+    public Choice transferUnexplored() {
+        Choice newChoice = new Choice();
+        newChoice.currentScheduleChoice = this.currentScheduleChoice;
+        newChoice.currentDataChoice = this.currentDataChoice;
+
+        newChoice.unexploredScheduleChoices = this.unexploredScheduleChoices;
+        newChoice.unexploredDataChoices = this.unexploredDataChoices;
+        newChoice.choiceStep = this.choiceStep;
+
+        this.unexploredScheduleChoices = new ArrayList<>();
+        this.unexploredDataChoices = new ArrayList<>();
+        this.choiceStep = null;
+
+        return newChoice;
+    }
+
     /**
      * Check if this choice has an unexplored choice remaining.
      *
@@ -73,15 +89,9 @@ public class Choice implements Serializable {
     public void clearUnexplored() {
         unexploredScheduleChoices.clear();
         unexploredDataChoices.clear();
-        choiceStep = null;
-    }
-
-    /**
-     * Clear this choice
-     */
-    public void clear() {
-        clearCurrent();
-        clearUnexplored();
+        if (choiceStep != null) {
+            choiceStep.clear();
+        }
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -27,7 +27,7 @@ public class Schedule implements Serializable {
      * Used in stateful backtracking
      */
     @Setter
-    private StepState stepBeginState = null;
+    private transient StepState stepBeginState = null;
 
     /**
      * Constructor
@@ -55,22 +55,13 @@ public class Schedule implements Serializable {
     }
 
     /**
-     * Set the choice at a choice depth.
-     *
-     * @param idx    Choice depth
-     * @param choice Choice object
-     */
-    public void setChoice(int idx, Choice choice) {
-        choices.set(idx, choice);
-    }
-
-    /**
      * Clear choice at a choice depth
      *
      * @param idx Choice depth
      */
     public void clearChoice(int idx) {
-        choices.get(idx).clear();
+        choices.get(idx).clearCurrent();
+        choices.get(idx).clearUnexplored();
     }
 
     /**
@@ -81,32 +72,22 @@ public class Schedule implements Serializable {
     public int getNumUnexploredChoices() {
         int numUnexplored = 0;
         for (Choice c : choices) {
-            if (c.isUnexploredNonEmpty()) {
-                numUnexplored += c.unexploredScheduleChoices.size() + c.unexploredDataChoices.size();
-            }
+            numUnexplored += c.unexploredScheduleChoices.size() + c.unexploredDataChoices.size();
         }
         return numUnexplored;
     }
 
     /**
-     * Get the percentage of unexplored choices in this schedule that are data choices
+     * Get the number of unexplored data choices in this schedule
      *
-     * @return Percentage of unexplored choices that are data choices
+     * @return Number of unexplored data choices
      */
-    public double getUnexploredDataChoicesPercent() {
-        int totalUnexplored = getNumUnexploredChoices();
-        if (totalUnexplored == 0) {
-            return 0;
-        }
-
-        int numUnexploredData = 0;
+    public int getNumUnexploredDataChoices() {
+        int numUnexplored = 0;
         for (Choice c : choices) {
-            if (c.isUnexploredDataChoicesNonEmpty()) {
-                numUnexploredData += c.unexploredDataChoices.size();
-            }
+            numUnexplored += c.unexploredDataChoices.size();
         }
-
-        return (numUnexploredData * 100.0) / totalUnexplored;
+        return numUnexplored;
     }
 
     /**
@@ -228,15 +209,6 @@ public class Schedule implements Serializable {
      */
     public void clearCurrent(int idx) {
         choices.get(idx).clearCurrent();
-    }
-
-    /**
-     * Clear unexplored choices at a choice depth
-     *
-     * @param idx Choice depth
-     */
-    public void clearUnexplored(int idx) {
-        choices.get(idx).clearUnexplored();
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
@@ -6,7 +6,6 @@ import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMonitor;
-import pexplicit.runtime.machine.events.PMessage;
 import pexplicit.runtime.scheduler.explicit.StepState;
 import pexplicit.utils.exceptions.DeadlockException;
 import pexplicit.utils.exceptions.LivenessException;
@@ -44,6 +43,10 @@ public abstract class Scheduler implements SchedulerInterface {
     @Getter
     @Setter
     protected transient int stepNumLogs = 0;
+    /**
+     * Whether last step was a sticky step (i.e., createMachine step)
+     */
+    protected boolean isStickyStep = true;
 
     /**
      * Constructor
@@ -85,6 +88,7 @@ public abstract class Scheduler implements SchedulerInterface {
      * Reset the scheduler.
      */
     protected void reset() {
+        isStickyStep = true;
     }
 
     /**
@@ -219,7 +223,8 @@ public abstract class Scheduler implements SchedulerInterface {
         // pop message from sender queue
         PMessage msg = sender.getSendBuffer().remove();
 
-        if (!msg.getEvent().isCreateMachineEvent()) {
+        isStickyStep = msg.getEvent().isCreateMachineEvent();
+        if (!isStickyStep) {
             // update step number
             stepState.setStepNumber(stepState.getStepNumber() + 1);
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -446,7 +446,9 @@ public class ExplicitSearchScheduler extends Scheduler {
         searchStrategy.addNewTask(newTask);
     }
 
-    /** Set next backtrack task with given orchestration mode */
+    /**
+     * Set next backtrack task with given orchestration mode
+     */
     public SearchTask setNextTask() {
         SearchTask nextTask = searchStrategy.setNextTask();
         if (nextTask != null) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -122,7 +122,6 @@ public class ExplicitSearchScheduler extends Scheduler {
             // set the next task
             SearchTask nextTask = setNextTask();
             assert (nextTask != null);
-            PExplicitLogger.logNextTask(nextTask);
         }
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StateCachingMode.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StateCachingMode.java
@@ -2,6 +2,9 @@ package pexplicit.runtime.scheduler.explicit;
 
 public enum StateCachingMode {
     None,
-    Fingerprint,
+    HashCode,
+    SipHash24,
+    Murmur3_128,
+    Sha256,
     Exact
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
@@ -56,6 +56,12 @@ public class StepState implements Serializable {
         return stepState;
     }
 
+    public void clear() {
+        machineListByType.clear();
+        machineSet.clear();
+        machineLocalStates.clear();
+    }
+
 
     public void resetToZero() {
         this.stepNumber = 0;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -70,7 +70,7 @@ public abstract class SearchStrategy implements Serializable {
         return (id < allTasks.size());
     }
 
-    private SearchTask getTask(int id) {
+    protected SearchTask getTask(int id) {
         assert (isValidTaskId(id));
         return allTasks.get(id);
     }
@@ -81,7 +81,6 @@ public abstract class SearchStrategy implements Serializable {
         }
 
         SearchTask nextTask = popNextTask();
-        assert (!nextTask.isInitialTask());
         setCurrTask(nextTask);
 
         return nextTask;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -1,0 +1,121 @@
+package pexplicit.runtime.scheduler.explicit.strategy;
+
+import lombok.Getter;
+import pexplicit.runtime.PExplicitGlobal;
+import pexplicit.runtime.logger.PExplicitLogger;
+import pexplicit.runtime.scheduler.Choice;
+import pexplicit.runtime.scheduler.explicit.SearchStatistics;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+public abstract class SearchStrategy implements Serializable {
+    /**
+     * List of all search tasks
+     */
+    final List<SearchTask> allTasks = new ArrayList<>();
+    /**
+     * Set of all search tasks that are pending
+     */
+    final Set<Integer> pendingTasks = new HashSet<>();
+    /**
+     * List of all search tasks that finished
+     */
+    final List<Integer> finishedTasks = new ArrayList<>();
+    /**
+     * Task id of the latest search task
+     */
+    int currTaskId = 0;
+    /**
+     * Starting iteration number for the current task
+     */
+    int currTaskStartIteration = 0;
+
+    public SearchTask createTask(Choice choice, int choiceNum, SearchTask parentTask) {
+        SearchTask newTask = new SearchTask(allTasks.size(), choice, choiceNum, parentTask);
+        allTasks.add(newTask);
+        pendingTasks.add(newTask.getId());
+        return newTask;
+    }
+
+    private void setCurrTask(SearchTask task) {
+        assert (pendingTasks.contains(task.getId()));
+        pendingTasks.remove(task.getId());
+        currTaskId = task.getId();
+        currTaskStartIteration = SearchStatistics.iteration;
+    }
+
+    public void createFirstTask() {
+        assert (allTasks.size() == 0);
+        SearchTask firstTask = createTask(null, 0, null);
+        setCurrTask(firstTask);
+    }
+
+    public SearchTask getCurrTask() {
+        return getTask(currTaskId);
+    }
+
+
+    public int getNumSchedulesInCurrTask() {
+        return SearchStatistics.iteration - currTaskStartIteration;
+    }
+
+
+
+    private boolean isValidTaskId(int id) {
+        return (id < allTasks.size());
+    }
+
+    private SearchTask getTask(int id) {
+        assert (isValidTaskId(id));
+        return allTasks.get(id);
+    }
+
+    public SearchTask setNextTask() {
+        if (pendingTasks.isEmpty()) {
+            return null;
+        }
+
+        SearchTask nextTask = popNextTask();
+        assert (!nextTask.isInitialTask());
+        setCurrTask(nextTask);
+
+        return nextTask;
+    }
+
+    /**
+     * Get the number of unexplored choices in the pending tasks
+     *
+     * @return Number of unexplored choices
+     */
+    public int getNumPendingChoices() {
+        int numUnexplored = 0;
+        for (Integer tid: pendingTasks) {
+            SearchTask task = getTask(tid);
+            numUnexplored += task.getNumUnexploredScheduleChoices() + task.getNumUnexploredDataChoices();
+        }
+        return numUnexplored;
+    }
+
+    /**
+     * Get the number of unexplored data choices in the pending tasks
+     *
+     * @return Number of unexplored data choices
+     */
+    public int getNumPendingDataChoices() {
+        int numUnexplored = 0;
+        for (Integer tid: pendingTasks) {
+            SearchTask task = getTask(tid);
+            numUnexplored += task.getNumUnexploredDataChoices();
+        }
+        return numUnexplored;
+    }
+
+    public abstract void addNewTask(SearchTask task);
+
+    abstract SearchTask popNextTask();
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -1,8 +1,6 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
-import pexplicit.runtime.PExplicitGlobal;
-import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.scheduler.Choice;
 import pexplicit.runtime.scheduler.explicit.SearchStatistics;
 
@@ -42,13 +40,6 @@ public abstract class SearchStrategy implements Serializable {
         return newTask;
     }
 
-    private void setCurrTask(SearchTask task) {
-        assert (pendingTasks.contains(task.getId()));
-        pendingTasks.remove(task.getId());
-        currTaskId = task.getId();
-        currTaskStartIteration = SearchStatistics.iteration;
-    }
-
     public void createFirstTask() {
         assert (allTasks.size() == 0);
         SearchTask firstTask = createTask(null, 0, null);
@@ -59,11 +50,16 @@ public abstract class SearchStrategy implements Serializable {
         return getTask(currTaskId);
     }
 
+    private void setCurrTask(SearchTask task) {
+        assert (pendingTasks.contains(task.getId()));
+        pendingTasks.remove(task.getId());
+        currTaskId = task.getId();
+        currTaskStartIteration = SearchStatistics.iteration;
+    }
 
     public int getNumSchedulesInCurrTask() {
         return SearchStatistics.iteration - currTaskStartIteration;
     }
-
 
 
     private boolean isValidTaskId(int id) {
@@ -93,7 +89,7 @@ public abstract class SearchStrategy implements Serializable {
      */
     public int getNumPendingChoices() {
         int numUnexplored = 0;
-        for (Integer tid: pendingTasks) {
+        for (Integer tid : pendingTasks) {
             SearchTask task = getTask(tid);
             numUnexplored += task.getNumUnexploredScheduleChoices() + task.getNumUnexploredDataChoices();
         }
@@ -107,7 +103,7 @@ public abstract class SearchStrategy implements Serializable {
      */
     public int getNumPendingDataChoices() {
         int numUnexplored = 0;
-        for (Integer tid: pendingTasks) {
+        for (Integer tid : pendingTasks) {
             SearchTask task = getTask(tid);
             numUnexplored += task.getNumUnexploredDataChoices();
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
@@ -4,25 +4,25 @@ import java.util.Comparator;
 import java.util.concurrent.PriorityBlockingQueue;
 
 public class SearchStrategyAStar extends SearchStrategy {
-  private final PriorityBlockingQueue<SearchTask> elements;
+    private final PriorityBlockingQueue<SearchTask> elements;
 
-  public SearchStrategyAStar() {
-    elements =
-        new PriorityBlockingQueue<SearchTask>(
-            100,
-            new Comparator<SearchTask>() {
-              public int compare(SearchTask a, SearchTask b) {
-                return Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber());
-              }
-            });
-  }
+    public SearchStrategyAStar() {
+        elements =
+                new PriorityBlockingQueue<SearchTask>(
+                        100,
+                        new Comparator<SearchTask>() {
+                            public int compare(SearchTask a, SearchTask b) {
+                                return Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber());
+                            }
+                        });
+    }
 
-  public void addNewTask(SearchTask task) {
-    elements.offer(task);
-  }
+    public void addNewTask(SearchTask task) {
+        elements.offer(task);
+    }
 
-  public SearchTask popNextTask() {
-    assert (!elements.isEmpty());
-    return elements.poll();
-  }
+    public SearchTask popNextTask() {
+        assert (!elements.isEmpty());
+        return elements.poll();
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
@@ -1,0 +1,28 @@
+package pexplicit.runtime.scheduler.explicit.strategy;
+
+import java.util.Comparator;
+import java.util.concurrent.PriorityBlockingQueue;
+
+public class SearchStrategyAStar extends SearchStrategy {
+  private final PriorityBlockingQueue<SearchTask> elements;
+
+  public SearchStrategyAStar() {
+    elements =
+        new PriorityBlockingQueue<SearchTask>(
+            100,
+            new Comparator<SearchTask>() {
+              public int compare(SearchTask a, SearchTask b) {
+                return Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber());
+              }
+            });
+  }
+
+  public void addNewTask(SearchTask task) {
+    elements.offer(task);
+  }
+
+  public SearchTask popNextTask() {
+    assert (!elements.isEmpty());
+    return elements.poll();
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyDfs.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyDfs.java
@@ -5,9 +5,11 @@ public class SearchStrategyDfs extends SearchStrategy {
     }
 
     public void addNewTask(SearchTask task) {
+        assert (pendingTasks.isEmpty());
     }
 
     public SearchTask popNextTask() {
-        throw new RuntimeException("Cannot pop the next task in dfs strategy since there should be just a single task");
+        assert (pendingTasks.size() == 1);
+        return getTask(pendingTasks.iterator().next());
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyDfs.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyDfs.java
@@ -1,0 +1,13 @@
+package pexplicit.runtime.scheduler.explicit.strategy;
+
+public class SearchStrategyDfs extends SearchStrategy {
+    public SearchStrategyDfs() {
+    }
+
+    public void addNewTask(SearchTask task) {
+    }
+
+    public SearchTask popNextTask() {
+        throw new RuntimeException("Cannot pop the next task in dfs strategy since there should be just a single task");
+    }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
@@ -1,0 +1,7 @@
+package pexplicit.runtime.scheduler.explicit.strategy;
+
+public enum SearchStrategyMode {
+    DepthFirst,
+    Random,
+    AStar
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
@@ -5,27 +5,27 @@ import pexplicit.utils.random.RandomNumberGenerator;
 import java.util.*;
 
 public class SearchStrategyRandom extends SearchStrategy {
-  private final List<SearchTask> elementList;
-  private final Set<SearchTask> elementSet;
+    private final List<SearchTask> elementList;
+    private final Set<SearchTask> elementSet;
 
-  public SearchStrategyRandom() {
-    elementList = new ArrayList<>();
-    elementSet = new HashSet<>();
-  }
+    public SearchStrategyRandom() {
+        elementList = new ArrayList<>();
+        elementSet = new HashSet<>();
+    }
 
-  public void addNewTask(SearchTask task) {
-    assert (!elementSet.contains(task));
-    elementList.add(task);
-    elementSet.add(task);
-  }
+    public void addNewTask(SearchTask task) {
+        assert (!elementSet.contains(task));
+        elementList.add(task);
+        elementSet.add(task);
+    }
 
-  public SearchTask popNextTask() {
-    assert (!elementList.isEmpty());
-    Collections.shuffle(
-        elementList, new Random(RandomNumberGenerator.getInstance().getRandomLong()));
-    SearchTask result = elementList.get(0);
-    elementList.remove(0);
-    elementSet.remove(result);
-    return result;
-  }
+    public SearchTask popNextTask() {
+        assert (!elementList.isEmpty());
+        Collections.shuffle(
+                elementList, new Random(RandomNumberGenerator.getInstance().getRandomLong()));
+        SearchTask result = elementList.get(0);
+        elementList.remove(0);
+        elementSet.remove(result);
+        return result;
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyRandom.java
@@ -1,0 +1,31 @@
+package pexplicit.runtime.scheduler.explicit.strategy;
+
+import pexplicit.utils.random.RandomNumberGenerator;
+
+import java.util.*;
+
+public class SearchStrategyRandom extends SearchStrategy {
+  private final List<SearchTask> elementList;
+  private final Set<SearchTask> elementSet;
+
+  public SearchStrategyRandom() {
+    elementList = new ArrayList<>();
+    elementSet = new HashSet<>();
+  }
+
+  public void addNewTask(SearchTask task) {
+    assert (!elementSet.contains(task));
+    elementList.add(task);
+    elementSet.add(task);
+  }
+
+  public SearchTask popNextTask() {
+    assert (!elementList.isEmpty());
+    Collections.shuffle(
+        elementList, new Random(RandomNumberGenerator.getInstance().getRandomLong()));
+    SearchTask result = elementList.get(0);
+    elementList.remove(0);
+    elementSet.remove(result);
+    return result;
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -1,0 +1,126 @@
+package pexplicit.runtime.scheduler.explicit.strategy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+import pexplicit.runtime.scheduler.Choice;
+
+public class SearchTask implements Serializable {
+  @Getter
+  private final int id;
+  @Getter
+  private final SearchTask parentTask;
+  @Getter
+  private final List<SearchTask> children = new ArrayList<>();
+  @Getter
+  private final int currChoiceNumber;
+
+  @Getter
+  private int numUnexploredScheduleChoices = 0;
+  @Getter
+  private int numUnexploredDataChoices = 0;
+
+
+  private final Choice currChoice;
+  private Map<Integer, Choice> prefixChoices = new HashMap<>();
+  private List<Choice> suffixChoices = new ArrayList<>();
+
+  public SearchTask(int id, Choice choice, int choiceNum, SearchTask parentTask) {
+    this.id = id;
+    this.currChoice = choice;
+    this.currChoiceNumber = choiceNum;
+    this.parentTask = parentTask;
+    if (!isInitialTask()) {
+      numUnexploredScheduleChoices += choice.getUnexploredScheduleChoices().size();
+      numUnexploredDataChoices += choice.getUnexploredDataChoices().size();
+    }
+  }
+
+  public boolean isInitialTask() {
+    return id == 0;
+  }
+
+  public void addChild(SearchTask task) {
+    children.add(task);
+  }
+
+  public void cleanup() {
+    if (currChoice != null) {
+      currChoice.clearUnexplored();
+    }
+    suffixChoices.clear();
+  }
+
+  public void addPrefixChoice(Choice choice, int choiceNum) {
+    assert (!choice.isUnexploredNonEmpty());
+    prefixChoices.put(choiceNum, choice);
+  }
+
+  public void addSuffixChoice(Choice choice) {
+    // TODO: check if we need copy here
+    suffixChoices.add(choice);
+    numUnexploredScheduleChoices += choice.getUnexploredScheduleChoices().size();
+    numUnexploredDataChoices += choice.getUnexploredDataChoices().size();
+  }
+
+  public List<Choice> getAllChoices() {
+    List<Choice> result = new ArrayList<>(suffixChoices);
+    result.add(0, currChoice);
+
+    SearchTask task = this;
+    int i = currChoiceNumber-1;
+    while(i >= 0) {
+      Choice c = task.prefixChoices.get(i);
+      if (c == null) {
+        assert (!task.isInitialTask());
+        task = task.parentTask;
+      } else {
+        result.add(0, c);
+        i--;
+      }
+    }
+    assert(result.size() == (currChoiceNumber + 1 + suffixChoices.size()));
+    return result;
+  }
+
+  @Override
+  public int hashCode() {
+    return this.id;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) return true;
+    else if (!(obj instanceof SearchTask)) {
+      return false;
+    }
+    return this.id == ((SearchTask) obj).id;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("task%d", id);
+  }
+
+  public String toStringDetailed() {
+    if (isInitialTask()) {
+      return String.format("%s @0::0 (parent: null)", toString());
+    }
+    if (currChoice.getChoiceStep() != null) {
+      return String.format("%s @%d::%d (parent: %s)",
+              toString(),
+              currChoice.getChoiceStep().getStepNumber(),
+              currChoiceNumber,
+              parentTask);
+    }
+    return String.format("%s @?::%d (parent: %s)",
+            toString(),
+            currChoiceNumber,
+            parentTask);
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -1,126 +1,122 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
+import lombok.Getter;
+import pexplicit.runtime.scheduler.Choice;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import lombok.Getter;
-import lombok.Setter;
-import pexplicit.runtime.scheduler.Choice;
-
 public class SearchTask implements Serializable {
-  @Getter
-  private final int id;
-  @Getter
-  private final SearchTask parentTask;
-  @Getter
-  private final List<SearchTask> children = new ArrayList<>();
-  @Getter
-  private final int currChoiceNumber;
+    @Getter
+    private final int id;
+    @Getter
+    private final SearchTask parentTask;
+    @Getter
+    private final List<SearchTask> children = new ArrayList<>();
+    @Getter
+    private final int currChoiceNumber;
+    private final Choice currChoice;
+    @Getter
+    private int numUnexploredScheduleChoices = 0;
+    @Getter
+    private int numUnexploredDataChoices = 0;
+    private final Map<Integer, Choice> prefixChoices = new HashMap<>();
+    private final List<Choice> suffixChoices = new ArrayList<>();
 
-  @Getter
-  private int numUnexploredScheduleChoices = 0;
-  @Getter
-  private int numUnexploredDataChoices = 0;
-
-
-  private final Choice currChoice;
-  private Map<Integer, Choice> prefixChoices = new HashMap<>();
-  private List<Choice> suffixChoices = new ArrayList<>();
-
-  public SearchTask(int id, Choice choice, int choiceNum, SearchTask parentTask) {
-    this.id = id;
-    this.currChoice = choice;
-    this.currChoiceNumber = choiceNum;
-    this.parentTask = parentTask;
-    if (!isInitialTask()) {
-      numUnexploredScheduleChoices += choice.getUnexploredScheduleChoices().size();
-      numUnexploredDataChoices += choice.getUnexploredDataChoices().size();
+    public SearchTask(int id, Choice choice, int choiceNum, SearchTask parentTask) {
+        this.id = id;
+        this.currChoice = choice;
+        this.currChoiceNumber = choiceNum;
+        this.parentTask = parentTask;
+        if (!isInitialTask()) {
+            numUnexploredScheduleChoices += choice.getUnexploredScheduleChoices().size();
+            numUnexploredDataChoices += choice.getUnexploredDataChoices().size();
+        }
     }
-  }
 
-  public boolean isInitialTask() {
-    return id == 0;
-  }
-
-  public void addChild(SearchTask task) {
-    children.add(task);
-  }
-
-  public void cleanup() {
-    if (currChoice != null) {
-      currChoice.clearUnexplored();
+    public boolean isInitialTask() {
+        return id == 0;
     }
-    suffixChoices.clear();
-  }
 
-  public void addPrefixChoice(Choice choice, int choiceNum) {
-    assert (!choice.isUnexploredNonEmpty());
-    prefixChoices.put(choiceNum, choice);
-  }
-
-  public void addSuffixChoice(Choice choice) {
-    // TODO: check if we need copy here
-    suffixChoices.add(choice);
-    numUnexploredScheduleChoices += choice.getUnexploredScheduleChoices().size();
-    numUnexploredDataChoices += choice.getUnexploredDataChoices().size();
-  }
-
-  public List<Choice> getAllChoices() {
-    List<Choice> result = new ArrayList<>(suffixChoices);
-    result.add(0, currChoice);
-
-    SearchTask task = this;
-    int i = currChoiceNumber-1;
-    while(i >= 0) {
-      Choice c = task.prefixChoices.get(i);
-      if (c == null) {
-        assert (!task.isInitialTask());
-        task = task.parentTask;
-      } else {
-        result.add(0, c);
-        i--;
-      }
+    public void addChild(SearchTask task) {
+        children.add(task);
     }
-    assert(result.size() == (currChoiceNumber + 1 + suffixChoices.size()));
-    return result;
-  }
 
-  @Override
-  public int hashCode() {
-    return this.id;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (obj == this) return true;
-    else if (!(obj instanceof SearchTask)) {
-      return false;
+    public void cleanup() {
+        if (currChoice != null) {
+            currChoice.clearUnexplored();
+        }
+        suffixChoices.clear();
     }
-    return this.id == ((SearchTask) obj).id;
-  }
 
-  @Override
-  public String toString() {
-    return String.format("task%d", id);
-  }
+    public void addPrefixChoice(Choice choice, int choiceNum) {
+        assert (!choice.isUnexploredNonEmpty());
+        prefixChoices.put(choiceNum, choice);
+    }
 
-  public String toStringDetailed() {
-    if (isInitialTask()) {
-      return String.format("%s @0::0 (parent: null)", toString());
+    public void addSuffixChoice(Choice choice) {
+        // TODO: check if we need copy here
+        suffixChoices.add(choice);
+        numUnexploredScheduleChoices += choice.getUnexploredScheduleChoices().size();
+        numUnexploredDataChoices += choice.getUnexploredDataChoices().size();
     }
-    if (currChoice.getChoiceStep() != null) {
-      return String.format("%s @%d::%d (parent: %s)",
-              toString(),
-              currChoice.getChoiceStep().getStepNumber(),
-              currChoiceNumber,
-              parentTask);
+
+    public List<Choice> getAllChoices() {
+        List<Choice> result = new ArrayList<>(suffixChoices);
+        result.add(0, currChoice);
+
+        SearchTask task = this;
+        int i = currChoiceNumber - 1;
+        while (i >= 0) {
+            Choice c = task.prefixChoices.get(i);
+            if (c == null) {
+                assert (!task.isInitialTask());
+                task = task.parentTask;
+            } else {
+                result.add(0, c);
+                i--;
+            }
+        }
+        assert (result.size() == (currChoiceNumber + 1 + suffixChoices.size()));
+        return result;
     }
-    return String.format("%s @?::%d (parent: %s)",
-            toString(),
-            currChoiceNumber,
-            parentTask);
-  }
+
+    @Override
+    public int hashCode() {
+        return this.id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        else if (!(obj instanceof SearchTask)) {
+            return false;
+        }
+        return this.id == ((SearchTask) obj).id;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("task%d", id);
+    }
+
+    public String toStringDetailed() {
+        if (isInitialTask()) {
+            return String.format("%s @0::0 (parent: null)", this);
+        }
+        if (currChoice.getChoiceStep() != null) {
+            return String.format("%s @%d::%d (parent: %s)",
+                    this,
+                    currChoice.getChoiceStep().getStepNumber(),
+                    currChoiceNumber,
+                    parentTask);
+        }
+        return String.format("%s @?::%d (parent: %s)",
+                this,
+                currChoiceNumber,
+                parentTask);
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/ComputeHash.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/ComputeHash.java
@@ -1,7 +1,10 @@
 package pexplicit.values;
 
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
 import pexplicit.runtime.machine.PMachine;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -11,6 +14,9 @@ import java.util.SortedSet;
  * Static class to compute hash values
  */
 public class ComputeHash {
+    public static void Initialize() {
+    }
+
 
     /**
      * Compute hash value for a collection of PValues.
@@ -47,7 +53,10 @@ public class ComputeHash {
     }
 
     /**
-     * Compute hash value for a PMachine local variables.
+     * Get the hash code of the protocol state using Java inbuilt hashCode() function.
+     *
+     * @param machines Sorted set of protocol machines
+     * @return Integer representing hash code corresponding to the protocol state
      */
     public static int getHashCode(SortedSet<PMachine> machines) {
         int hashValue = 0x802CBBDB;
@@ -59,4 +68,33 @@ public class ComputeHash {
         }
         return hashValue;
     }
+
+    /**
+     * Get the hash code of the protocol state given a hash function.
+     *
+     * @param machines     Sorted set of protocol machines
+     * @param hashFunction Hash function to hash with
+     * @return HashCode representing protocol state hashed by the given hash function
+     */
+    public static HashCode getHashCode(SortedSet<PMachine> machines, HashFunction hashFunction) {
+        return hashFunction.hashString(getExactString(machines), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Get the exact protocol state as a string.
+     *
+     * @param machines Sorted set of protocol machines
+     * @return String representing the exact protocol state
+     */
+    public static String getExactString(SortedSet<PMachine> machines) {
+        StringBuilder sb = new StringBuilder();
+        for (PMachine machine : machines) {
+            sb.append(machine);
+            for (Object value : machine.getLocalVarValues()) {
+                sb.append(value);
+            }
+        }
+        return sb.toString();
+    }
+
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
@@ -16,6 +16,7 @@ public class PBool extends PValue<PBool> {
      */
     public PBool(boolean val) {
         value = val;
+        setRep();
     }
 
     /**
@@ -26,6 +27,7 @@ public class PBool extends PValue<PBool> {
     public PBool(Object val) {
         if (val instanceof PBool) value = ((PBool) val).value;
         else value = (boolean) val;
+        setRep();
     }
 
     /**
@@ -35,6 +37,7 @@ public class PBool extends PValue<PBool> {
      */
     public PBool(PBool val) {
         value = val.value;
+        setRep();
     }
 
     /**
@@ -90,8 +93,13 @@ public class PBool extends PValue<PBool> {
     }
 
     @Override
-    public int hashCode() {
-        return Boolean.valueOf(value).hashCode();
+    protected void setHashCode() {
+        hashCode = Boolean.valueOf(value).hashCode();
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = Boolean.toString(value);
     }
 
     @Override
@@ -101,10 +109,5 @@ public class PBool extends PValue<PBool> {
             return false;
         }
         return this.value == ((PBool) obj).value;
-    }
-
-    @Override
-    public String toString() {
-        return Boolean.toString(value);
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
@@ -16,7 +16,7 @@ public class PBool extends PValue<PBool> {
      */
     public PBool(boolean val) {
         value = val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -27,7 +27,7 @@ public class PBool extends PValue<PBool> {
     public PBool(Object val) {
         if (val instanceof PBool) value = ((PBool) val).value;
         else value = (boolean) val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -37,7 +37,7 @@ public class PBool extends PValue<PBool> {
      */
     public PBool(PBool val) {
         value = val.value;
-        setRep();
+        initialize();
     }
 
     /**
@@ -93,13 +93,8 @@ public class PBool extends PValue<PBool> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = Boolean.valueOf(value).hashCode();
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = Boolean.toString(value);
+    protected String _asString() {
+        return Boolean.toString(value);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
@@ -21,6 +21,7 @@ public class PEnum extends PValue<PEnum> {
         this.type = type;
         this.name = name;
         this.value = val;
+        setRep();
     }
 
     /**
@@ -32,6 +33,7 @@ public class PEnum extends PValue<PEnum> {
         type = val.type;
         name = val.name;
         value = val.value;
+        setRep();
     }
 
     /**
@@ -49,8 +51,13 @@ public class PEnum extends PValue<PEnum> {
     }
 
     @Override
-    public int hashCode() {
-        return Long.hashCode(value);
+    protected void setHashCode() {
+        hashCode = Long.hashCode(value);
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = name;
     }
 
     @Override
@@ -60,10 +67,5 @@ public class PEnum extends PValue<PEnum> {
             return false;
         }
         return this.value == ((PEnum) obj).value;
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
@@ -21,7 +21,7 @@ public class PEnum extends PValue<PEnum> {
         this.type = type;
         this.name = name;
         this.value = val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -33,7 +33,7 @@ public class PEnum extends PValue<PEnum> {
         type = val.type;
         name = val.name;
         value = val.value;
-        setRep();
+        initialize();
     }
 
     /**
@@ -51,13 +51,8 @@ public class PEnum extends PValue<PEnum> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = Long.hashCode(value);
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = name;
+    protected String _asString() {
+        return name;
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEvent.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEvent.java
@@ -28,6 +28,7 @@ public class PEvent extends PValue<PEvent> {
      */
     public PEvent(String name) {
         this.name = name;
+        setRep();
     }
 
     /**
@@ -37,6 +38,7 @@ public class PEvent extends PValue<PEvent> {
      */
     public PEvent(PEvent event) {
         this.name = event.name;
+        setRep();
     }
 
     public boolean isCreateMachineEvent() {
@@ -53,21 +55,21 @@ public class PEvent extends PValue<PEvent> {
     }
 
     @Override
+    protected void setHashCode() {
+        hashCode = Objects.hash(name);
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = name;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         else if (!(obj instanceof PEvent)) {
             return false;
         }
         return this.name.equals(((PEvent) obj).name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name);
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEvent.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEvent.java
@@ -1,7 +1,5 @@
 package pexplicit.values;
 
-import java.util.Objects;
-
 /**
  * Represents a P event
  */
@@ -28,7 +26,7 @@ public class PEvent extends PValue<PEvent> {
      */
     public PEvent(String name) {
         this.name = name;
-        setRep();
+        initialize();
     }
 
     /**
@@ -38,7 +36,7 @@ public class PEvent extends PValue<PEvent> {
      */
     public PEvent(PEvent event) {
         this.name = event.name;
-        setRep();
+        initialize();
     }
 
     public boolean isCreateMachineEvent() {
@@ -55,13 +53,8 @@ public class PEvent extends PValue<PEvent> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = Objects.hash(name);
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = name;
+    protected String _asString() {
+        return name;
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
@@ -16,7 +16,7 @@ public class PFloat extends PValue<PFloat> {
      */
     public PFloat(double val) {
         value = val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -30,7 +30,7 @@ public class PFloat extends PValue<PFloat> {
             value = ((PFloat) val).value;
         else
             value = (double) val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -40,7 +40,7 @@ public class PFloat extends PValue<PFloat> {
      */
     public PFloat(PFloat val) {
         value = val.value;
-        setRep();
+        initialize();
     }
 
     /**
@@ -158,13 +158,8 @@ public class PFloat extends PValue<PFloat> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = Double.valueOf(value).hashCode();
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = Double.toString(value);
+    protected String _asString() {
+        return Double.toString(value);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
@@ -16,6 +16,7 @@ public class PFloat extends PValue<PFloat> {
      */
     public PFloat(double val) {
         value = val;
+        setRep();
     }
 
     /**
@@ -29,6 +30,7 @@ public class PFloat extends PValue<PFloat> {
             value = ((PFloat) val).value;
         else
             value = (double) val;
+        setRep();
     }
 
     /**
@@ -38,6 +40,7 @@ public class PFloat extends PValue<PFloat> {
      */
     public PFloat(PFloat val) {
         value = val.value;
+        setRep();
     }
 
     /**
@@ -155,8 +158,13 @@ public class PFloat extends PValue<PFloat> {
     }
 
     @Override
-    public int hashCode() {
-        return Double.valueOf(value).hashCode();
+    protected void setHashCode() {
+        hashCode = Double.valueOf(value).hashCode();
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = Double.toString(value);
     }
 
     @Override
@@ -167,10 +175,5 @@ public class PFloat extends PValue<PFloat> {
             return false;
         }
         return this.value == ((PFloat) obj).value;
-    }
-
-    @Override
-    public String toString() {
-        return Double.toString(value);
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -16,7 +16,7 @@ public class PInt extends PValue<PInt> {
      */
     public PInt(int val) {
         value = val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -29,7 +29,7 @@ public class PInt extends PValue<PInt> {
             value = ((PInt) val).value;
         else
             value = (int) val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -39,7 +39,7 @@ public class PInt extends PValue<PInt> {
      */
     public PInt(PInt val) {
         value = val.value;
-        setRep();
+        initialize();
     }
 
     /**
@@ -156,13 +156,8 @@ public class PInt extends PValue<PInt> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = ((Integer) value).hashCode();
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = Long.toString(value);
+    protected String _asString() {
+        return Long.toString(value);
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -16,6 +16,7 @@ public class PInt extends PValue<PInt> {
      */
     public PInt(int val) {
         value = val;
+        setRep();
     }
 
     /**
@@ -28,6 +29,7 @@ public class PInt extends PValue<PInt> {
             value = ((PInt) val).value;
         else
             value = (int) val;
+        setRep();
     }
 
     /**
@@ -37,6 +39,7 @@ public class PInt extends PValue<PInt> {
      */
     public PInt(PInt val) {
         value = val.value;
+        setRep();
     }
 
     /**
@@ -153,8 +156,13 @@ public class PInt extends PValue<PInt> {
     }
 
     @Override
-    public int hashCode() {
-        return ((Integer) value).hashCode();
+    protected void setHashCode() {
+        hashCode = ((Integer) value).hashCode();
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = Long.toString(value);
     }
 
     @Override
@@ -165,10 +173,5 @@ public class PInt extends PValue<PInt> {
             return false;
         }
         return this.value == ((PInt) obj).value;
-    }
-
-    @Override
-    public String toString() {
-        return Long.toString(value);
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
@@ -19,7 +19,7 @@ public class PMachineValue extends PValue<PMachineValue> {
      */
     public PMachineValue(PMachine val) {
         value = val;
-        setRep();
+        initialize();
     }
 
     /**
@@ -40,13 +40,8 @@ public class PMachineValue extends PValue<PMachineValue> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = value.hashCode();
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = value.toString();
+    protected String _asString() {
+        return value.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
@@ -19,6 +19,7 @@ public class PMachineValue extends PValue<PMachineValue> {
      */
     public PMachineValue(PMachine val) {
         value = val;
+        setRep();
     }
 
     /**
@@ -39,8 +40,13 @@ public class PMachineValue extends PValue<PMachineValue> {
     }
 
     @Override
-    public int hashCode() {
-        return value.hashCode();
+    protected void setHashCode() {
+        hashCode = value.hashCode();
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = value.toString();
     }
 
     @Override
@@ -50,10 +56,5 @@ public class PMachineValue extends PValue<PMachineValue> {
             return false;
         }
         return this.value.equals(((PMachineValue) obj).value);
-    }
-
-    @Override
-    public String toString() {
-        return value.toString();
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -23,7 +23,7 @@ public class PMap extends PValue<PMap> implements PCollection {
         for (Map.Entry<PValue<?>, PValue<?>> entry : input_map.entrySet()) {
             map.put(PValue.clone(entry.getKey()), PValue.clone(entry.getValue()));
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -157,12 +157,7 @@ public class PMap extends PValue<PMap> implements PCollection {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = ComputeHash.getHashCode(map.values()) ^ ComputeHash.getHashCode(map.keySet());
-    }
-
-    @Override
-    protected void setStringRep() {
+    protected String _asString() {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         boolean hadElements = false;
@@ -176,7 +171,7 @@ public class PMap extends PValue<PMap> implements PCollection {
             hadElements = true;
         }
         sb.append("}");
-        stringRep = sb.toString();
+        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -23,6 +23,7 @@ public class PMap extends PValue<PMap> implements PCollection {
         for (Map.Entry<PValue<?>, PValue<?>> entry : input_map.entrySet()) {
             map.put(PValue.clone(entry.getKey()), PValue.clone(entry.getValue()));
         }
+        setRep();
     }
 
     /**
@@ -156,8 +157,26 @@ public class PMap extends PValue<PMap> implements PCollection {
     }
 
     @Override
-    public int hashCode() {
-        return ComputeHash.getHashCode(map.values()) ^ ComputeHash.getHashCode(map.keySet());
+    protected void setHashCode() {
+        hashCode = ComputeHash.getHashCode(map.values()) ^ ComputeHash.getHashCode(map.keySet());
+    }
+
+    @Override
+    protected void setStringRep() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        boolean hadElements = false;
+        for (PValue<?> key : map.keySet()) {
+            if (hadElements) {
+                sb.append(", ");
+            }
+            sb.append(key);
+            sb.append("-> ");
+            sb.append(map.get(key));
+            hadElements = true;
+        }
+        sb.append("}");
+        stringRep = sb.toString();
     }
 
     @Override
@@ -178,23 +197,5 @@ public class PMap extends PValue<PMap> implements PCollection {
             }
         }
         return true;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("(");
-        boolean hadElements = false;
-        for (PValue<?> key : map.keySet()) {
-            if (hadElements) {
-                sb.append(", ");
-            }
-            sb.append(key);
-            sb.append("-> ");
-            sb.append(map.get(key));
-            hadElements = true;
-        }
-        sb.append(")");
-        return sb.toString();
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMessage.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMessage.java
@@ -23,7 +23,7 @@ public class PMessage extends PValue<PMessage> {
         this.event = event;
         this.target = target;
         this.payload = payload;
-        setRep();
+        initialize();
     }
 
     public PMessage setTarget(PMachine target) {
@@ -36,18 +36,13 @@ public class PMessage extends PValue<PMessage> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = ComputeHash.getHashCode(target, event, payload);
-    }
-
-    @Override
-    protected void setStringRep() {
+    protected String _asString() {
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("%s@%s", event, target));
         if (payload != null) {
             sb.append(String.format(" :payload %s", payload));
         }
-        stringRep = sb.toString();
+        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMessage.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMessage.java
@@ -1,10 +1,7 @@
-package pexplicit.runtime.machine.events;
+package pexplicit.values;
 
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.values.ComputeHash;
-import pexplicit.values.PEvent;
-import pexplicit.values.PValue;
 
 /**
  * Represents a message containing details about the event, target machine, and event payload.
@@ -26,6 +23,7 @@ public class PMessage extends PValue<PMessage> {
         this.event = event;
         this.target = target;
         this.payload = payload;
+        setRep();
     }
 
     public PMessage setTarget(PMachine target) {
@@ -38,8 +36,18 @@ public class PMessage extends PValue<PMessage> {
     }
 
     @Override
-    public int hashCode() {
-        return ComputeHash.getHashCode(target, event, payload);
+    protected void setHashCode() {
+        hashCode = ComputeHash.getHashCode(target, event, payload);
+    }
+
+    @Override
+    protected void setStringRep() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("%s@%s", event, target));
+        if (payload != null) {
+            sb.append(String.format(" :payload %s", payload));
+        }
+        stringRep = sb.toString();
     }
 
     @Override
@@ -57,15 +65,5 @@ public class PMessage extends PValue<PMessage> {
             return false;
         }
         return this.payload == other.payload;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("%s@%s", event, target));
-        if (payload != null) {
-            sb.append(String.format(" :payload %s", payload));
-        }
-        return sb.toString();
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
@@ -27,6 +27,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
         for (int i = 0; i < input_fields.size(); i++) {
             values.put(input_fields.get(i), input_values.get(i));
         }
+        setRep();
     }
 
     /**
@@ -39,6 +40,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
         for (Map.Entry<String, PValue<?>> entry : input_values.entrySet()) {
             values.put(entry.getKey(), PValue.clone(entry.getValue()));
         }
+        setRep();
     }
 
     /**
@@ -108,8 +110,26 @@ public class PNamedTuple extends PValue<PNamedTuple> {
     }
 
     @Override
-    public int hashCode() {
-        return ComputeHash.getHashCode(values.values());
+    protected void setHashCode() {
+        hashCode = ComputeHash.getHashCode(values.values());
+    }
+
+    @Override
+    protected void setStringRep() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(");
+        boolean hadElements = false;
+        for (String name : values.keySet()) {
+            if (hadElements) {
+                sb.append(", ");
+            }
+            sb.append(name);
+            sb.append(": ");
+            sb.append(values.get(name));
+            hadElements = true;
+        }
+        sb.append(")");
+        stringRep = sb.toString();
     }
 
     @Override
@@ -132,23 +152,5 @@ public class PNamedTuple extends PValue<PNamedTuple> {
             }
         }
         return true;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("(");
-        boolean hadElements = false;
-        for (String name : values.keySet()) {
-            if (hadElements) {
-                sb.append(", ");
-            }
-            sb.append(name);
-            sb.append(": ");
-            sb.append(values.get(name));
-            hadElements = true;
-        }
-        sb.append(")");
-        return sb.toString();
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
@@ -27,7 +27,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
         for (int i = 0; i < input_fields.size(); i++) {
             values.put(input_fields.get(i), input_values.get(i));
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -40,7 +40,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
         for (Map.Entry<String, PValue<?>> entry : input_values.entrySet()) {
             values.put(entry.getKey(), PValue.clone(entry.getValue()));
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -110,12 +110,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = ComputeHash.getHashCode(values.values());
-    }
-
-    @Override
-    protected void setStringRep() {
+    protected String _asString() {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
         boolean hadElements = false;
@@ -129,7 +124,7 @@ public class PNamedTuple extends PValue<PNamedTuple> {
             hadElements = true;
         }
         sb.append(")");
-        stringRep = sb.toString();
+        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -21,6 +21,7 @@ public class PSeq extends PValue<PSeq> implements PCollection {
         for (PValue<?> entry : input_seq) {
             seq.add(PValue.clone(entry));
         }
+        setRep();
     }
 
     /**
@@ -111,8 +112,22 @@ public class PSeq extends PValue<PSeq> implements PCollection {
     }
 
     @Override
-    public int hashCode() {
-        return ComputeHash.getHashCode(seq);
+    protected void setHashCode() {
+        hashCode = ComputeHash.getHashCode(seq);
+    }
+
+    @Override
+    protected void setStringRep() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        String sep = "";
+        for (PValue<?> item : seq) {
+            sb.append(sep);
+            sb.append(item);
+            sep = ", ";
+        }
+        sb.append("]");
+        stringRep = sb.toString();
     }
 
     @Override
@@ -133,20 +148,6 @@ public class PSeq extends PValue<PSeq> implements PCollection {
             }
         }
         return true;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
-        String sep = "";
-        for (PValue<?> item : seq) {
-            sb.append(sep);
-            sb.append(item);
-            sep = ", ";
-        }
-        sb.append("]");
-        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -21,7 +21,7 @@ public class PSeq extends PValue<PSeq> implements PCollection {
         for (PValue<?> entry : input_seq) {
             seq.add(PValue.clone(entry));
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -112,12 +112,7 @@ public class PSeq extends PValue<PSeq> implements PCollection {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = ComputeHash.getHashCode(seq);
-    }
-
-    @Override
-    protected void setStringRep() {
+    protected String _asString() {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         String sep = "";
@@ -127,7 +122,7 @@ public class PSeq extends PValue<PSeq> implements PCollection {
             sep = ", ";
         }
         sb.append("]");
-        stringRep = sb.toString();
+        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
@@ -23,7 +23,7 @@ public class PSet extends PValue<PSet> implements PCollection {
     public PSet(List<PValue<?>> input_set) {
         entries = new ArrayList<>(input_set);
         unique_entries = new HashSet<>(input_set);
-        setRep();
+        initialize();
     }
 
     /**
@@ -109,12 +109,7 @@ public class PSet extends PValue<PSet> implements PCollection {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = ComputeHash.getHashCode(unique_entries);
-    }
-
-    @Override
-    protected void setStringRep() {
+    protected String _asString() {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         String sep = "";
@@ -124,7 +119,7 @@ public class PSet extends PValue<PSet> implements PCollection {
             sep = ", ";
         }
         sb.append("}");
-        stringRep = sb.toString();
+        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
@@ -23,6 +23,7 @@ public class PSet extends PValue<PSet> implements PCollection {
     public PSet(List<PValue<?>> input_set) {
         entries = new ArrayList<>(input_set);
         unique_entries = new HashSet<>(input_set);
+        setRep();
     }
 
     /**
@@ -108,8 +109,22 @@ public class PSet extends PValue<PSet> implements PCollection {
     }
 
     @Override
-    public int hashCode() {
-        return ComputeHash.getHashCode(unique_entries);
+    protected void setHashCode() {
+        hashCode = ComputeHash.getHashCode(unique_entries);
+    }
+
+    @Override
+    protected void setStringRep() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        String sep = "";
+        for (PValue<?> item : entries) {
+            sb.append(sep);
+            sb.append(item);
+            sep = ", ";
+        }
+        sb.append("}");
+        stringRep = sb.toString();
     }
 
     @Override
@@ -130,20 +145,6 @@ public class PSet extends PValue<PSet> implements PCollection {
             }
         }
         return true;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("(");
-        String sep = "";
-        for (PValue<?> item : entries) {
-            sb.append(sep);
-            sb.append(item);
-            sep = ", ";
-        }
-        sb.append(")");
-        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
@@ -32,6 +32,7 @@ public class PString extends PValue<PString> {
             }
             this.value = MessageFormat.format(base, args);
         }
+        setRep();
     }
 
     /**
@@ -101,8 +102,13 @@ public class PString extends PValue<PString> {
     }
 
     @Override
-    public int hashCode() {
-        return value.hashCode();
+    protected void setHashCode() {
+        hashCode = value.hashCode();
+    }
+
+    @Override
+    protected void setStringRep() {
+        stringRep = value;
     }
 
     @Override
@@ -112,10 +118,5 @@ public class PString extends PValue<PString> {
             return false;
         }
         return this.value.equals(((PString) obj).value);
-    }
-
-    @Override
-    public String toString() {
-        return value;
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
@@ -32,7 +32,7 @@ public class PString extends PValue<PString> {
             }
             this.value = MessageFormat.format(base, args);
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -102,13 +102,8 @@ public class PString extends PValue<PString> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = value.hashCode();
-    }
-
-    @Override
-    protected void setStringRep() {
-        stringRep = value;
+    protected String _asString() {
+        return value;
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -2,8 +2,6 @@ package pexplicit.values;
 
 import pexplicit.values.exceptions.TupleInvalidIndexException;
 
-import java.util.Arrays;
-
 /**
  * Represents the PValue for P unnamed tuple
  */
@@ -18,7 +16,7 @@ public class PTuple extends PValue<PTuple> {
         for (int i = 0; i < input_fields.length; i++) {
             this.fields[i] = PValue.clone(input_fields[i]);
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -29,7 +27,7 @@ public class PTuple extends PValue<PTuple> {
         for (int i = 0; i < other.fields.length; i++) {
             this.fields[i] = PValue.clone(other.fields[i]);
         }
-        setRep();
+        initialize();
     }
 
     /**
@@ -63,12 +61,7 @@ public class PTuple extends PValue<PTuple> {
     }
 
     @Override
-    protected void setHashCode() {
-        hashCode = Arrays.hashCode(fields);
-    }
-
-    @Override
-    protected void setStringRep() {
+    protected String _asString() {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
         String sep = "";
@@ -78,7 +71,7 @@ public class PTuple extends PValue<PTuple> {
             sep = ", ";
         }
         sb.append(")");
-        stringRep = sb.toString();
+        return sb.toString();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -18,6 +18,7 @@ public class PTuple extends PValue<PTuple> {
         for (int i = 0; i < input_fields.length; i++) {
             this.fields[i] = PValue.clone(input_fields[i]);
         }
+        setRep();
     }
 
     /**
@@ -28,6 +29,7 @@ public class PTuple extends PValue<PTuple> {
         for (int i = 0; i < other.fields.length; i++) {
             this.fields[i] = PValue.clone(other.fields[i]);
         }
+        setRep();
     }
 
     /**
@@ -61,8 +63,22 @@ public class PTuple extends PValue<PTuple> {
     }
 
     @Override
-    public int hashCode() {
-        return Arrays.hashCode(fields);
+    protected void setHashCode() {
+        hashCode = Arrays.hashCode(fields);
+    }
+
+    @Override
+    protected void setStringRep() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(");
+        String sep = "";
+        for (PValue<?> field : fields) {
+            sb.append(sep);
+            sb.append(field);
+            sep = ", ";
+        }
+        sb.append(")");
+        stringRep = sb.toString();
     }
 
     @Override
@@ -83,19 +99,5 @@ public class PTuple extends PValue<PTuple> {
             }
         }
         return true;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("(");
-        String sep = "";
-        for (PValue<?> field : fields) {
-            sb.append(sep);
-            sb.append(field);
-            sep = ", ";
-        }
-        sb.append(")");
-        return sb.toString();
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -18,11 +18,6 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      */
     private String stringRep;
 
-    protected void initialize() {
-        stringRep = _asString();
-        hashCode = Objects.hashCode(stringRep);
-    }
-
     /**
      * Create a safe clone of the passed PValue
      *
@@ -61,6 +56,11 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      */
     public static boolean notEqual(PValue<?> val1, PValue<?> val2) {
         return !isEqual(val1, val2);
+    }
+
+    protected void initialize() {
+        stringRep = _asString();
+        hashCode = Objects.hashCode(stringRep);
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -12,11 +12,16 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
     /**
      * Hash code corresponding to the PValue
      */
-    protected int hashCode;
+    private int hashCode;
     /**
      * String representation of the PValue
      */
-    protected String stringRep;
+    private String stringRep;
+
+    protected void initialize() {
+        stringRep = _asString();
+        hashCode = Objects.hashCode(stringRep);
+    }
 
     /**
      * Create a safe clone of the passed PValue
@@ -63,6 +68,7 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      *
      * @return hash code
      */
+    @Override
     public int hashCode() {
         return hashCode;
     }
@@ -72,25 +78,15 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      *
      * @return string representation of the PValue
      */
+    @Override
     public String toString() {
         return stringRep;
     }
 
-    protected void setRep() {
-//        setHashCode();
-        setStringRep();
-        hashCode = Objects.hashCode(stringRep);
-    }
-
-    /**
-     * Computes the hash representation for the PValue
-     */
-    protected abstract void setHashCode();
-
     /**
      * Computes the string representation for the PValue
      */
-    protected abstract void setStringRep();
+    protected abstract String _asString();
 
     /**
      * Function to create a deep clone of the PValue

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -1,6 +1,7 @@
 package pexplicit.values;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Interface that must be implemented by all P data types.
@@ -8,6 +9,15 @@ import java.io.Serializable;
  * @param <T> T is the type of P Value
  */
 public abstract class PValue<T extends PValue<T>> implements Serializable {
+    /**
+     * Hash code corresponding to the PValue
+     */
+    protected int hashCode;
+    /**
+     * String representation of the PValue
+     */
+    protected String stringRep;
+
     /**
      * Create a safe clone of the passed PValue
      *
@@ -49,18 +59,45 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
     }
 
     /**
+     * Returns the hash code for the PValue
+     *
+     * @return hash code
+     */
+    public int hashCode() {
+        return hashCode;
+    }
+
+    /**
+     * Returns the string representation of the PValue
+     *
+     * @return string representation of the PValue
+     */
+    public String toString() {
+        return stringRep;
+    }
+
+    protected void setRep() {
+//        setHashCode();
+        setStringRep();
+        hashCode = Objects.hashCode(stringRep);
+    }
+
+    /**
+     * Computes the hash representation for the PValue
+     */
+    protected abstract void setHashCode();
+
+    /**
+     * Computes the string representation for the PValue
+     */
+    protected abstract void setStringRep();
+
+    /**
      * Function to create a deep clone of the PValue
      *
      * @return deep clone of the PValue
      */
     public abstract T clone();
-
-    /**
-     * Returns the hash code for the PValue
-     *
-     * @return hash code
-     */
-    public abstract int hashCode();
 
     /**
      * Checks if the current PValue is equal to the passed PValue
@@ -69,12 +106,5 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
      * @return true if the two values are equal and false otherwise
      */
     public abstract boolean equals(Object other);
-
-    /**
-     * Returns the string representation of the PValue
-     *
-     * @return string representation of the PValue
-     */
-    public abstract String toString();
 
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 public class TestPExplicit {
     private static final String outputDirectory = "output/testCases";
     private static final List<String> excluded = new ArrayList<>();
-    private static String timeout = "60";
+    private static String timeout = "30";
     private static String schedules = "100";
     private static String maxSteps = "10000";
-    private static String runArgs = "--sch-coverage dfs -v";
+    private static String runArgs = "";
     private static boolean initialized = false;
 
     private static void setRunArgs() {


### PR DESCRIPTION
Updates include:

[State caching]
- Adds storing hash code and string representation during `PValue` initialization for performance
- Adds new state caching modes using hash functions from Google's guava library
- New state caching modes include: `hashcode` (using `hashCode()` from `PValue` and Java built-ins, 32-bit hashes), `siphash24` (64-bit), `murmur3_128` (128-bit, default), `sha256` (256-bit), or `exact` (using exact string representation).

[Non-chronological backtracking]
- Adds non-chronological search that implements search beyond a fixed order (e.g., beyond depth-first or breadth-first).
- Breaks down exploration into `SearchTask`, where each task explores a slice of the execution tree.
- Each search task tracks a set of contiguous unexplored choices it is assigned to explore. It either explores all of them completely, or creates new children tasks for remaining unexplored sub-choices.
- Exploration within a SearchTask is chronological, exploration across SearchTasks is non-chronological and can jump at arbitrary places in the execution tree.
- New CLI option `--strategy` to set the search strategy: `dfs`, `random` (default), `astar`
- New hidden CLI option `--schedules-per-task <uint>` to set the number of schedules explored in each SearchTask in `random`/`astar` strategy. Default is `100`. For `dfs`, there is no limit.
- New hidden CLI option `--children-per-task <uint>` (default `2`). This relates with how packaging of SearchTask is done, to set how many children tasks each SearchTask can generate after completion. Default is 2 that uses head-tail split, i.e., slice the shallowest unexplored choice as an independent SearchTask (head), and any remaining unexplored choices as another SearchTask (tail).
- DFS strategy has a single SearchTask at any given time.
- Random strategy can have many SearchTask. After a SearchTask completes, the next task is randomly chosen from the pending tasks list.
- A* strategy can have many SearchTask as well. After a SearchTask completes, the next task is chosen by preferring the one that is shallowest, by using search depth as the cost function.

