### PR TITLE
[PEx] Adds hybrid stateful backtracking, improves storing search tasks

### DIFF
--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import pexplicit.runtime.machine.buffer.BufferSemantics;
 import pexplicit.runtime.scheduler.explicit.StateCachingMode;
+import pexplicit.runtime.scheduler.explicit.StatefulBacktrackingMode;
 import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 
 /**
@@ -52,9 +53,9 @@ public class PExplicitConfig {
     // state caching mode
     @Setter
     StateCachingMode stateCachingMode = StateCachingMode.Murmur3_128;
-    // use stateful backtracking
+    // stateful backtracking mode
     @Setter
-    boolean statefulBacktrackEnabled = true;
+    StatefulBacktrackingMode statefulBacktrackingMode = StatefulBacktrackingMode.IntraTask;
     // search strategy mode
     @Setter
     SearchStrategyMode searchStrategyMode = SearchStrategyMode.Random;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -2,6 +2,7 @@ package pexplicit.commandline;
 
 import org.apache.commons.cli.*;
 import pexplicit.runtime.scheduler.explicit.StateCachingMode;
+import pexplicit.runtime.scheduler.explicit.StatefulBacktrackingMode;
 import pexplicit.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 
 import java.io.PrintWriter;
@@ -165,13 +166,15 @@ public class PExplicitOptions {
         addHiddenOption(stateCachingMode);
 
         // whether or not to disable stateful backtracking
-        Option backtrack =
+        Option backtrackMode =
                 Option.builder()
-                        .longOpt("no-backtrack")
-                        .desc("Disable stateful backtracking")
-                        .numberOfArgs(0)
+                        .longOpt("stateful-backtrack")
+                        .desc("Stateful backtracking mode: none, intra-task, all (default: intra-task)")
+                        .numberOfArgs(1)
+                        .hasArg()
+                        .argName("Backtrack Mode (string)")
                         .build();
-        addHiddenOption(backtrack);
+        addHiddenOption(backtrackMode);
 
         // max number of schedules to explore per search task
         Option maxSchedulesPerTask =
@@ -363,8 +366,22 @@ public class PExplicitOptions {
                                     String.format("Unrecognized state caching mode, got %s", option.getValue()));
                     }
                     break;
-                case "no-backtrack":
-                    config.setStatefulBacktrackEnabled(false);
+                case "stateful-backtrack":
+                    switch (option.getValue()) {
+                        case "none":
+                            config.setStatefulBacktrackingMode(StatefulBacktrackingMode.None);
+                            break;
+                        case "intra-task":
+                            config.setStatefulBacktrackingMode(StatefulBacktrackingMode.IntraTask);
+                            break;
+                        case "all":
+                            config.setStatefulBacktrackingMode(StatefulBacktrackingMode.All);
+                            break;
+                        default:
+                            optionError(
+                                    option,
+                                    String.format("Unrecognized stateful backtrack mode, got %s", option.getValue()));
+                    }
                     break;
                 case "schedules-per-task":
                     try {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/ForeignFunctionInterface.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/ForeignFunctionInterface.java
@@ -5,24 +5,24 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class ForeignFunctionInterface {
-  /**
-   * Invoke a foreign function with a void return type
-   *
-   * @param fn function to invoke
-   * @param args arguments
-   */
-  public static void accept(Consumer<List<Object>> fn, Object... args) {
-    fn.accept(List.of(args));
-  }
+    /**
+     * Invoke a foreign function with a void return type
+     *
+     * @param fn   function to invoke
+     * @param args arguments
+     */
+    public static void accept(Consumer<List<Object>> fn, Object... args) {
+        fn.accept(List.of(args));
+    }
 
-  /**
-   * Invoke a foreign function with a non-void return type
-   *
-   * @param fn function to invoke
-   * @param args arguments
-   * @return the return value of the function
-   */
-  public static Object apply(Function<List<Object>, Object> fn, Object... args) {
-    return fn.apply(List.of(args));
-  }
+    /**
+     * Invoke a foreign function with a non-void return type
+     *
+     * @param fn   function to invoke
+     * @param args arguments
+     * @return the return value of the function
+     */
+    public static Object apply(Function<List<Object>, Object> fn, Object... args) {
+        return fn.apply(List.of(args));
+    }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -13,8 +13,6 @@ import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.machine.PMonitor;
 import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PContinuation;
-import pexplicit.runtime.scheduler.choice.Choice;
-import pexplicit.runtime.scheduler.choice.ScheduleChoice;
 import pexplicit.runtime.scheduler.choice.ScheduleSearchUnit;
 import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;
@@ -155,7 +153,7 @@ public class PExplicitLogger {
      * @param task Next search task
      */
     public static void logNextTask(SearchTask task) {
-        if (verbosity > 1) {
+        if (verbosity > 0) {
             log.info(String.format("  Next task: %s", task.toStringDetailed()));
         }
     }
@@ -168,6 +166,29 @@ public class PExplicitLogger {
             for (SearchTask task : tasks) {
                 log.info(String.format("      %s", task.toStringDetailed()));
             }
+        }
+    }
+
+    /**
+     * Log when serializing a task
+     *
+     * @param task    Task to serialize
+     * @param szBytes Bytes written
+     */
+    public static void logSerializeTask(SearchTask task, long szBytes) {
+        if (verbosity > 1) {
+            log.info(String.format("      %,.1f MB  written in %s", (szBytes / 1024.0 / 1024.0), task.getSerializeFile()));
+        }
+    }
+
+    /**
+     * Log when deserializing a task
+     *
+     * @param task Task that is deserialized
+     */
+    public static void logDeserializeTask(SearchTask task) {
+        if (verbosity > 1) {
+            log.info(String.format("      Reading %s from %s", task, task.getSerializeFile()));
         }
     }
 
@@ -209,9 +230,9 @@ public class PExplicitLogger {
     /**
      * Log when backtracking to a search unit
      *
-     * @param stepNum Step number
+     * @param stepNum   Step number
      * @param choiceNum Choice number
-     * @param unit Search unit to which backtracking to
+     * @param unit      Search unit to which backtracking to
      */
     public static void logBacktrack(int stepNum, int choiceNum, SearchUnit unit) {
         if (verbosity > 1) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachineId.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/PMachineId.java
@@ -3,8 +3,10 @@ package pexplicit.runtime.machine;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter
-public class PMachineId {
+public class PMachineId implements Serializable {
     Class<? extends PMachine> type;
     int typeId;
     @Setter

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/buffer/MessageQueue.java
@@ -3,7 +3,6 @@ package pexplicit.runtime.machine.buffer;
 import lombok.Getter;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.utils.exceptions.PExplicitRuntimeException;
-import pexplicit.utils.misc.Assert;
 import pexplicit.values.PMessage;
 
 import java.io.Serializable;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -63,9 +63,9 @@ public class Schedule implements Serializable {
     /**
      * Set the schedule choice at a choice depth.
      *
-     * @param stepNum    Step number
-     * @param choiceNum  Choice number
-     * @param current    Machine to set as current schedule choice
+     * @param stepNum   Step number
+     * @param choiceNum Choice number
+     * @param current   Machine to set as current schedule choice
      */
     public void setScheduleChoice(int stepNum, int choiceNum, PMachineId current) {
         if (choiceNum == choices.size()) {
@@ -84,9 +84,9 @@ public class Schedule implements Serializable {
     /**
      * Set the data choice at a choice depth.
      *
-     * @param stepNum    Step number
-     * @param choiceNum  Choice number
-     * @param current    PValue to set as current schedule choice
+     * @param stepNum   Step number
+     * @param choiceNum Choice number
+     * @param current   PValue to set as current schedule choice
      */
     public void setDataChoice(int stepNum, int choiceNum, PValue<?> current) {
         if (choiceNum == choices.size()) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -7,6 +7,7 @@ import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.choice.DataChoice;
 import pexplicit.runtime.scheduler.choice.ScheduleChoice;
+import pexplicit.runtime.scheduler.explicit.StatefulBacktrackingMode;
 import pexplicit.runtime.scheduler.explicit.StepState;
 import pexplicit.values.PValue;
 
@@ -71,7 +72,7 @@ public class Schedule implements Serializable {
             choices.add(null);
         }
         assert (choiceNum < choices.size());
-        if (PExplicitGlobal.getConfig().isStatefulBacktrackEnabled()
+        if (PExplicitGlobal.getConfig().getStatefulBacktrackingMode() != StatefulBacktrackingMode.None
                 && stepNum != 0) {
             assert (stepBeginState != null);
             choices.set(choiceNum, new ScheduleChoice(stepNum, choiceNum, current, stepBeginState));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/SchedulerInterface.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/SchedulerInterface.java
@@ -14,7 +14,7 @@ public interface SchedulerInterface extends Serializable {
     /**
      * Perform the search
      */
-    void run() throws TimeoutException, InterruptedException, IOException;
+    void run() throws TimeoutException, InterruptedException;
 
     /**
      * Return a random PBool based on the search and strategy.

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/SchedulerInterface.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/SchedulerInterface.java
@@ -2,6 +2,7 @@ package pexplicit.runtime.scheduler;
 
 import pexplicit.values.*;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.TimeoutException;
 
@@ -13,7 +14,7 @@ public interface SchedulerInterface extends Serializable {
     /**
      * Perform the search
      */
-    void run() throws TimeoutException, InterruptedException;
+    void run() throws TimeoutException, InterruptedException, IOException;
 
     /**
      * Return a random PBool based on the search and strategy.

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/Choice.java
@@ -29,7 +29,7 @@ public abstract class Choice<T> implements Serializable {
      *
      * @return Choice object with the copied current choice
      */
-    abstract public Choice copyCurrent();
+    abstract public Choice copyCurrent(boolean copyState);
 
     abstract public String toString();
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataChoice.java
@@ -14,7 +14,7 @@ public class DataChoice extends Choice<PValue<?>> {
         super(c);
     }
 
-    public Choice copyCurrent() {
+    public Choice copyCurrent(boolean copyState) {
         return new DataChoice(this.current);
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataSearchUnit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/DataSearchUnit.java
@@ -5,7 +5,7 @@ import pexplicit.values.PValue;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DataSearchUnit extends SearchUnit<PValue<?>>{
+public class DataSearchUnit extends SearchUnit<PValue<?>> {
     /**
      * Constructor
      */

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
@@ -2,7 +2,6 @@ package pexplicit.runtime.scheduler.choice;
 
 import lombok.Getter;
 import lombok.Setter;
-import pexplicit.commandline.PExplicitConfig;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.explicit.StepState;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
@@ -2,6 +2,7 @@ package pexplicit.runtime.scheduler.choice;
 
 import lombok.Getter;
 import lombok.Setter;
+import pexplicit.commandline.PExplicitConfig;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.explicit.StepState;
 
@@ -32,8 +33,12 @@ public class ScheduleChoice extends Choice<PMachineId> {
         this.choiceState = s;
     }
 
-    public Choice copyCurrent() {
-        return new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, this.choiceState);
+    public Choice copyCurrent(boolean copyState) {
+        if (copyState) {
+            return new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, this.choiceState);
+        } else {
+            return new ScheduleChoice(this.stepNumber, this.choiceNumber, this.current, null);
+        }
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleSearchUnit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleSearchUnit.java
@@ -1,7 +1,6 @@
 package pexplicit.runtime.scheduler.choice;
 
 import pexplicit.runtime.machine.PMachineId;
-import pexplicit.runtime.scheduler.explicit.StepState;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -193,7 +193,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             return;
         }
 
-        if (PExplicitGlobal.getConfig().isStatefulBacktrackEnabled()
+        if (PExplicitGlobal.getConfig().getStatefulBacktrackingMode() != StatefulBacktrackingMode.None
                 && stepNumber != 0) {
             schedule.setStepBeginState(stepState.copyState());
         }
@@ -528,7 +528,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             backtrackChoiceNumber = cIdx;
             int newStepNumber = 0;
             ScheduleChoice scheduleChoice = null;
-            if (PExplicitGlobal.getConfig().isStatefulBacktrackEnabled()) {
+            if (PExplicitGlobal.getConfig().getStatefulBacktrackingMode() != StatefulBacktrackingMode.None) {
                 scheduleChoice = schedule.getScheduleChoiceAt(cIdx);
                 if (scheduleChoice != null && scheduleChoice.getChoiceState() != null) {
                     newStepNumber = scheduleChoice.getStepNumber();

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -12,7 +12,6 @@ import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.Scheduler;
-import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.choice.ScheduleChoice;
 import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.runtime.scheduler.explicit.strategy.*;
@@ -112,9 +111,9 @@ public class ExplicitSearchScheduler extends Scheduler {
                 runIteration();
                 postProcessIteration();
             }
+            PExplicitLogger.logEndTask(searchStrategy.getCurrTask(), searchStrategy.getNumSchedulesInCurrTask());
             addRemainingChoicesAsChildrenTasks();
             endCurrTask();
-            PExplicitLogger.logEndTask(searchStrategy.getCurrTask(), searchStrategy.getNumSchedulesInCurrTask());
 
             if (searchStrategy.getPendingTasks().isEmpty() || PExplicitGlobal.getStatus() == STATUS.SCHEDULEOUT) {
                 // all tasks completed or schedule limit reached
@@ -431,7 +430,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     private void addRemainingChoicesAsChildrenTasks() {
         SearchTask parentTask = searchStrategy.getCurrTask();
         int numChildrenAdded = 0;
-        for (int i: parentTask.getSearchUnitKeys(false)) {
+        for (int i : parentTask.getSearchUnitKeys(false)) {
             SearchUnit unit = parentTask.getSearchUnit(i);
             // if search unit at this depth is non-empty
             if (!unit.getUnexplored().isEmpty()) {
@@ -462,7 +461,7 @@ public class ExplicitSearchScheduler extends Scheduler {
         newTask.addSuffixSearchUnit(choiceNum, unit);
 
         if (!isExact) {
-            for (int i: parentTask.getSearchUnitKeys(false)) {
+            for (int i : parentTask.getSearchUnitKeys(false)) {
                 if (i > choiceNum) {
                     if (i > maxChoiceNum) {
                         maxChoiceNum = i;
@@ -476,6 +475,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             newTask.addPrefixChoice(schedule.getChoice(i));
         }
 
+        newTask.serializeTask();
         parentTask.addChild(newTask);
         searchStrategy.addNewTask(newTask);
     }
@@ -494,11 +494,11 @@ public class ExplicitSearchScheduler extends Scheduler {
     }
 
     public int getNumUnexploredChoices() {
-        return searchStrategy.getCurrTask().getNumUnexploredChoices() + searchStrategy.getNumPendingChoices();
+        return searchStrategy.getCurrTask().getCurrentNumUnexploredChoices() + searchStrategy.getNumPendingChoices();
     }
 
     public int getNumUnexploredDataChoices() {
-        return searchStrategy.getCurrTask().getNumUnexploredDataChoices() + searchStrategy.getNumPendingDataChoices();
+        return searchStrategy.getCurrTask().getCurrentNumUnexploredDataChoices() + searchStrategy.getNumPendingDataChoices();
     }
 
     /**
@@ -518,7 +518,7 @@ public class ExplicitSearchScheduler extends Scheduler {
 
     private void postIterationCleanup() {
         SearchTask task = searchStrategy.getCurrTask();
-        for (int cIdx: task.getSearchUnitKeys(true)) {
+        for (int cIdx : task.getSearchUnitKeys(true)) {
             SearchUnit unit = task.getSearchUnit(cIdx);
             if (unit.getUnexplored().isEmpty()) {
                 task.clearSearchUnit(cIdx);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StatefulBacktrackingMode.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StatefulBacktrackingMode.java
@@ -1,0 +1,7 @@
+package pexplicit.runtime.scheduler.explicit;
+
+public enum StatefulBacktrackingMode {
+    None,
+    IntraTask,
+    All
+}

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -76,6 +76,7 @@ public abstract class SearchStrategy implements Serializable {
         }
 
         SearchTask nextTask = popNextTask();
+        nextTask.deserializeTask();
         setCurrTask(nextTask);
 
         return nextTask;
@@ -88,11 +89,9 @@ public abstract class SearchStrategy implements Serializable {
      */
     public int getNumPendingChoices() {
         int numUnexplored = 0;
-        SearchTask task = getCurrTask();
-        numUnexplored += task.getNumUnexploredChoices();
         for (Integer tid : pendingTasks) {
-            task = getTask(tid);
-            numUnexplored += task.getNumUnexploredChoices();
+            SearchTask task = getTask(tid);
+            numUnexplored += task.getTotalUnexploredChoices();
         }
         return numUnexplored;
     }
@@ -104,11 +103,9 @@ public abstract class SearchStrategy implements Serializable {
      */
     public int getNumPendingDataChoices() {
         int numUnexplored = 0;
-        SearchTask task = getCurrTask();
-        numUnexplored += task.getNumUnexploredDataChoices();
         for (Integer tid : pendingTasks) {
-            task = getTask(tid);
-            numUnexplored += task.getNumUnexploredDataChoices();
+            SearchTask task = getTask(tid);
+            numUnexplored += task.getTotalUnexploredDataChoices();
         }
         return numUnexplored;
     }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -1,8 +1,10 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
+import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.choice.*;
+import pexplicit.runtime.scheduler.explicit.StatefulBacktrackingMode;
 import pexplicit.values.PValue;
 
 import java.io.Serializable;
@@ -41,7 +43,8 @@ public class SearchTask implements Serializable {
     }
 
     public void addPrefixChoice(Choice choice) {
-        prefixChoices.add(choice.copyCurrent());
+        boolean copyState = (PExplicitGlobal.getConfig().getStatefulBacktrackingMode() == StatefulBacktrackingMode.All);
+        prefixChoices.add(choice.copyCurrent(copyState));
     }
 
     public void addSuffixSearchUnit(int choiceNum, SearchUnit unit) {

--- a/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/test/java/pexplicit/TestPExplicit.java
@@ -27,7 +27,7 @@ public class TestPExplicit {
     private static String timeout = "30";
     private static String schedules = "100";
     private static String maxSteps = "10000";
-    private static String runArgs = "";
+    private static String runArgs = "--checker-args :--schedules-per-task:10";
     private static boolean initialized = false;
 
     private static void setRunArgs() {


### PR DESCRIPTION
Updates include:

[PEx RT]
- Serialize/deserialize memory-heavy fields of `SearchTask` as needed since taking too much space for long runs
- Added hydrid stateful backtracking that performs stateful backtracking for search within a search task only
- Adds CLI option `--stateful-backtrack <none|intra-task|all>` (default is `intra-task`). Deprecates option `--no-backtrack`
- Minor refactoring