### PR TITLE
[Bug finding] Track memory usage and enforce memory limit

### DIFF
--- a/Src/PChecker/CheckerCore/Scheduling/TestingProcessScheduler.cs
+++ b/Src/PChecker/CheckerCore/Scheduling/TestingProcessScheduler.cs
@@ -172,7 +172,7 @@ namespace PChecker.Scheduling
             }
 
             Console.WriteLine(GlobalTestReport.GetText(_checkerConfiguration, "..."));
-            Console.WriteLine($"... Elapsed {Profiler.Results()} sec.");
+            Console.WriteLine($"... Elapsed {Profiler.GetElapsedTime():0.##} sec and used {Profiler.GetMaxMemoryUsage():0.##} GB.");
 
             if (GlobalTestReport.InternalErrors.Count > 0)
             {

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -432,7 +432,10 @@ namespace PChecker.SystematicTesting
 
                         if (Profiler.GetCurrentMemoryUsage() > _checkerConfiguration.MemoryLimit)
                         {
-                            throw new OutOfMemoryException();
+                            if (_checkerConfiguration.MemoryLimit != 0)
+                            {
+                                throw new OutOfMemoryException();
+                            }
                         }
 
                         // Runs a new testing schedule.

--- a/Src/PChecker/CheckerCore/Utilities/Profiler.cs
+++ b/Src/PChecker/CheckerCore/Utilities/Profiler.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using PChecker.IO.Logging;
 
 namespace PChecker.Utilities
 {

--- a/Src/PChecker/CheckerCore/Utilities/Profiler.cs
+++ b/Src/PChecker/CheckerCore/Utilities/Profiler.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
+using PChecker.IO.Logging;
 
 namespace PChecker.Utilities
 {
@@ -11,6 +13,7 @@ namespace PChecker.Utilities
     public class Profiler
     {
         private Stopwatch StopWatch;
+        private static double maxMemoryUsed = 0.0;
 
         /// <summary>
         /// Starts measuring execution time.
@@ -33,9 +36,28 @@ namespace PChecker.Utilities
         }
 
         /// <summary>
-        /// Returns profilling results.
+        /// Returns profiling results.
         /// </summary>
-        public double Results() =>
+        public double GetElapsedTime() =>
             StopWatch != null ? StopWatch.Elapsed.TotalSeconds : 0;
+
+        /// <summary>
+        /// Get memory usage in gigabytes.
+        /// </summary>
+        public double GetCurrentMemoryUsage()
+        {
+            double memUsed = GC.GetTotalMemory(false) / 1024.0 / 1024.0 / 1024.0;
+            if (memUsed > maxMemoryUsed)
+                maxMemoryUsed = memUsed;
+            return memUsed;
+        }
+
+        /// <summary>
+        /// Get max memory usage in gigabytes.
+        /// </summary>
+        public static double GetMaxMemoryUsage()
+        {
+            return maxMemoryUsed;
+        }
     }
 }

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -40,7 +40,7 @@ namespace Plang.Options
 
             var basicGroup = Parser.GetOrCreateGroup("Basic", "Basic options");
             basicGroup.AddArgument("timeout", "t", "Timeout in seconds (disabled by default)", typeof(uint));
-            basicGroup.AddArgument("memout", null, "Memory limit in Giga bytes (disabled by default)", typeof(double)).IsHidden = true;
+            basicGroup.AddArgument("memout", "m", "Memory limit in Giga bytes (disabled by default)", typeof(double));
             basicGroup.AddArgument("outdir", "o", "Dump output to directory (absolute or relative path)");
             basicGroup.AddArgument("verbose", "v", "Enable verbose log output during exploration", typeof(bool));
             basicGroup.AddArgument("debug", "d", "Enable debugging", typeof(bool)).IsHidden = true;


### PR DESCRIPTION
Updates include:

[C# checker]
- Adds tracking memory usage.
- Adds enforcing memory limit using the `--memout` CLI option.

[CLI]
- Unhides option `-m`/`--memout` to specify memory limit in GB (default is 0 i.e., no limit)