### PR TITLE
[PEx] Corrections to stateful search, support Java foreign functions

### DIFF
--- a/Docs/docs/manual/expressions.md
+++ b/Docs/docs/manual/expressions.md
@@ -342,3 +342,12 @@ The choose operation can be used to model nondeterministic environment machines 
 
 !!! note ""
     Performing a `choose` over an empty collection leads to an error. Also, `choose` from a `map` value returns a random key from the map.
+
+Note that the maximum number of choices allowed in a `choose(expr)` is 10,000. Performing a `choose` with an `int` value greater than 10000 or over a collection with more than 10000 elements leads to an error.
+
+``` java
+choose(10001) // throws a compile-time error
+choose(x)     // throws a runtime error if x is of integer type and has value greater than 10000
+choose(x)     // throws a runtime error if x is of seq/set/map type and has size greater than 10000 elements
+```
+

--- a/Src/PChecker/CheckerCore/CheckerConfiguration.cs
+++ b/Src/PChecker/CheckerCore/CheckerConfiguration.cs
@@ -275,10 +275,10 @@ namespace PChecker
         public bool DisableEnvironmentExit;
 
         /// <summary>
-        /// Additional arguments to pass to PSym.
+        /// Additional arguments to pass to checker.
         /// </summary>
         [DataMember]
-        public string PSymArgs;
+        public string CheckerArgs;
 
         /// <summary>
         /// Additional arguments to pass to JVM-based checker.
@@ -332,7 +332,7 @@ namespace PChecker
             EnableColoredConsoleOutput = false;
             DisableEnvironmentExit = true;
 
-            PSymArgs = "";
+            CheckerArgs = "";
             JvmArgs = "";
         }
 

--- a/Src/PChecker/CheckerCore/ExhaustiveSearch/ExhaustiveSearch.cs
+++ b/Src/PChecker/CheckerCore/ExhaustiveSearch/ExhaustiveSearch.cs
@@ -110,7 +110,7 @@ namespace PChecker.ExhaustiveSearch
                 }
             }
 
-            arguments.Append($"{_checkerConfiguration.PSymArgs} ");
+            arguments.Append($"{_checkerConfiguration.CheckerArgs} ");
 
             return arguments.ToString();
         }

--- a/Src/PCompiler/CompilerCore/Backend/Java/EventGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/EventGenerator.cs
@@ -51,7 +51,7 @@ namespace Plang.Compiler.Backend.Java
             var payloadType = argType.TypeName;
             var payloadRefType = argType.ReferenceTypeName;
 
-            WriteLine($"public static class {eventName} extends {Constants.PEventsClass}<{payloadRefType}> {{");
+            WriteLine($"public static class {eventName} extends {Constants.PEventsClass}<{payloadRefType}> implements Serializable {{");
 
             var hasPayload = !(argType is TypeManager.JType.JVoid);
             if (hasPayload)

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypesGenerator.cs
@@ -109,7 +109,7 @@ namespace Plang.Compiler.Backend.Java
             }
 
             var tname = Names.NameForNamedTuple(t);
-            WriteLine($"public static class {tname} implements {Constants.PValueClass}<{tname}> {{");
+            WriteLine($"public static class {tname} implements {Constants.PValueClass}<{tname}>, Serializable {{");
             WriteLine($"// {t.CanonicalRepresentation}");
 
             WriteNamedTupleFields(fields);

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -1645,26 +1645,29 @@ namespace Plang.Compiler.Backend.PExplicit
                     context.Write(output, $".getValues()");
                     break;
                 case MapAccessExpr mapAccessExpr:
+                    context.Write(output, $"(({GetPExplicitType(mapAccessExpr.MapExpr.Type)})");
                     WriteExpr(context, output, mapAccessExpr.MapExpr);
-                    context.Write(output, ".get(");
+                    context.Write(output, ").get(");
                     WriteExpr(context, output, mapAccessExpr.IndexExpr);
                     context.Write(output, ")");
                     break;
                 case SeqAccessExpr seqAccessExpr:
+                    context.Write(output, $"(({GetPExplicitType(seqAccessExpr.SeqExpr.Type)})");
                     WriteExpr(context, output, seqAccessExpr.SeqExpr);
-                    context.Write(output, ".get(");
+                    context.Write(output, ").get(");
                     WriteExpr(context, output, seqAccessExpr.IndexExpr);
                     context.Write(output, ")");
                     break;
                 case SetAccessExpr setAccessExpr:
+                    context.Write(output, $"(({GetPExplicitType(setAccessExpr.SetExpr.Type)})");
                     WriteExpr(context, output, setAccessExpr.SetExpr);
-                    context.Write(output, ".get(");
+                    context.Write(output, ").get(");
                     WriteExpr(context, output, setAccessExpr.IndexExpr);
                     context.Write(output, ")");
                     break;
                 case NamedTupleAccessExpr namedTupleAccessExpr:
                     context.Write(output, $"(({GetPExplicitType(namedTupleAccessExpr.Type)})(");
-                    context.Write(output, "(");
+                    context.Write(output, $"(({GetPExplicitType(namedTupleAccessExpr.SubExpr.Type)})");
                     WriteExpr(context, output, namedTupleAccessExpr.SubExpr);
                     context.Write(output, $").getField(\"{namedTupleAccessExpr.FieldName}\")))");
                     break;
@@ -1674,7 +1677,7 @@ namespace Plang.Compiler.Backend.PExplicit
                 case TupleAccessExpr tupleAccessExpr:
                     context.Write(output, $"({GetPExplicitType(tupleAccessExpr.Type)})(");
                     var tupleType = (tupleAccessExpr.SubExpr.Type.Canonicalize() as TupleType);
-                    context.Write(output, "(");
+                    context.Write(output, $"(({GetPExplicitType(tupleAccessExpr.SubExpr.Type)})");
                     WriteExpr(context, output, tupleAccessExpr.SubExpr);
                     context.Write(output, $").getField({tupleAccessExpr.FieldNo}))");
                     break;

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -946,8 +946,9 @@ namespace Plang.Compiler.Backend.PExplicit
                         (structureTemp) =>
                         {
                             context.Write(output, $"{structureTemp} = ");
+                            context.Write(output, $"(({GetPExplicitType(insertStmt.Variable.Type)}) ");
                             WriteExpr(context, output, insertStmt.Variable);
-                            context.Write(output, $".add(");
+                            context.Write(output, $").add(");
 
                             WriteExpr(context, output, insertStmt.Index);
                             context.Write(output, ", ");
@@ -970,8 +971,9 @@ namespace Plang.Compiler.Backend.PExplicit
                         (structureTemp) =>
                         {
                             context.Write(output, $"{structureTemp} = ");
+                            context.Write(output, $"(({GetPExplicitType(addStmt.Variable.Type)}) ");
                             WriteExpr(context, output, addStmt.Variable);
-                            context.Write(output, $".add(");
+                            context.Write(output, $").add(");
                             WriteExpr(context, output, addStmt.Value);
                             context.WriteLine(output, ");");
                         }
@@ -993,12 +995,13 @@ namespace Plang.Compiler.Backend.PExplicit
                         (structureTemp) =>
                         {
                             context.Write(output, $"{structureTemp} = ");
+                            context.Write(output, $"(({GetPExplicitType(removeStmt.Variable.Type)}) ");
                             WriteExpr(context, output, removeStmt.Variable);
 
                             if (isMap || isSet)
-                                context.Write(output, $".remove(");
+                                context.Write(output, $").remove(");
                             else
-                                context.Write(output, $".removeAt(");
+                                context.Write(output, $").removeAt(");
 
                             WriteExpr(context, output, removeStmt.Value);
                             context.WriteLine(output, ");");

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -1022,6 +1022,8 @@ namespace Plang.Compiler.Backend.PExplicit
                     break;
                 case ReceiveSplitStmt splitStmt:
                     context.WriteLine(output, $"{CompilationContext.CurrentMachine}.blockUntil(\"{context.GetContinuationName(splitStmt.Cont)}\");");
+                    context.Write(output, "return;");
+                    exited = true;
                     break;
                 default:
                     throw new NotImplementedException($"Statement type '{stmt.GetType().Name}' is not supported, found in {function.Name}");

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/TransformASTPass.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/TransformASTPass.cs
@@ -720,59 +720,59 @@ namespace Plang.Compiler.Backend.PExplicit
                             case WhileStmt loop:
                                 if (CanReceive(loop.Body))
                                 {
-                                    throw new NotImplementedException($"Receive in a while statement is not yet supported, found in {machine.Name}");
-                                    // // turn the while statement into a recursive function
-                                    // var whileName = $"while_{whileNumber}";
-                                    // whileNumber++;
-                                    // var rec = new WhileFunction(whileName, loop.SourceLocation);
-                                    // rec.Owner = function.Owner;
-                                    // rec.ParentFunction = function;
-                                    // foreach (var param in function.Signature.Parameters) rec.AddParameter(param);
-                                    // var newVarMap = new Dictionary<Variable,Variable>();
-                                    // foreach (var local in function.LocalVariables)
-                                    // {
-                                    //     var machineVar = new Variable($"{whileName}_{local.Name}", local.SourceLocation, local.Role);
-                                    //     machineVar.Type = local.Type;
-                                    //     machine.AddField(machineVar);
-                                    //     newVarMap.Add(local, machineVar);
-                                    // }
-                                    // foreach (var i in function.CreatesInterfaces) rec.AddCreatesInterface(i);
-                                    // rec.CanChangeState = function.CanChangeState;
-                                    // rec.CanRaiseEvent = function.CanRaiseEvent;
-                                    // rec.CanReceive = function.CanReceive;
-                                    // rec.IsNondeterministic = function.IsNondeterministic;
-                                    // // make while loop body
-                                    // var loopBody = new List<IPStmt>();
-                                    // var bodyEnumerator = loop.Body.Statements.GetEnumerator();
-                                    // while (bodyEnumerator.MoveNext())
-                                    // {   
-                                    //     var stmt = bodyEnumerator.Current;
-                                    //     var replaceBreak = ReplaceBreaks(stmt, afterStmts);
-                                    //     if (replaceBreak != null) {
-                                    //         loopBody.Add(ReplaceVars(replaceBreak, newVarMap));
-                                    //     }
-                                    // }
-                                    // var recArgs = new List<VariableAccessExpr>();
-                                    // foreach (var param in rec.Signature.Parameters)
-                                    // {
-                                    //     recArgs.Add(new VariableAccessExpr(rec.SourceLocation, param));
-                                    // }
-                                    // // call the function
-                                    // var recCall = new FunCallStmt(loop.SourceLocation, rec, recArgs);
-                                    // loopBody.Add(recCall);
-                                    // rec.AddCallee(rec);
-                                    // loopBody = new List<IPStmt>(((CompoundStmt) HandleReceives(new CompoundStmt(rec.SourceLocation, loopBody), rec, machine)).Statements);
-                                    // rec.Body = new CompoundStmt(rec.SourceLocation, loopBody);
-                                    // if (machine != null) machine.AddMethod(rec);
-                                    // // assign local variables
-                                    // foreach (var local in function.LocalVariables)
-                                    // {
-                                    //     result.Add(new AssignStmt(local.SourceLocation, new VariableAccessExpr(local.SourceLocation, newVarMap[local]), new VariableAccessExpr(local.SourceLocation, local)));
-                                    // }
-                                    // // replace the while statement with a function call
-                                    // result.Add(recCall);
-                                    // result.Add(new ReturnStmt(loop.SourceLocation, null));
-                                    // function.AddCallee(rec);
+                                    // throw new NotImplementedException($"Receive in a while statement is not yet supported, found in {machine.Name}");
+                                    // turn the while statement into a recursive function
+                                    var whileName = $"while_{whileNumber}";
+                                    whileNumber++;
+                                    var rec = new WhileFunction(whileName, loop.SourceLocation);
+                                    rec.Owner = function.Owner;
+                                    rec.ParentFunction = function;
+                                    foreach (var param in function.Signature.Parameters) rec.AddParameter(param);
+                                    var newVarMap = new Dictionary<Variable,Variable>();
+                                    foreach (var local in function.LocalVariables)
+                                    {
+                                        var machineVar = new Variable($"{whileName}_{local.Name}", local.SourceLocation, local.Role);
+                                        machineVar.Type = local.Type;
+                                        machine.AddField(machineVar);
+                                        newVarMap.Add(local, machineVar);
+                                    }
+                                    foreach (var i in function.CreatesInterfaces) rec.AddCreatesInterface(i);
+                                    rec.CanChangeState = function.CanChangeState;
+                                    rec.CanRaiseEvent = function.CanRaiseEvent;
+                                    rec.CanReceive = function.CanReceive;
+                                    rec.IsNondeterministic = function.IsNondeterministic;
+                                    // make while loop body
+                                    var loopBody = new List<IPStmt>();
+                                    var bodyEnumerator = loop.Body.Statements.GetEnumerator();
+                                    while (bodyEnumerator.MoveNext())
+                                    {   
+                                        var stmt = bodyEnumerator.Current;
+                                        var replaceBreak = ReplaceBreaks(stmt, afterStmts);
+                                        if (replaceBreak != null) {
+                                            loopBody.Add(ReplaceVars(replaceBreak, newVarMap));
+                                        }
+                                    }
+                                    var recArgs = new List<VariableAccessExpr>();
+                                    foreach (var param in rec.Signature.Parameters)
+                                    {
+                                        recArgs.Add(new VariableAccessExpr(rec.SourceLocation, param));
+                                    }
+                                    // call the function
+                                    var recCall = new FunCallStmt(loop.SourceLocation, rec, recArgs);
+                                    loopBody.Add(recCall);
+                                    rec.AddCallee(rec);
+                                    loopBody = new List<IPStmt>(((CompoundStmt) HandleReceives(new CompoundStmt(rec.SourceLocation, loopBody), rec, machine)).Statements);
+                                    rec.Body = new CompoundStmt(rec.SourceLocation, loopBody);
+                                    if (machine != null) machine.AddMethod(rec);
+                                    // assign local variables
+                                    foreach (var local in function.LocalVariables)
+                                    {
+                                        result.Add(new AssignStmt(local.SourceLocation, new VariableAccessExpr(local.SourceLocation, newVarMap[local]), new VariableAccessExpr(local.SourceLocation, local)));
+                                    }
+                                    // replace the while statement with a function call
+                                    result.Add(recCall);
+                                    result.Add(new ReturnStmt(loop.SourceLocation, null));
+                                    function.AddCallee(rec);
                                 }
                                 else
                                 {

--- a/Src/PCompiler/CompilerCore/DefaultTranslationErrorHandler.cs
+++ b/Src/PCompiler/CompilerCore/DefaultTranslationErrorHandler.cs
@@ -159,6 +159,11 @@ namespace Plang.Compiler
             return IssueError(context, $"choose expects a parameter of type int (max value) or a collection type (seq, set, or map) got a parameter of type {subExprType}");
         }
 
+        public Exception IllegalChooseSubExprValue(PParser.ChooseExprContext context, int numChoices)
+        {
+            return IssueError(context, $"choose expects a parameter with at most 10000 choices, got {numChoices} choices instead.");
+        }
+
         public Exception IllegalFunctionUsedInSpecMachine(Function function, Machine callerOwner)
         {
             return IssueError(function.SourceLocation,

--- a/Src/PCompiler/CompilerCore/ITranslationErrorHandler.cs
+++ b/Src/PCompiler/CompilerCore/ITranslationErrorHandler.cs
@@ -116,6 +116,7 @@ namespace Plang.Compiler
         Exception MoreThanOneParameterForHandlers(ParserRuleContext sourceLocation, int count);
 
         Exception IllegalChooseSubExprType(PParser.ChooseExprContext context, PLanguageType subExprType);
+        Exception IllegalChooseSubExprValue(PParser.ChooseExprContext context, int numChoices);
         Exception IllegalFunctionUsedInSpecMachine(Function function, Machine callerOwner);
 
         String SpecObservesSetIncompleteWarning(ParserRuleContext loc, PEvent ev, Machine machine);

--- a/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
@@ -393,7 +393,11 @@ namespace Plang.Compiler.TypeChecker
                     return new ChooseExpr(context, subExpr, mapType.KeyType);
 
                 case PrimitiveType primType when primType.IsSameTypeAs(PrimitiveType.Int):
+                {
+                    if (subExpr is IntLiteralExpr subExprAsInt && subExprAsInt.Value > 10000)
+                        throw handler.IllegalChooseSubExprValue(context, subExprAsInt.Value);
                     return new ChooseExpr(context, subExpr, PrimitiveType.Int);
+                }
 
                 default:
                     throw handler.IllegalChooseSubExprType(context, subExprType);

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -62,6 +62,9 @@ namespace Plang.Options
             var schCoverage = schedulingGroup.AddArgument("sch-coverage", null, "Choose the scheduling strategy for coverage mode (options: learn, random, dfs, stateless). (default: learn)");
             schCoverage.AllowedValues = new List<string>() { "learn", "random", "dfs", "stateless" };
             schCoverage.IsHidden = true;
+            var schExplicit = schedulingGroup.AddArgument("sch-explicit", null, "Choose the scheduling strategy for explicit mode (options: random, dfs, astar). (default: random)");
+            schExplicit.AllowedValues = new List<string>() { "random", "dfs", "astar" };
+            schExplicit.IsHidden = true;
 
             var replayOptions = Parser.GetOrCreateGroup("replay", "Replay and debug options");
             replayOptions.AddArgument("replay", "r", "Schedule file to replay");
@@ -72,9 +75,9 @@ namespace Plang.Options
             advancedGroup.AddArgument("graph-bug", null, "Output a DGML graph of the schedule that found a bug", typeof(bool));
             advancedGroup.AddArgument("graph", null, "Output a DGML graph of all test schedules whether a bug was found or not", typeof(bool));
             advancedGroup.AddArgument("xml-trace", null, "Specify a filename for XML runtime log output to be written to", typeof(bool));
+            advancedGroup.AddArgument("jvm-args", null, "Specify a concatenated list of JVM arguments to pass, each starting with a colon").IsHidden = true;
+            advancedGroup.AddArgument("checker-args", null, "Specify a concatenated list of additional checker arguments to pass, each starting with a colon").IsHidden = true;
             advancedGroup.AddArgument("psym-args", null, "Specify a concatenated list of additional PSym-specific arguments to pass, each starting with a colon").IsHidden = true;
-            advancedGroup.AddArgument("jvm-args", null, "Specify a concatenated list of PSym-specific JVM arguments to pass, each starting with a colon").IsHidden = true;
-
         }
 
         /// <summary>
@@ -245,6 +248,9 @@ namespace Plang.Options
                 case "sch-coverage":
                     checkerConfiguration.SchedulingStrategy = (string)option.Value;
                     break;
+                case "sch-explicit":
+                    checkerConfiguration.SchedulingStrategy = (string)option.Value;
+                    break;
                 case "replay":
                 {
                     var filename = (string)option.Value;
@@ -308,11 +314,12 @@ namespace Plang.Options
                 case "fail-on-maxsteps":
                     checkerConfiguration.ConsiderDepthBoundHitAsBug = true;
                     break;
-                case "psym-args":
-                    checkerConfiguration.PSymArgs = ((string)option.Value).Replace(':', ' ');
-                    break;
                 case "jvm-args":
                     checkerConfiguration.JvmArgs = ((string)option.Value).Replace(':', ' ');
+                    break;
+                case "checker-args":
+                case "psym-args":
+                    checkerConfiguration.CheckerArgs = ((string)option.Value).Replace(':', ' ');
                     break;
                 case "pproj":
                     // do nothing, since already configured through UpdateConfigurationWithPProjectFile
@@ -347,7 +354,8 @@ namespace Plang.Options
                 checkerConfiguration.SchedulingStrategy != "replay" &&
                 checkerConfiguration.SchedulingStrategy != "learn" &&
                 checkerConfiguration.SchedulingStrategy != "dfs" &&
-                checkerConfiguration.SchedulingStrategy != "stateless")
+                checkerConfiguration.SchedulingStrategy != "stateless" &&
+                checkerConfiguration.SchedulingStrategy != "astar")
             {
                 Error.CheckerReportAndExit("Please provide a scheduling strategy (see --sch* options)");
             }

--- a/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
+++ b/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
@@ -236,7 +236,6 @@ namespace Plang.Parser
                             outputLanguages.Add(CompilerOutput.Symbolic);
                             break;
                         case "explicit":
-                        case "pexplicit":
                             outputLanguages.Add(CompilerOutput.PExplicit);
                             break;
                         case "pobserve":

--- a/Src/PRuntimes/PCSharpRuntime/PMachine.cs
+++ b/Src/PRuntimes/PCSharpRuntime/PMachine.cs
@@ -136,21 +136,27 @@ namespace Plang.CSharpRuntime
             switch (param)
             {
                 case PrtInt maxValue:
+                {
+                    TryAssert(maxValue <= 10000, $"choose expects a parameter with at most 10000 choices, got {maxValue} choices instead.");
                     return (PrtInt)TryRandomInt(maxValue);
+                }
 
                 case PrtSeq seq:
                 {
                     TryAssert(seq.Any(), "Trying to choose from an empty sequence!");
+                    TryAssert(seq.Count <= 10000, $"choose expects a parameter with at most 10000 choices, got {seq.Count} choices instead.");
                     return seq[TryRandomInt(seq.Count)];
                 }
                 case PrtSet set:
                 {
                     TryAssert(set.Any(), "Trying to choose from an empty set!");
+                    TryAssert(set.Count <= 10000, $"choose expects a parameter with at most 10000 choices, got {set.Count} choices instead.");
                     return set.ElementAt(TryRandomInt(set.Count));
                 }
                 case PrtMap map:
                 {
                     TryAssert(map.Any(), "Trying to choose from an empty map!");
+                    TryAssert(map.Keys.Count <= 10000, $"choose expects a parameter with at most 10000 choices, got {map.Keys.Count} choices instead.");
                     return map.Keys.ElementAt(TryRandomInt(map.Keys.Count));
                 }
                 default:

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -94,7 +94,7 @@ public class RuntimeExecutor {
             throw new Exception("MEMOUT", e);
         } catch (BugFoundException e) {
             PExplicitGlobal.setStatus(STATUS.BUG_FOUND);
-            PExplicitGlobal.setResult(String.format("found cex of length %d", scheduler.getStepState().getStepNumber()));
+            PExplicitGlobal.setResult(String.format("found cex of length %d", scheduler.getStepNumber()));
             PExplicitLogger.logStackTrace(e);
 
             ReplayScheduler replayer = new ReplayScheduler(scheduler.schedule);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -58,6 +58,8 @@ public class RuntimeExecutor {
         scheduler.recordStats();
         if (PExplicitGlobal.getResult().equals("correct for any depth")) {
             PExplicitGlobal.setStatus(STATUS.VERIFIED);
+        } else if (PExplicitGlobal.getResult().startsWith("correct up to step")) {
+            PExplicitGlobal.setStatus(STATUS.VERIFIED_UPTO_MAX_STEPS);
         }
         StatWriter.log("time-search-seconds", String.format("%.1f", searchTime));
     }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -13,8 +13,6 @@ import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 public class PExplicitConfig {
     // default name of the test driver
     final String testDriverDefault = "DefaultImpl";
-    // max internal steps before throwing an exception
-    final int maxInternalSteps = 100;
     // name of the test driver
     @Setter
     String testDriver = testDriverDefault;
@@ -62,7 +60,7 @@ public class PExplicitConfig {
     SearchStrategyMode searchStrategyMode = SearchStrategyMode.Random;
     // max number of schedules per search task
     @Setter
-    int maxSchedulesPerTask = 100;
+    int maxSchedulesPerTask = 10;
     //max number of children search tasks
     @Setter
     int maxChildrenPerTask = 2;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -297,7 +297,7 @@ public class PExplicitOptions {
                             config.setSearchStrategyMode(SearchStrategyMode.Random);
                             break;
                         case "astar":
-                            config.setSearchStrategyMode(SearchStrategyMode.AStar);
+                            config.setSearchStrategyMode(SearchStrategyMode.Astar);
                             break;
                         default:
                             optionError(

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/ForeignFunctionInterface.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/ForeignFunctionInterface.java
@@ -1,0 +1,28 @@
+package pexplicit.runtime;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ForeignFunctionInterface {
+  /**
+   * Invoke a foreign function with a void return type
+   *
+   * @param fn function to invoke
+   * @param args arguments
+   */
+  public static void accept(Consumer<List<Object>> fn, Object... args) {
+    fn.accept(List.of(args));
+  }
+
+  /**
+   * Invoke a foreign function with a non-void return type
+   *
+   * @param fn function to invoke
+   * @param args arguments
+   * @return the return value of the function
+   */
+  public static Object apply(Function<List<Object>, Object> fn, Object... args) {
+    return fn.apply(List.of(args));
+  }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/STATUS.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/STATUS.java
@@ -1,12 +1,29 @@
 package pexplicit.runtime;
 
 public enum STATUS {
-    INCOMPLETE,         // search still ongoing
-    SCHEDULEOUT,        // schedule limit reached
-    TIMEOUT,            // timeout reached
-    MEMOUT,             // memout reached
-    VERIFIED,           // full state space explored and no bug found
-    BUG_FOUND,          // found a bug
-    INTERRUPTED,        // interrupted by user
-    ERROR               // unexpected error encountered
+    INCOMPLETE("incomplete"),                           // search still ongoing
+    SCHEDULEOUT("scheduleout"),                         // schedule limit reached
+    TIMEOUT("timeout"),                                 // timeout reached
+    MEMOUT("memout"),                                   // memout reached
+    VERIFIED("proved"),                                 // full state space explored and no bug found
+    VERIFIED_UPTO_MAX_STEPS("proved"),   // full state space explored and no bug found upto max steps
+    BUG_FOUND("cex"),                                   // found a bug
+    INTERRUPTED("interrupted"),                         // interrupted by user
+    ERROR("error");                                     // unexpected error encountered
+
+    private String name;
+
+    /**
+     * Constructor
+     *
+     * @param n Name of the enum
+     */
+    STATUS(String n) {
+        this.name = n;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -146,6 +146,17 @@ public class PExplicitLogger {
         }
     }
 
+    /**
+     * Log when the next task is selected
+     *
+     * @param task Next search task
+     */
+    public static void logNextTask(SearchTask task) {
+        if (verbosity > 1) {
+            log.info(String.format("  Next task: %s", task.toStringDetailed()));
+        }
+    }
+
     public static void logNewTasks(List<SearchTask> tasks) {
         if (verbosity > 0) {
             log.info(String.format("    Added %d new tasks", tasks.size()));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -256,7 +256,7 @@ public class PExplicitLogger {
     public static void logNewState(int step, int idx, Object stateKey, SortedSet<PMachine> machines) {
         if (verbosity > 3) {
             log.info(String.format("    @%d::%d new state with key %s", step, idx, stateKey));
-            if (verbosity > 4) {
+            if (verbosity > 6) {
                 log.info(String.format("      %s", ComputeHash.getExactString(machines)));
             }
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachine.java
@@ -216,8 +216,8 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
 
         currentState = (State) values.get(idx++);
 
-        sendBuffer.setElements((List<PMessage>) values.get(idx++));
-        deferQueue.setElements((List<PMessage>) values.get(idx++));
+        sendBuffer.setElements(new ArrayList<>((List<PMessage>) values.get(idx++)));
+        deferQueue.setElements(new ArrayList<>((List<PMessage>) values.get(idx++)));
 
         started = (boolean) values.get(idx++);
         halted = (boolean) values.get(idx++);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
@@ -2,6 +2,7 @@ package pexplicit.runtime.machine.buffer;
 
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachine;
+import pexplicit.utils.exceptions.PExplicitRuntimeException;
 import pexplicit.utils.misc.Assert;
 import pexplicit.values.PMessage;
 
@@ -140,11 +141,8 @@ public abstract class MessageQueue implements Serializable {
         // dequeue the peek
         if (dequeue) {
             if (msgIdx == -1) {
-                if (elements.isEmpty()) {
-                    Assert.fromModel(false, "Cannot dequeue from empty queue");
-                } else {
-                    Assert.fromModel(false, "Cannot dequeue since all events in the queue are deferred");
-                }
+                assert (elements.isEmpty());
+                throw new PExplicitRuntimeException("Cannot dequeue from empty queue");
             } else {
                 msg = elements.remove(msgIdx);
                 if (msgIdx < elements.size()) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -2,7 +2,6 @@ package pexplicit.runtime.scheduler;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.tuple.Pair;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.scheduler.choice.Choice;
@@ -65,7 +64,7 @@ public class Schedule implements Serializable {
      * @param choiceNum Choice depth
      */
     public void removeChoicesAfter(int choiceNum) {
-        choices.subList(choiceNum+1, choices.size()).clear();
+        choices.subList(choiceNum + 1, choices.size()).clear();
     }
 
     /**
@@ -100,8 +99,8 @@ public class Schedule implements Serializable {
      * Set the schedule choice at a choice depth.
      *
      * @param stepNum    Step number
-     * @param choiceNum    Choice number
-     * @param current Machine to set as current schedule choice
+     * @param choiceNum  Choice number
+     * @param current    Machine to set as current schedule choice
      * @param unexplored List of machine to set as unexplored schedule choices
      */
     public void setScheduleChoice(int stepNum, int choiceNum, PMachine current, List<PMachine> unexplored) {
@@ -122,8 +121,8 @@ public class Schedule implements Serializable {
      * Set the data choice at a choice depth.
      *
      * @param stepNum    Step number
-     * @param choiceNum    Choice number
-     * @param current PValue to set as current schedule choice
+     * @param choiceNum  Choice number
+     * @param current    PValue to set as current schedule choice
      * @param unexplored List of PValue to set as unexplored schedule choices
      */
     public void setDataChoice(int stepNum, int choiceNum, PValue<?> current, List<PValue<?>> unexplored) {
@@ -190,7 +189,7 @@ public class Schedule implements Serializable {
         if (choice instanceof ScheduleChoice scheduleChoice) {
             return scheduleChoice;
         } else {
-            for (int i = choice.getChoiceNumber()-1; i >= 0; i--) {
+            for (int i = choice.getChoiceNumber() - 1; i >= 0; i--) {
                 Choice c = choices.get(i);
                 if (c instanceof ScheduleChoice scheduleChoice) {
                     return scheduleChoice;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -109,8 +109,8 @@ public class Schedule implements Serializable {
         }
         assert (choiceNum < choices.size());
         if (PExplicitGlobal.getConfig().isStatefulBacktrackEnabled()
-                && stepBeginState != null
                 && stepNum != 0) {
+            assert (stepBeginState != null);
             choices.set(choiceNum, new ScheduleChoice(stepNum, choiceNum, current, unexplored, stepBeginState));
         } else {
             choices.set(choiceNum, new ScheduleChoice(stepNum, choiceNum, current, unexplored, null));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Scheduler.java
@@ -7,6 +7,7 @@ import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMonitor;
 import pexplicit.runtime.scheduler.explicit.StepState;
+import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.NotImplementedException;
 import pexplicit.utils.misc.Assert;
 import pexplicit.values.*;
@@ -146,6 +147,9 @@ public abstract class Scheduler implements SchedulerInterface {
     public PInt getRandomInt(PInt bound) {
         List<PValue<?>> choices = new ArrayList<>();
         int boundInt = bound.getValue();
+        if (boundInt > 10000) {
+            throw new BugFoundException(String.format("choose expects a parameter with at most 10,000 choices, got %d choices instead.", boundInt));
+        }
         if (boundInt == 0) {
             boundInt = 1;
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
@@ -1,59 +1,39 @@
-package pexplicit.runtime.scheduler;
+package pexplicit.runtime.scheduler.choice;
 
 import lombok.Getter;
 import lombok.Setter;
-import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.scheduler.explicit.StepState;
 import pexplicit.values.PValue;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Represents a schedule or data choice
  */
-@Getter
-public class Choice implements Serializable {
+public abstract class Choice<T> implements Serializable {
+    @Getter
     @Setter
-    PMachine currentScheduleChoice = null;
+    protected T current;
+    @Getter
     @Setter
-    PValue<?> currentDataChoice = null;
-    @Setter
-    List<PMachine> unexploredScheduleChoices = new ArrayList<>();
-    @Setter
-    List<PValue<?>> unexploredDataChoices = new ArrayList<>();
-    @Setter
-    StepState choiceStep = null;
+    protected List<T> unexplored;
 
     /**
-     * Constructor
+     * Step number
      */
-    public Choice() {
-    }
+    @Getter
+    protected int stepNumber = 0;
+    /**
+     * Choice number
+     */
+    @Getter
+    protected int choiceNumber = 0;
 
-    public Choice transferUnexplored() {
-        Choice newChoice = new Choice();
-        newChoice.currentScheduleChoice = this.currentScheduleChoice;
-        newChoice.currentDataChoice = this.currentDataChoice;
-
-        newChoice.unexploredScheduleChoices = this.unexploredScheduleChoices;
-        newChoice.unexploredDataChoices = this.unexploredDataChoices;
-        newChoice.choiceStep = this.choiceStep;
-
-        this.unexploredScheduleChoices = new ArrayList<>();
-        this.unexploredDataChoices = new ArrayList<>();
-        this.choiceStep = null;
-
-        return newChoice;
-    }
-
-    public Choice copyCurrent() {
-        Choice newChoice = new Choice();
-        newChoice.currentScheduleChoice = this.currentScheduleChoice;
-        newChoice.currentDataChoice = this.currentDataChoice;
-
-        return newChoice;
+    protected Choice(T c, List<T> u, int stepNum, int choiceNum) {
+        this.current = c;
+        this.unexplored = u;
+        this.stepNumber = stepNum;
+        this.choiceNumber = choiceNum;
     }
 
     /**
@@ -62,61 +42,33 @@ public class Choice implements Serializable {
      * @return true if this choice has an unexplored choice, false otherwise
      */
     public boolean isUnexploredNonEmpty() {
-        return isUnexploredScheduleChoicesNonEmpty() || isUnexploredDataChoicesNonEmpty();
-    }
-
-    /**
-     * Check if this choice has an unexplored schedule choice remaining.
-     *
-     * @return true if this choice has an unexplored schedule choice, false otherwise
-     */
-    public boolean isUnexploredScheduleChoicesNonEmpty() {
-        return !getUnexploredScheduleChoices().isEmpty();
-    }
-
-    /**
-     * Check if this choice has an unexplored data choice remaining.
-     *
-     * @return true if this choice has an unexplored data choice, false otherwise
-     */
-    public boolean isUnexploredDataChoicesNonEmpty() {
-        return !getUnexploredDataChoices().isEmpty();
+        return !unexplored.isEmpty();
     }
 
     /**
      * Clear current choices
      */
     public void clearCurrent() {
-        currentScheduleChoice = null;
-        currentDataChoice = null;
+        this.current = null;
     }
 
     /**
      * Clean unexplored choices
      */
-    public void clearUnexplored() {
-        unexploredScheduleChoices.clear();
-        unexploredDataChoices.clear();
-        if (choiceStep != null) {
-            choiceStep.clear();
-        }
-    }
+    abstract public void clearUnexplored();
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        if (currentScheduleChoice != null) {
-            sb.append(String.format("curr@%s", currentScheduleChoice));
-        }
-        if (currentDataChoice != null) {
-            sb.append(String.format("curr:%s", currentDataChoice));
-        }
-        if (unexploredScheduleChoices != null && !unexploredScheduleChoices.isEmpty()) {
-            sb.append(String.format(" rem@%s", unexploredScheduleChoices));
-        }
-        if (unexploredDataChoices != null && !unexploredDataChoices.isEmpty()) {
-            sb.append(String.format(" rem:%s", unexploredDataChoices));
-        }
-        return sb.toString();
-    }
+    /**
+     * Copy current choice as a new Choice object
+     * @return Choice object with the copied current choice
+     */
+    abstract public Choice copyCurrent();
+
+    /**
+     * Copy this choice to a new choice and clear any unexplored choices.
+     *
+     * @return New choice same as original choice
+     */
+    abstract public Choice transferChoice();
+
+    abstract public String toString();
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
@@ -2,7 +2,6 @@ package pexplicit.runtime.scheduler.choice;
 
 import lombok.Getter;
 import lombok.Setter;
-import pexplicit.values.PValue;
 
 import java.io.Serializable;
 import java.util.List;
@@ -59,6 +58,7 @@ public abstract class Choice<T> implements Serializable {
 
     /**
      * Copy current choice as a new Choice object
+     *
      * @return Choice object with the copied current choice
      */
     abstract public Choice copyCurrent();

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
@@ -48,6 +48,14 @@ public class Choice implements Serializable {
         return newChoice;
     }
 
+    public Choice copyCurrent() {
+        Choice newChoice = new Choice();
+        newChoice.currentScheduleChoice = this.currentScheduleChoice;
+        newChoice.currentDataChoice = this.currentDataChoice;
+
+        return newChoice;
+    }
+
     /**
      * Check if this choice has an unexplored choice remaining.
      *

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataChoice.java
@@ -1,0 +1,48 @@
+package pexplicit.runtime.scheduler.choice;
+
+import lombok.Getter;
+import lombok.Setter;
+import pexplicit.values.PValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class DataChoice extends Choice<PValue<?>> {
+    /**
+     * Constructor
+     */
+    public DataChoice(int stepNum, int choiceNum, PValue<?> c, List<PValue<?>> u) {
+        super(c, u, stepNum, choiceNum);
+    }
+
+    /**
+     * Clean unexplored choices
+     */
+    public void clearUnexplored() {
+        unexplored.clear();
+    }
+
+    public Choice copyCurrent() {
+        return new DataChoice(this.stepNumber, this.choiceNumber, this.current, new ArrayList<>());
+    }
+
+    public Choice transferChoice() {
+        DataChoice newChoice = new DataChoice(this.stepNumber, this.choiceNumber, this.current, this.unexplored);
+        this.unexplored = new ArrayList<>();
+        return newChoice;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (current != null) {
+            sb.append(String.format("curr:%s", current));
+        }
+        if (unexplored != null && !unexplored.isEmpty()) {
+            sb.append(String.format(" rem:%s", unexplored));
+        }
+        return sb.toString();
+    }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
@@ -1,0 +1,54 @@
+package pexplicit.runtime.scheduler.choice;
+
+import lombok.Getter;
+import lombok.Setter;
+import pexplicit.runtime.machine.PMachine;
+import pexplicit.runtime.scheduler.explicit.StepState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class ScheduleChoice extends Choice<PMachine> {
+    private StepState choiceState = null;
+
+    /**
+     * Constructor
+     */
+    public ScheduleChoice(int stepNum, int choiceNum, PMachine c, List<PMachine> u, StepState s) {
+        super(c, u, stepNum, choiceNum);
+        this.choiceState = s;
+    }
+
+    /**
+     * Clean unexplored choices
+     */
+    public void clearUnexplored() {
+        unexplored.clear();
+        choiceState = null;
+    }
+
+    public Choice copyCurrent() {
+        return new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, new ArrayList<>(), null);
+    }
+
+    public Choice transferChoice() {
+        ScheduleChoice newChoice = new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, this.unexplored, this.choiceState);
+        this.unexplored = new ArrayList<>();
+        this.choiceState = null;
+        return newChoice;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (current != null) {
+            sb.append(String.format("curr@%s", current));
+        }
+        if (unexplored != null && !unexplored.isEmpty()) {
+            sb.append(String.format(" rem@%s", unexplored));
+        }
+        return sb.toString();
+    }
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
@@ -26,17 +26,15 @@ public class ScheduleChoice extends Choice<PMachine> {
      */
     public void clearUnexplored() {
         unexplored.clear();
-        choiceState = null;
     }
 
     public Choice copyCurrent() {
-        return new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, new ArrayList<>(), null);
+        return new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, new ArrayList<>(), this.choiceState);
     }
 
     public Choice transferChoice() {
         ScheduleChoice newChoice = new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, this.unexplored, this.choiceState);
         this.unexplored = new ArrayList<>();
-        this.choiceState = null;
         return newChoice;
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -507,7 +507,7 @@ public class ExplicitSearchScheduler extends Scheduler {
                         assert ((scheduleChoice == choice) || (scheduleChoice.getStepNumber() == (choice.getStepNumber() - 1)));
                         newStepNumber = scheduleChoice.getStepNumber();
                     } else {
-                        assert (choice.getStepNumber() == 0);
+                        assert (choice.getStepNumber() <= 1);
                     }
                 }
                 if (newStepNumber == 0) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -590,13 +590,13 @@ public class ExplicitSearchScheduler extends Scheduler {
         StatWriter.log("time-seconds", String.format("%.1f", timeUsed));
         StatWriter.log("memory-max-MB", String.format("%.1f", MemoryMonitor.getMaxMemSpent()));
         StatWriter.log("memory-current-MB", String.format("%.1f", memoryUsed));
-        StatWriter.log("#-schedules", String.format("%d", SearchStatistics.iteration));
+        StatWriter.log("#-executions", String.format("%d", SearchStatistics.iteration));
         if (PExplicitGlobal.getConfig().getStateCachingMode() != StateCachingMode.None) {
             StatWriter.log("#-states", String.format("%d", SearchStatistics.totalStates));
             StatWriter.log("#-distinct-states", String.format("%d", SearchStatistics.totalDistinctStates));
         }
         StatWriter.log("steps-min", String.format("%d", SearchStatistics.minSteps));
-        StatWriter.log("steps-max", String.format("%d", SearchStatistics.maxSteps));
+        StatWriter.log("max-depth-explored", String.format("%d", SearchStatistics.maxSteps));
         StatWriter.log("steps-avg", String.format("%d", SearchStatistics.totalSteps / SearchStatistics.iteration));
         StatWriter.log("#-choices-unexplored", String.format("%d", getNumUnexploredChoices()));
         StatWriter.log("%-choices-unexplored-data", String.format("%.1f", getUnexploredDataChoicesPercent()));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -4,15 +4,14 @@ import com.google.common.hash.Hashing;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.STATUS;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.ScratchLogger;
 import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.machine.PMachine;
-import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.Scheduler;
+import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.choice.ScheduleChoice;
 import pexplicit.runtime.scheduler.explicit.strategy.*;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
@@ -518,7 +517,7 @@ public class ExplicitSearchScheduler extends Scheduler {
                     stepState.setTo(scheduleChoice.getChoiceState());
 
                     assert (!scheduleChoice.getCurrent().getSendBuffer().isEmpty());
-                    for (PMachine machine: scheduleChoice.getUnexplored()) {
+                    for (PMachine machine : scheduleChoice.getUnexplored()) {
                         assert (!machine.getSendBuffer().isEmpty());
                     }
                 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -74,7 +74,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             case Random:
                 searchStrategy = new SearchStrategyRandom();
                 break;
-            case AStar:
+            case Astar:
                 searchStrategy = new SearchStrategyAStar();
                 break;
             default:

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -506,6 +506,8 @@ public class ExplicitSearchScheduler extends Scheduler {
                     if (scheduleChoice != null && scheduleChoice.getChoiceState() != null) {
                         assert ((scheduleChoice == choice) || (scheduleChoice.getStepNumber() == (choice.getStepNumber() - 1)));
                         newStepNumber = scheduleChoice.getStepNumber();
+                    } else {
+                        assert (choice.getStepNumber() == 0);
                     }
                 }
                 if (newStepNumber == 0) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -600,18 +600,19 @@ public class ExplicitSearchScheduler extends Scheduler {
     }
 
     private void printCurrentStatus(double newRuntime) {
-
-        String s = "--------------------" +
-                String.format("\n    Status after %.2f seconds:", newRuntime) +
-                String.format("\n      Memory:           %.2f MB", MemoryMonitor.getMemSpent()) +
-                String.format("\n      Depth:            %d", stepNumber) +
-                String.format("\n      Schedules:        %d", SearchStatistics.iteration) +
-                String.format("\n      Unexplored:       %d", getNumUnexploredChoices());
+        StringBuilder s = new StringBuilder("--------------------");
+        s.append(String.format("\n    Status after %.2f seconds:", newRuntime));
+        s.append(String.format("\n      Memory:           %.2f MB", MemoryMonitor.getMemSpent()));
+        s.append(String.format("\n      Step:             %d", stepNumber));
+        s.append(String.format("\n      Schedules:        %d", SearchStatistics.iteration));
+        s.append(String.format("\n      Unexplored:       %d", getNumUnexploredChoices()));
+        s.append(String.format("\n      FinishedTasks:    %d", searchStrategy.getFinishedTasks().size()));
+        s.append(String.format("\n      PendingTasks:     %d", searchStrategy.getPendingTasks().size()));
         if (PExplicitGlobal.getConfig().getStateCachingMode() != StateCachingMode.None) {
-            s += String.format("\n      DistinctStates:   %d", SearchStatistics.totalDistinctStates);
+            s.append(String.format("\n      States:           %d", SearchStatistics.totalStates));
+            s.append(String.format("\n      DistinctStates:   %d", SearchStatistics.totalDistinctStates));
         }
-
-        ScratchLogger.log(s);
+        ScratchLogger.log(s.toString());
     }
 
     private void printProgressHeader(boolean consolePrint) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -444,7 +444,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             newTask.addPrefixChoice(schedule.getChoice(i));
         }
 
-        newTask.addSuffixChoice(choice.transferChoice());
+        newTask.addSuffixChoice(choice);
 
         if (!isExact) {
             for (int i = choiceNum + 1; i < schedule.size(); i++) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -464,6 +464,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     public SearchTask setNextTask() {
         SearchTask nextTask = searchStrategy.setNextTask();
         if (nextTask != null) {
+            PExplicitLogger.logNextTask(nextTask);
             schedule.setChoices(nextTask.getAllChoices());
             postIterationCleanup();
         }
@@ -504,7 +505,9 @@ public class ExplicitSearchScheduler extends Scheduler {
                 if (PExplicitGlobal.getConfig().isStatefulBacktrackEnabled()) {
                     scheduleChoice = schedule.getScheduleChoiceAt(choice);
                     if (scheduleChoice != null && scheduleChoice.getChoiceState() != null) {
-                        assert ((scheduleChoice == choice) || (scheduleChoice.getStepNumber() == (choice.getStepNumber() - 1)));
+                        assert ((scheduleChoice == choice) ||
+                                (scheduleChoice.getStepNumber() == (choice.getStepNumber() - 1)) ||
+                                (scheduleChoice.getStepNumber() == choice.getStepNumber()));
                         newStepNumber = scheduleChoice.getStepNumber();
                     } else {
                         assert (choice.getStepNumber() <= 1);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
@@ -59,9 +59,9 @@ public class StepState implements Serializable {
     }
 
     public void setTo(StepState input) {
-        machineListByType = input.machineListByType;
-        machineSet = input.machineSet;
-        machineLocalStates = input.machineLocalStates;
+        machineListByType = new HashMap<>(input.machineListByType);
+        machineSet = new TreeSet<>(input.machineSet);
+        machineLocalStates = new HashMap<>(input.machineLocalStates);
         assert (machineSet.size() == machineLocalStates.size());
 
         for (PMachine machine : PExplicitGlobal.getMachineSet()) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
@@ -1,7 +1,6 @@
 package pexplicit.runtime.scheduler.explicit;
 
 import lombok.Getter;
-import lombok.Setter;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.machine.MachineLocalState;
 import pexplicit.runtime.machine.PMachine;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -1,7 +1,6 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
-import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.explicit.SearchStatistics;
 
 import java.io.Serializable;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -1,7 +1,7 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
-import pexplicit.runtime.scheduler.Choice;
+import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.explicit.SearchStatistics;
 
 import java.io.Serializable;
@@ -33,8 +33,8 @@ public abstract class SearchStrategy implements Serializable {
      */
     int currTaskStartIteration = 0;
 
-    public SearchTask createTask(Choice choice, int choiceNum, SearchTask parentTask) {
-        SearchTask newTask = new SearchTask(allTasks.size(), choice, choiceNum, parentTask);
+    public SearchTask createTask(int choiceNum, SearchTask parentTask) {
+        SearchTask newTask = new SearchTask(allTasks.size(), choiceNum, parentTask);
         allTasks.add(newTask);
         pendingTasks.add(newTask.getId());
         return newTask;
@@ -42,7 +42,7 @@ public abstract class SearchStrategy implements Serializable {
 
     public void createFirstTask() {
         assert (allTasks.size() == 0);
-        SearchTask firstTask = createTask(null, 0, null);
+        SearchTask firstTask = createTask(0, null);
         setCurrTask(firstTask);
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
@@ -1,7 +1,23 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 public enum SearchStrategyMode {
-    DepthFirst,
-    Random,
-    Astar
+    DepthFirst("dfs"),
+    Random("random"),
+    Astar("astar");
+
+    private String name;
+
+    /**
+     * Constructor
+     *
+     * @param n Name of the enum
+     */
+    SearchStrategyMode(String n) {
+        this.name = n;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
@@ -3,5 +3,5 @@ package pexplicit.runtime.scheduler.explicit.strategy;
 public enum SearchStrategyMode {
     DepthFirst,
     Random,
-    AStar
+    Astar
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -18,12 +18,12 @@ public class SearchTask implements Serializable {
     private final List<SearchTask> children = new ArrayList<>();
     @Getter
     private final int currChoiceNumber;
+    private final List<Choice> prefixChoices = new ArrayList<>();
+    private final List<Choice> suffixChoices = new ArrayList<>();
     @Getter
     private int numUnexploredScheduleChoices = 0;
     @Getter
     private int numUnexploredDataChoices = 0;
-    private final List<Choice> prefixChoices = new ArrayList<>();
-    private final List<Choice> suffixChoices = new ArrayList<>();
 
     public SearchTask(int id, int choiceNum, SearchTask parentTask) {
         this.id = id;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -49,13 +49,12 @@ public class SearchTask implements Serializable {
     }
 
     public void addSuffixChoice(Choice choice) {
-        // TODO: check if we need copy here
-        suffixChoices.add(choice.transferChoice());
         if (choice instanceof ScheduleChoice scheduleChoice) {
             numUnexploredScheduleChoices += scheduleChoice.getUnexplored().size();
         } else {
             numUnexploredDataChoices += ((DataChoice) choice).getUnexplored().size();
         }
+        suffixChoices.add(choice.transferChoice());
     }
 
     public List<Choice> getAllChoices() {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/misc/Assert.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/utils/misc/Assert.java
@@ -2,6 +2,7 @@ package pexplicit.utils.misc;
 
 import lombok.Getter;
 import pexplicit.utils.exceptions.BugFoundException;
+import pexplicit.utils.exceptions.DeadlockException;
 import pexplicit.utils.exceptions.LivenessException;
 import pexplicit.values.PString;
 
@@ -23,19 +24,21 @@ public class Assert {
         fromModel(p, msg.getValue());
     }
 
-    public static void liveness(boolean p, String msg) {
-        if (!p) {
-            failureType = "liveness";
-            failureMsg = "Property violated: " + msg;
-            throw new LivenessException(failureMsg);
-        }
+    public static void deadlock(String msg) {
+        failureType = "deadlock";
+        failureMsg = "Property violated: " + msg;
+        throw new DeadlockException(failureMsg);
     }
 
-    public static void cycle(boolean p, String msg) {
-        if (!p) {
-            failureType = "cycle";
-            failureMsg = "Property violated: " + msg;
-            throw new LivenessException(failureMsg);
-        }
+    public static void liveness(String msg) {
+        failureType = "liveness";
+        failureMsg = "Property violated: " + msg;
+        throw new LivenessException(failureMsg);
+    }
+
+    public static void cycle(String msg) {
+        failureType = "cycle";
+        failureMsg = "Property violated: " + msg;
+        throw new LivenessException(failureMsg);
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -1,5 +1,6 @@
 package pexplicit.values;
 
+import pexplicit.utils.misc.Assert;
 import pexplicit.values.exceptions.KeyNotFoundException;
 
 import java.util.ArrayList;
@@ -88,6 +89,13 @@ public class PMap extends PValue<PMap> implements PCollection {
      * @param val value to set
      */
     public PMap add(PValue<?> key, PValue<?> val) {
+        if (map.containsKey(key)) {
+            Assert.fromModel(
+                    false,
+                    String.format(
+                            "ArgumentException: An item with the same key has already been added. Key: %s, Value: %s",
+                            key, map.get(key)));
+        }
         return put(key, val);
     }
 

--- a/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
+++ b/Src/PRuntimes/PSymRuntime/src/test/java/psym/TestSymbolicRegression.java
@@ -68,6 +68,11 @@ public class TestSymbolicRegression {
   }
 
   private static void createExcludeList() {
+    // TODO Unsupported: too many choices to throw error if choices more than 10000
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesSeq");
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesSet");
+    excluded.add("../../../Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesMap");
+
     // TODO Unsupported: liveness with temperatures
     excluded.add("../../../Tst/RegressionTests/Liveness/Correct/Liveness_1");
     excluded.add("../../../Tst/RegressionTests/Liveness/Correct/Liveness_1_falsePass");

--- a/Tst/RegressionTests/Feature2Stmts/Correct/pingPongReceive4/pingPongReceive4.p
+++ b/Tst/RegressionTests/Feature2Stmts/Correct/pingPongReceive4/pingPongReceive4.p
@@ -1,0 +1,46 @@
+event ping: (sender: machine, id: int);
+event pong: (id: int);
+
+machine Main {
+  var follower: machine;
+
+  start state Init {
+    entry {
+      var id: int;
+      follower = new Follower();
+      id = 0;
+
+      while(id < 2) {
+        send follower, ping, (sender=this, id=id);
+        print format ("(inside) {0}: ping sent", id);
+        receive {
+            case pong: (rsp: (id: int)) {
+                id = rsp.id;
+                print format ("(inside) {0}: pong received", id);
+           }
+        }
+        print format ("(inside) {0}: done", id);
+      }
+      assert (id == 2), format("expected id to be 2, got {0}", id);
+
+      send follower, ping, (sender=this, id=id);
+      print format ("(outside) {0}: ping sent", id);
+      receive {
+        case pong: (rsp: (id: int)) {
+            id = rsp.id;
+            print format ("(outside) {0}: pong received", id);
+          }
+      }
+
+      assert (id == 3), format("expected id to be 3, got {0}", id);
+    }
+  }
+}
+
+machine Follower {
+  start state Init {
+    on ping do (payload: (sender: machine, id: int)) {
+      send payload.sender, pong, (id = payload.id+1,);
+    }
+  }
+}

--- a/Tst/RegressionTests/Feature2Stmts/Correct/pingPongReceive5/pingPongReceive5.p
+++ b/Tst/RegressionTests/Feature2Stmts/Correct/pingPongReceive5/pingPongReceive5.p
@@ -1,0 +1,58 @@
+event ping: (sender: machine, id: int);
+event pong: (id: int);
+
+machine Main {
+  var follower: machine;
+
+  start state Init {
+    entry {
+      var id: int;
+      follower = new Follower();
+      id = 0;
+
+      if (id == 0) {
+        send follower, ping, (sender=this, id=id);
+        print format ("(first) {0}: ping sent", id);
+        receive {
+          case pong: (rsp: (id: int)) {
+              id = rsp.id*2;
+              print format ("(first) {0}: pong received", id);
+         }
+        }
+      }
+      assert (id == 2), format("expected id to be 2, got {0}", id);
+
+      while(id < 4) {
+        send follower, ping, (sender=this, id=id);
+        print format ("(inside) {0}: ping sent", id);
+        receive {
+            case pong: (rsp: (id: int)) {
+                id = rsp.id;
+                print format ("(inside) {0}: pong received", id);
+           }
+        }
+        print format ("(inside) {0}: done", id);
+      }
+      assert (id == 4), format("expected id to be 4, got {0}", id);
+
+      send follower, ping, (sender=this, id=id);
+      print format ("(outside) {0}: ping sent", id);
+      receive {
+        case pong: (rsp: (id: int)) {
+            id = rsp.id;
+            print format ("(outside) {0}: pong received", id);
+          }
+      }
+
+      assert (id == 5), format("expected id to be 5, got {0}", id);
+    }
+  }
+}
+
+machine Follower {
+  start state Init {
+    on ping do (payload: (sender: machine, id: int)) {
+      send payload.sender, pong, (id = payload.id+1,);
+    }
+  }
+}

--- a/Tst/RegressionTests/Feature2Stmts/DynamicError/pingPongReceive4/pingPongReceive4.p
+++ b/Tst/RegressionTests/Feature2Stmts/DynamicError/pingPongReceive4/pingPongReceive4.p
@@ -1,0 +1,46 @@
+event ping: (sender: machine, id: int);
+event pong: (id: int);
+
+machine Main {
+  var follower: machine;
+
+  start state Init {
+    entry {
+      var id: int;
+      follower = new Follower();
+      id = 0;
+
+      while(id < 2) {
+        send follower, ping, (sender=this, id=id);
+        print format ("(inside) {0}: ping sent", id);
+        receive {
+            case pong: (rsp: (id: int)) {
+                id = rsp.id;
+                print format ("(inside) {0}: pong received", id);
+           }
+        }
+        print format ("(inside) {0}: done", id);
+      }
+      assert (id == 2), format("expected id to be 2, got {0}", id);
+
+      send follower, ping, (sender=this, id=id);
+      print format ("(outside) {0}: ping sent", id);
+      receive {
+        case pong: (rsp: (id: int)) {
+            id = rsp.id;
+            print format ("(outside) {0}: pong received", id);
+          }
+      }
+
+      assert (id != 3), format("expected id to be 3, got {0}", id); // error
+    }
+  }
+}
+
+machine Follower {
+  start state Init {
+    on ping do (payload: (sender: machine, id: int)) {
+      send payload.sender, pong, (id = payload.id+1,);
+    }
+  }
+}

--- a/Tst/RegressionTests/Feature2Stmts/DynamicError/pingPongReceive5/pingPongReceive5.p
+++ b/Tst/RegressionTests/Feature2Stmts/DynamicError/pingPongReceive5/pingPongReceive5.p
@@ -1,0 +1,58 @@
+event ping: (sender: machine, id: int);
+event pong: (id: int);
+
+machine Main {
+  var follower: machine;
+
+  start state Init {
+    entry {
+      var id: int;
+      follower = new Follower();
+      id = 0;
+
+      if (id == 0) {
+        send follower, ping, (sender=this, id=id);
+        print format ("(first) {0}: ping sent", id);
+        receive {
+          case pong: (rsp: (id: int)) {
+              id = rsp.id*2;
+              print format ("(first) {0}: pong received", id);
+         }
+        }
+      }
+      assert (id == 2), format("expected id to be 2, got {0}", id);
+
+      while(id < 4) {
+        send follower, ping, (sender=this, id=id);
+        print format ("(inside) {0}: ping sent", id);
+        receive {
+            case pong: (rsp: (id: int)) {
+                id = rsp.id;
+                print format ("(inside) {0}: pong received", id);
+           }
+        }
+        print format ("(inside) {0}: done", id);
+      }
+      assert (id == 4), format("expected id to be 4, got {0}", id);
+
+      send follower, ping, (sender=this, id=id);
+      print format ("(outside) {0}: ping sent", id);
+      receive {
+        case pong: (rsp: (id: int)) {
+            id = rsp.id;
+            print format ("(outside) {0}: pong received", id);
+          }
+      }
+
+      assert (id != 5), format("expected id to be 5, got {0}", id); // error
+    }
+  }
+}
+
+machine Follower {
+  start state Init {
+    on ping do (payload: (sender: machine, id: int)) {
+      send payload.sender, pong, (id = payload.id+1,);
+    }
+  }
+}

--- a/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesInt/tooManyChoicesInt.p
+++ b/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesInt/tooManyChoicesInt.p
@@ -1,0 +1,16 @@
+machine Main {
+	start state S {
+		entry {
+		    var x: int;
+		    var y: int;
+		    
+		    x = 10000;
+		    y = choose(x); // OK
+		    print format("y is {0}", y);
+		    
+		    x = 10001;
+		    y = choose(x); // error
+		    print format("y is {0}", y);
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesMap/tooManyChoicesMap.p
+++ b/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesMap/tooManyChoicesMap.p
@@ -1,0 +1,22 @@
+machine Main {
+	start state S {
+		entry {
+		    var x: map[int, int];
+		    var y: int;
+		    var i: int;
+
+            i = 0;
+            while (i < 10000) {
+                x[i] = i;
+                i = i + 1;
+            }
+            
+		    y = choose(x); // OK
+		    print format("y is {0}", y);
+		    
+            x[i] = i;
+		    y = choose(x); // error
+		    print format("y is {0}", y);
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesSeq/tooManyChoicesSeq.p
+++ b/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesSeq/tooManyChoicesSeq.p
@@ -1,0 +1,22 @@
+machine Main {
+	start state S {
+		entry {
+		    var x: seq[int];
+		    var y: int;
+		    var i: int;
+
+            i = 0;
+            while (i < 10000) {
+                x += (i, i);
+                i = i + 1;
+            }
+            
+		    y = choose(x); // OK
+		    print format("y is {0}", y);
+		    
+            x += (i, i);
+		    y = choose(x); // error
+		    print format("y is {0}", y);
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesSet/tooManyChoicesSet.p
+++ b/Tst/RegressionTests/Feature3Exprs/DynamicError/tooManyChoicesSet/tooManyChoicesSet.p
@@ -1,0 +1,22 @@
+machine Main {
+	start state S {
+		entry {
+		    var x: set[int];
+		    var y: int;
+		    var i: int;
+
+            i = 0;
+            while (i < 10000) {
+                x += (i);
+                i = i + 1;
+            }
+            
+		    y = choose(x); // OK
+		    print format("y is {0}", y);
+		    
+            x += (i);
+		    y = choose(x); // error
+		    print format("y is {0}", y);
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature3Exprs/StaticError/tooManyChoices/tooManyChoices.p
+++ b/Tst/RegressionTests/Feature3Exprs/StaticError/tooManyChoices/tooManyChoices.p
@@ -1,0 +1,14 @@
+machine Main {
+	start state S {
+		entry {
+		    var x: int;
+		    var y: int;
+		    
+		    x = choose(10000); // OK
+		    print format("x is {0}", x);
+		    
+		    y = choose(10001); // error
+		    print format("y is {0}", y);
+		}
+	}
+}


### PR DESCRIPTION
Updates include:

[PEx RT]
- Revamp a schedule/data `Choice` into separate classes `ScheduleChoice` or `DataChoice`. Only `ScheduleChoice` stores protocol state for stateful backtracking. Stateful backtracking for a `DataChoice` resumes from the most recent `ScheduleChoice`.
- Revamp `StepState` to not track step/choice number, only track current machines and machine states
- Revamp `SearchTask` to store full list of current choices (prefix) and assigned unexplored choices (suffix).
- Adds support for Java foreign functions
- Corrects replaying liveness/deadlock bug
- Throw error if `N` in `choose(N)` is greater than 10K.
- Minor refactoring and improvements to logging.

[PEx IR]
- Several minor corrections needed relating to dynamic type casting of `PValue`.
- Updates foreign function interface
- Corrects and improves IR generator for while loop containing receive statement.

[P CLI]
- Adds hidden option `--checker-args <colon-separated args>` to pass additional options to PEx or PSym.

[Misc]
- Sync with latest changes in master branch
- Adds few unit tests dealing with while and receive statements.
