### PR TITLE
[PEx] Several upgrades post preliminary experimentation

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/Continuation.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/Continuation.cs
@@ -25,7 +25,6 @@ namespace Plang.Compiler.Backend.PExplicit
             var localAccess = new VariableAccessExpr(SourceLocation, local);
             var storeAccess = new VariableAccessExpr(SourceLocation, store);
             var storeStmt = new AssignStmt(SourceLocation, storeAccess, localAccess);
-            storeStmts.Add(storeStmt);
             storeForLocal.Add(local, store);
         }
 
@@ -33,11 +32,9 @@ namespace Plang.Compiler.Backend.PExplicit
         public IPStmt After { get; } 
         public IEnumerable<Variable> StoreParameters => storeParameters;
         public IEnumerable<Variable> LocalParameters => localParameters;
-        public IEnumerable<AssignStmt> StoreStmts => storeStmts;
         public IReadOnlyDictionary<Variable, Variable> StoreForLocal => storeForLocal;
         private readonly List<Variable> storeParameters = new List<Variable>();
         private readonly List<Variable> localParameters = new List<Variable>();
-        private readonly List<AssignStmt> storeStmts = new List<AssignStmt>();
         private readonly Dictionary<Variable, Variable> storeForLocal = new Dictionary<Variable, Variable>();
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -1935,7 +1935,7 @@ namespace Plang.Compiler.Backend.PExplicit
                 case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Null):
                     return "void";
                 case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Any):
-                    return "? extends PValue<?>";
+                    return "Object";
                 default:
                     return "Object";
             }

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -309,63 +309,6 @@ namespace Plang.Compiler.Backend.PExplicit
             foreach (var field in machine.Fields)
                 context.WriteLine(output, $"public {GetPExplicitType(field.Type)} {CompilationContext.GetVar(field.Name)} = {GetDefaultValue(field.Type)};");
             context.WriteLine(output);
-
-            // context.WriteLine(output, "@Generated");
-            // context.WriteLine(output, "@Override");
-            // context.WriteLine(output, "public void reset() {");
-            // context.WriteLine(output, "    super.reset();");
-            // foreach (var field in machine.Fields)
-            //     context.WriteLine(output, $"    {CompilationContext.GetVar(field.Name)} = {GetDefaultValue(field.Type)};");
-            // context.WriteLine(output, "}");
-            // context.WriteLine(output);
-            //
-            // context.WriteLine(output, "@Generated");
-            // // context.WriteLine(output, "@Override");
-            // context.WriteLine(output, "public List<String> getLocalVarNames() {");
-            // context.WriteLine(output, "    List<String> result = super.getLocalVarNames();");
-            // foreach (var field in machine.Fields)
-            // {
-            //     context.WriteLine(output, $"    result.add(\"{CompilationContext.GetVar(field.Name)}\");");
-            // }
-            // context.WriteLine(output, "    return result;");
-            // context.WriteLine(output, "}");
-            // context.WriteLine(output);
-            //
-            // context.WriteLine(output, "@Generated");
-            // context.WriteLine(output, "@Override");
-            // context.WriteLine(output, "public List<Object> getLocalVarValues() {");
-            // context.WriteLine(output, "    List<Object> result = super.getLocalVarValues();");
-            // foreach (var field in machine.Fields)
-            // {
-            //     context.WriteLine(output, $"    result.add({CompilationContext.GetVar(field.Name)});");
-            // }
-            // context.WriteLine(output, "    return result;");
-            // context.WriteLine(output, "}");
-            // context.WriteLine(output);
-            //
-            // context.WriteLine(output, "@Generated");
-            // context.WriteLine(output, "@Override");
-            // context.WriteLine(output, "public List<Object> copyLocalVarValues() {");
-            // context.WriteLine(output, "    List<Object> result = super.copyLocalVarValues();");
-            // foreach (var field in machine.Fields)
-            // {
-            //     context.WriteLine(output, $"    result.add({CompilationContext.GetVar(field.Name)});");
-            // }
-            // context.WriteLine(output, "    return result;");
-            // context.WriteLine(output, "}");
-            // context.WriteLine(output);
-            //
-            // context.WriteLine(output, "@Generated");
-            // context.WriteLine(output, "@Override");
-            // context.WriteLine(output, "protected int setLocalVarValues(List<Object> values) {");
-            // context.WriteLine(output, "    int idx = super.setLocalVarValues(values);");
-            // foreach (var field in machine.Fields)
-            // {
-            //     context.WriteLine(output, $"    {CompilationContext.GetVar(field.Name)} = ({GetPExplicitType(field.Type)}) values.get(idx++);");
-            // }
-            // context.WriteLine(output, "    return idx;");
-            // context.WriteLine(output, "}");
-            // context.WriteLine(output);
         }
 
         private void WriteMachineConstructor(CompilationContext context, StringWriter output, Machine machine)

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/PExplicitCodeGenerator.cs
@@ -307,66 +307,65 @@ namespace Plang.Compiler.Backend.PExplicit
             }
 
             foreach (var field in machine.Fields)
-                context.WriteLine(output, $"private {GetPExplicitType(field.Type)} {CompilationContext.GetVar(field.Name)} = {GetDefaultValue(field.Type)};");
-
+                context.WriteLine(output, $"public {GetPExplicitType(field.Type)} {CompilationContext.GetVar(field.Name)} = {GetDefaultValue(field.Type)};");
             context.WriteLine(output);
 
-            context.WriteLine(output, "@Generated");
-            context.WriteLine(output, "@Override");
-            context.WriteLine(output, "public void reset() {");
-            context.WriteLine(output, "    super.reset();");
-            foreach (var field in machine.Fields)
-                context.WriteLine(output, $"    {CompilationContext.GetVar(field.Name)} = {GetDefaultValue(field.Type)};");
-            context.WriteLine(output, "}");
-            context.WriteLine(output);
-
-            context.WriteLine(output, "@Generated");
-            context.WriteLine(output, "@Override");
-            context.WriteLine(output, "public List<String> getLocalVarNames() {");
-            context.WriteLine(output, "    List<String> result = super.getLocalVarNames();");
-            foreach (var field in machine.Fields)
-            {
-                context.WriteLine(output, $"    result.add(\"{CompilationContext.GetVar(field.Name)}\");");
-            }
-            context.WriteLine(output, "    return result;");
-            context.WriteLine(output, "}");
-            context.WriteLine(output);
-
-            context.WriteLine(output, "@Generated");
-            context.WriteLine(output, "@Override");
-            context.WriteLine(output, "public List<Object> getLocalVarValues() {");
-            context.WriteLine(output, "    List<Object> result = super.getLocalVarValues();");
-            foreach (var field in machine.Fields)
-            {
-                context.WriteLine(output, $"    result.add({CompilationContext.GetVar(field.Name)});");
-            }
-            context.WriteLine(output, "    return result;");
-            context.WriteLine(output, "}");
-            context.WriteLine(output);
-
-            context.WriteLine(output, "@Generated");
-            context.WriteLine(output, "@Override");
-            context.WriteLine(output, "public List<Object> copyLocalVarValues() {");
-            context.WriteLine(output, "    List<Object> result = super.copyLocalVarValues();");
-            foreach (var field in machine.Fields)
-            {
-                context.WriteLine(output, $"    result.add({CompilationContext.GetVar(field.Name)});");
-            }
-            context.WriteLine(output, "    return result;");
-            context.WriteLine(output, "}");
-            context.WriteLine(output);
-
-            context.WriteLine(output, "@Generated");
-            context.WriteLine(output, "@Override");
-            context.WriteLine(output, "protected int setLocalVarValues(List<Object> values) {");
-            context.WriteLine(output, "    int idx = super.setLocalVarValues(values);");
-            foreach (var field in machine.Fields)
-            {
-                context.WriteLine(output, $"    {CompilationContext.GetVar(field.Name)} = ({GetPExplicitType(field.Type)}) values.get(idx++);");
-            }
-            context.WriteLine(output, "    return idx;");
-            context.WriteLine(output, "}");
-            context.WriteLine(output);
+            // context.WriteLine(output, "@Generated");
+            // context.WriteLine(output, "@Override");
+            // context.WriteLine(output, "public void reset() {");
+            // context.WriteLine(output, "    super.reset();");
+            // foreach (var field in machine.Fields)
+            //     context.WriteLine(output, $"    {CompilationContext.GetVar(field.Name)} = {GetDefaultValue(field.Type)};");
+            // context.WriteLine(output, "}");
+            // context.WriteLine(output);
+            //
+            // context.WriteLine(output, "@Generated");
+            // // context.WriteLine(output, "@Override");
+            // context.WriteLine(output, "public List<String> getLocalVarNames() {");
+            // context.WriteLine(output, "    List<String> result = super.getLocalVarNames();");
+            // foreach (var field in machine.Fields)
+            // {
+            //     context.WriteLine(output, $"    result.add(\"{CompilationContext.GetVar(field.Name)}\");");
+            // }
+            // context.WriteLine(output, "    return result;");
+            // context.WriteLine(output, "}");
+            // context.WriteLine(output);
+            //
+            // context.WriteLine(output, "@Generated");
+            // context.WriteLine(output, "@Override");
+            // context.WriteLine(output, "public List<Object> getLocalVarValues() {");
+            // context.WriteLine(output, "    List<Object> result = super.getLocalVarValues();");
+            // foreach (var field in machine.Fields)
+            // {
+            //     context.WriteLine(output, $"    result.add({CompilationContext.GetVar(field.Name)});");
+            // }
+            // context.WriteLine(output, "    return result;");
+            // context.WriteLine(output, "}");
+            // context.WriteLine(output);
+            //
+            // context.WriteLine(output, "@Generated");
+            // context.WriteLine(output, "@Override");
+            // context.WriteLine(output, "public List<Object> copyLocalVarValues() {");
+            // context.WriteLine(output, "    List<Object> result = super.copyLocalVarValues();");
+            // foreach (var field in machine.Fields)
+            // {
+            //     context.WriteLine(output, $"    result.add({CompilationContext.GetVar(field.Name)});");
+            // }
+            // context.WriteLine(output, "    return result;");
+            // context.WriteLine(output, "}");
+            // context.WriteLine(output);
+            //
+            // context.WriteLine(output, "@Generated");
+            // context.WriteLine(output, "@Override");
+            // context.WriteLine(output, "protected int setLocalVarValues(List<Object> values) {");
+            // context.WriteLine(output, "    int idx = super.setLocalVarValues(values);");
+            // foreach (var field in machine.Fields)
+            // {
+            //     context.WriteLine(output, $"    {CompilationContext.GetVar(field.Name)} = ({GetPExplicitType(field.Type)}) values.get(idx++);");
+            // }
+            // context.WriteLine(output, "    return idx;");
+            // context.WriteLine(output, "}");
+            // context.WriteLine(output);
         }
 
         private void WriteMachineConstructor(CompilationContext context, StringWriter output, Machine machine)
@@ -393,21 +392,7 @@ namespace Plang.Compiler.Backend.PExplicit
                 if (method is Continuation)
                 {
                     var cont = (Continuation) method;
-                    context.WriteLine(output, "registerContinuation(");
-                    context.WriteLine(output, $"\"{context.GetContinuationName(cont)}\"");
-                    context.WriteLine(output, $", (machine, msg) -> {context.GetContinuationName(cont)}(machine, msg)");
-                    context.WriteLine(output, $", () -> clear_{context.GetContinuationName(cont)}()");
-                    foreach (var (caseEvent, _) in cont.Cases)
-                    {
-                        context.Write(output, $", \"{caseEvent.Name}\"");
-                    }
-                    context.WriteLine(output, ");");
-
-                    // context.Write(output, $"continuations.put(\"{context.GetContinuationName(cont)}\", ");
-                    // context.Write(output, $"(pc) -> ((continuation_outcome, msg) -> {context.GetContinuationName(cont)}(");
-                    // context.Write(output, "continuation_outcome");
-                    // context.WriteLine(output, $", msg)));");
-                    // context.WriteLine(output, $"clearContinuationVars.add(() -> clear_{context.GetContinuationName(cont)}());");
+                    context.WriteLine(output, $"register_{context.GetContinuationName(cont)}();");
                 }
             }
 
@@ -1021,7 +1006,13 @@ namespace Plang.Compiler.Backend.PExplicit
                     context.WriteLine(output, ");");
                     break;
                 case ReceiveSplitStmt splitStmt:
-                    context.WriteLine(output, $"{CompilationContext.CurrentMachine}.blockUntil(\"{context.GetContinuationName(splitStmt.Cont)}\");");
+                    Continuation continuation = splitStmt.Cont;
+                    context.WriteLine(output, $"PContinuation {context.GetContinuationName(continuation)} = getContinuation(\"{context.GetContinuationName(continuation)}\");");
+                    foreach (var local in continuation.LocalParameters)
+                    {
+                        context.WriteLine(output, $"{context.GetContinuationName(continuation)}.setVar(\"{continuation.StoreForLocal[local].Name}\", {CompilationContext.GetVar(local.Name)});");
+                    }
+                    context.WriteLine(output, $"{CompilationContext.CurrentMachine}.blockUntil(\"{context.GetContinuationName(continuation)}\");");
                     context.Write(output, "return;");
                     exited = true;
                     break;
@@ -1039,11 +1030,20 @@ namespace Plang.Compiler.Backend.PExplicit
                 throw new NotImplementedException($"Receive statement in a function with non-void return type is not supported. Found in function named {continuation.ParentFunction.Name}.");
             }
 
-            context.Write(output, $"void clear_{context.GetContinuationName(continuation)}() ");
+            context.Write(output, $"void register_{context.GetContinuationName(continuation)}() ");
             context.WriteLine(output, "{");
+            context.Write(output, $"PContinuation {context.GetContinuationName(continuation)} = registerContinuation(");
+            context.WriteLine(output, $"\"{context.GetContinuationName(continuation)}\"");
+            context.WriteLine(output, $", (machine, msg) -> {context.GetContinuationName(continuation)}(machine, msg)");
+            foreach (var (caseEvent, _) in continuation.Cases)
+            {
+                context.Write(output, $", \"{caseEvent.Name}\"");
+            }
+            context.WriteLine(output, ");");
+
             foreach (var param in continuation.StoreParameters)
             {
-                context.WriteLine(output, $"{GetPExplicitType(param.Type)} {CompilationContext.GetVar(param.Name)} = {GetDefaultValue(param.Type)};");
+                context.WriteLine(output, $"{context.GetContinuationName(continuation)}.addVar(\"{param.Name}\", {GetDefaultValue(param.Type)});");
             }
             context.WriteLine(output, "}");
 
@@ -1063,11 +1063,12 @@ namespace Plang.Compiler.Backend.PExplicit
             context.WriteLine(output, "{");
 
             var continuationLocalParams = new HashSet<string>();
+            context.WriteLine(output, $"PContinuation {context.GetContinuationName(continuation)} = getContinuation(\"{context.GetContinuationName(continuation)}\");");
             foreach (var local in continuation.LocalParameters)
             {
                 continuationLocalParams.Add(local.Name);
                 context.Write(output, $"{GetPExplicitType(local.Type)} {CompilationContext.GetVar(local.Name)}");
-                context.WriteLine(output, $"= {CompilationContext.GetVar(continuation.StoreForLocal[local].Name)};");
+                context.WriteLine(output, $" = ({GetPExplicitType(local.Type)}) {context.GetContinuationName(continuation)}.getVar(\"{continuation.StoreForLocal[local].Name}\");");
             }
 
             context.WriteLine(output, $"switch ({messageName}.getEvent().toString())");

--- a/Src/PCompiler/CompilerCore/Backend/PExplicit/TransformASTPass.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PExplicit/TransformASTPass.cs
@@ -712,14 +712,6 @@ namespace Plang.Compiler.Backend.PExplicit
                                 }
                                 var continuation = GetContinuation(function, cases, after, recv.SourceLocation);
                                 if (machine != null) machine.AddMethod(continuation);
-                                foreach (var v in continuation.StoreParameters)
-                                {
-                                    machine.AddField(v);
-                                }
-                                foreach (var store in continuation.StoreStmts)
-                                {
-                                    result.Add(store);
-                                }
                                 var split = new ReceiveSplitStmt(compound.SourceLocation, continuation);
                                 result.Add(split);
                                 break;

--- a/Src/PRuntimes/PExplicitRuntime/pom.xml
+++ b/Src/PRuntimes/PExplicitRuntime/pom.xml
@@ -103,7 +103,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
@@ -82,8 +82,6 @@ public class PExplicit {
             }
         } finally {
             // log end-of-run metrics
-            StatWriter.log("result", PExplicitGlobal.getResult());
-            StatWriter.log("status", String.format("%s", PExplicitGlobal.getStatus()));
             StatWriter.log("exit-code", String.format("%d", exit_code));
 
             // exit

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
@@ -8,7 +8,6 @@ import pexplicit.runtime.logger.Log4JConfig;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.machine.PTestDriver;
-import pexplicit.runtime.scheduler.explicit.strategy.SearchTask;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.utils.monitor.TimeMonitor;
@@ -35,7 +34,6 @@ public class PExplicit {
         PExplicitGlobal.setConfig(PExplicitOptions.ParseCommandlineArgs(args));
         PExplicitLogger.Initialize(PExplicitGlobal.getConfig().getVerbosity());
         ComputeHash.Initialize();
-        SearchTask.Initialize();
 
         // get reflections corresponding to the model
         Reflections reflections = new Reflections("pexplicit.model");

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/PExplicit.java
@@ -8,6 +8,7 @@ import pexplicit.runtime.logger.Log4JConfig;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.machine.PTestDriver;
+import pexplicit.runtime.scheduler.explicit.strategy.SearchTask;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.monitor.MemoryMonitor;
 import pexplicit.utils.monitor.TimeMonitor;
@@ -34,6 +35,7 @@ public class PExplicit {
         PExplicitGlobal.setConfig(PExplicitOptions.ParseCommandlineArgs(args));
         PExplicitLogger.Initialize(PExplicitGlobal.getConfig().getVerbosity());
         ComputeHash.Initialize();
+        SearchTask.Initialize();
 
         // get reflections corresponding to the model
         Reflections reflections = new Reflections("pexplicit.model");

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -75,6 +75,9 @@ public class RuntimeExecutor {
                 PExplicitGlobal.setStatus(STATUS.VERIFIED_UPTO_MAX_STEPS);
             }
         }
+
+        StatWriter.log("result", PExplicitGlobal.getResult());
+        StatWriter.log("status", String.format("%s", PExplicitGlobal.getStatus()));
     }
 
     private static void preprocess() {
@@ -136,9 +139,9 @@ public class RuntimeExecutor {
             future.cancel(true);
             executor.shutdownNow();
             scheduler.updateResult();
-            SearchTask.Cleanup();
             printStats();
             PExplicitLogger.logEndOfRun(scheduler, Duration.between(TimeMonitor.getStart(), Instant.now()).getSeconds());
+            SearchTask.Cleanup();
         }
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -100,6 +100,10 @@ public class RuntimeExecutor {
             PExplicitGlobal.setResult(String.format("found cex of length %d", scheduler.getStepNumber()));
             PExplicitLogger.logStackTrace(e);
 
+            String schFile = PExplicitGlobal.getConfig().getOutputFolder() + "/" + PExplicitGlobal.getConfig().getProjectName() + "_0_0.schedule";
+            PExplicitLogger.logInfo(String.format("Writing buggy trace in %s", schFile));
+            scheduler.schedule.writeToFile(schFile);
+
             ReplayScheduler replayer = new ReplayScheduler(scheduler.schedule);
             PExplicitGlobal.setScheduler(replayer);
             try {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/RuntimeExecutor.java
@@ -5,6 +5,7 @@ import pexplicit.runtime.STATUS;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.StatWriter;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;
+import pexplicit.runtime.scheduler.explicit.strategy.SearchTask;
 import pexplicit.runtime.scheduler.replay.ReplayScheduler;
 import pexplicit.utils.exceptions.BugFoundException;
 import pexplicit.utils.exceptions.MemoutException;
@@ -124,6 +125,7 @@ public class RuntimeExecutor {
             future.cancel(true);
             executor.shutdownNow();
             scheduler.updateResult();
+            SearchTask.Cleanup();
             printStats();
             PExplicitLogger.logEndOfRun(scheduler, Duration.between(TimeMonitor.getStart(), Instant.now()).getSeconds());
         }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -61,7 +61,7 @@ public class PExplicitConfig {
     SearchStrategyMode searchStrategyMode = SearchStrategyMode.Random;
     // max number of schedules per search task
     @Setter
-    int maxSchedulesPerTask = 10;
+    int maxSchedulesPerTask = 500;
     //max number of children search tasks
     @Setter
     int maxChildrenPerTask = 2;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitConfig.java
@@ -44,6 +44,9 @@ public class PExplicitConfig {
     // random seed
     @Setter
     long randomSeed = System.currentTimeMillis();
+    // name of the replay file
+    @Setter
+    String replayFile = "";
     // max number of logs (i.e., internal steps) within a single schedule step
     @Setter
     int maxStepLogBound = 1000;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -149,6 +149,22 @@ public class PExplicitOptions {
                         .build();
         addOption(randomSeed);
 
+        /*
+         * Replay options
+         */
+
+        // replay file
+        Option replayFile =
+                Option.builder("r")
+                        .longOpt("replay")
+                        .desc("Schedule file to replay")
+                        .numberOfArgs(1)
+                        .hasArg()
+                        .argName("File Name (string)")
+                        .build();
+        addOption(replayFile);
+
+
 
         /*
          * Invisible/expert options
@@ -339,6 +355,12 @@ public class PExplicitOptions {
                                 option, String.format("Expected an integer value, got %s", option.getValue()));
                     }
                     break;
+                // replay options
+                case "r":
+                case "replay":
+                    config.setReplayFile(option.getValue());
+                    config.setSearchStrategyMode(SearchStrategyMode.Replay);
+                    break;
                 // invisible expert options
                 case "state-caching":
                     switch (option.getValue()) {
@@ -425,6 +447,15 @@ public class PExplicitOptions {
 
         if (config.getSearchStrategyMode() == SearchStrategyMode.DepthFirst) {
             config.setMaxSchedulesPerTask(0);
+        }
+
+        if (config.getSearchStrategyMode() == SearchStrategyMode.Replay) {
+            if (config.getVerbosity() == 0) {
+                config.setVerbosity(1);
+            }
+            if (config.getReplayFile().startsWith(config.getOutputFolder())) {
+                config.setOutputFolder(config.getOutputFolder() + "Replay");
+            }
         }
 
         return config;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/commandline/PExplicitOptions.java
@@ -359,7 +359,6 @@ public class PExplicitOptions {
                 case "r":
                 case "replay":
                     config.setReplayFile(option.getValue());
-                    config.setSearchStrategyMode(SearchStrategyMode.Replay);
                     break;
                 // invisible expert options
                 case "state-caching":
@@ -449,7 +448,8 @@ public class PExplicitOptions {
             config.setMaxSchedulesPerTask(0);
         }
 
-        if (config.getSearchStrategyMode() == SearchStrategyMode.Replay) {
+        if (config.getReplayFile() != "") {
+            config.setSearchStrategyMode(SearchStrategyMode.Replay);
             if (config.getVerbosity() == 0) {
                 config.setVerbosity(1);
             }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -61,8 +61,6 @@ public class PExplicitLogger {
         // initialize all loggers and writers
         StatWriter.Initialize();
         ScratchLogger.Initialize();
-        ScheduleWriter.Initialize();
-        TextWriter.Initialize();
     }
 
     public static void logInfo(String message) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -13,7 +13,6 @@ import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.machine.PMonitor;
 import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PContinuation;
-import pexplicit.runtime.scheduler.Schedule;
 import pexplicit.runtime.scheduler.choice.ScheduleSearchUnit;
 import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -13,6 +13,7 @@ import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.machine.PMonitor;
 import pexplicit.runtime.machine.State;
 import pexplicit.runtime.machine.events.PContinuation;
+import pexplicit.runtime.scheduler.Schedule;
 import pexplicit.runtime.scheduler.choice.ScheduleSearchUnit;
 import pexplicit.runtime.scheduler.choice.SearchUnit;
 import pexplicit.runtime.scheduler.explicit.ExplicitSearchScheduler;
@@ -164,6 +165,17 @@ public class PExplicitLogger {
             for (SearchTask task : tasks) {
                 log.info(String.format("      %s", task.toStringDetailed()));
             }
+        }
+    }
+
+    /**
+     * Log when serializing a schedule
+     *
+     * @param schedule Schedule to serialize
+     * @param szBytes Bytes written
+     */
+    public static void logSerializeSchedule(Schedule schedule, String fileName, long szBytes) {
+        if (verbosity > 1) {
         }
     }
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -167,17 +167,6 @@ public class PExplicitLogger {
     }
 
     /**
-     * Log when serializing a schedule
-     *
-     * @param schedule Schedule to serialize
-     * @param szBytes  Bytes written
-     */
-    public static void logSerializeSchedule(Schedule schedule, String fileName, long szBytes) {
-        if (verbosity > 1) {
-        }
-    }
-
-    /**
      * Log when serializing a task
      *
      * @param task    Task to serialize

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/PExplicitLogger.java
@@ -58,10 +58,6 @@ public class PExplicitLogger {
         consoleAppender.start();
 
         context.getConfiguration().addLoggerAppender(coreLogger, consoleAppender);
-
-        // initialize all loggers and writers
-        StatWriter.Initialize();
-        ScratchLogger.Initialize();
     }
 
     public static void logInfo(String message) {
@@ -96,15 +92,17 @@ public class PExplicitLogger {
         } else {
             log.info("..... Found 0 bugs.");
         }
-        log.info("... Scheduling statistics:");
-        if (PExplicitGlobal.getConfig().getStateCachingMode() != StateCachingMode.None) {
-            log.info(String.format("..... Explored %d distinct states", SearchStatistics.totalDistinctStates));
+        if (scheduler != null) {
+            log.info("... Scheduling statistics:");
+            if (PExplicitGlobal.getConfig().getStateCachingMode() != StateCachingMode.None) {
+                log.info(String.format("..... Explored %d distinct states", SearchStatistics.totalDistinctStates));
+            }
+            log.info(String.format("..... Explored %d distinct schedules", SearchStatistics.iteration));
+            log.info(String.format("..... Finished %d search tasks (%d pending)",
+                    scheduler.getSearchStrategy().getFinishedTasks().size(), scheduler.getSearchStrategy().getPendingTasks().size()));
+            log.info(String.format("..... Number of steps explored: %d (min), %d (avg), %d (max).",
+                    SearchStatistics.minSteps, (SearchStatistics.totalSteps / SearchStatistics.iteration), SearchStatistics.maxSteps));
         }
-        log.info(String.format("..... Explored %d distinct schedules", SearchStatistics.iteration));
-        log.info(String.format("..... Finished %d search tasks (%d pending)",
-                scheduler.getSearchStrategy().getFinishedTasks().size(), scheduler.getSearchStrategy().getPendingTasks().size()));
-        log.info(String.format("..... Number of steps explored: %d (min), %d (avg), %d (max).",
-                SearchStatistics.minSteps, (SearchStatistics.totalSteps / SearchStatistics.iteration), SearchStatistics.maxSteps));
         log.info(String.format("... Elapsed %d seconds and used %.1f GB", timeSpent, MemoryMonitor.getMaxMemSpent() / 1000.0));
         log.info(String.format(".. Result: " + PExplicitGlobal.getResult()));
         log.info(". Done");
@@ -172,7 +170,7 @@ public class PExplicitLogger {
      * Log when serializing a schedule
      *
      * @param schedule Schedule to serialize
-     * @param szBytes Bytes written
+     * @param szBytes  Bytes written
      */
     public static void logSerializeSchedule(Schedule schedule, String fileName, long szBytes) {
         if (verbosity > 1) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/ScheduleWriter.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/logger/ScheduleWriter.java
@@ -21,7 +21,7 @@ public class ScheduleWriter {
     public static void Initialize() {
         try {
             // get new file name
-            fileName = PExplicitGlobal.getConfig().getOutputFolder() + "/" + PExplicitGlobal.getConfig().getProjectName() + "_0_0.schedule";
+            fileName = PExplicitGlobal.getConfig().getOutputFolder() + "/" + PExplicitGlobal.getConfig().getProjectName() + "_0_0.steps";
             // Define new file printer
             File schFile = new File(fileName);
             schFile.getParentFile().mkdirs();

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PContinuation.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/machine/events/PContinuation.java
@@ -8,13 +8,14 @@ import pexplicit.values.PEvent;
 import pexplicit.values.PMessage;
 import pexplicit.values.PValue;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 @Getter
-public class PContinuation {
+public class PContinuation implements Serializable {
     private final Set<String> caseEvents;
     private final SerializableBiFunction<PMachine, PMessage> handleFun;
     @Getter

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -3,7 +3,6 @@ package pexplicit.runtime.scheduler;
 import lombok.Getter;
 import lombok.Setter;
 import pexplicit.runtime.PExplicitGlobal;
-import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.choice.DataChoice;
@@ -12,12 +11,7 @@ import pexplicit.runtime.scheduler.explicit.StatefulBacktrackingMode;
 import pexplicit.runtime.scheduler.explicit.StepState;
 import pexplicit.values.PValue;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +37,22 @@ public class Schedule implements Serializable {
      * Constructor
      */
     public Schedule() {
+    }
+
+    public static Schedule readFromFile(String fileName) {
+        assert (fileName != null);
+        Schedule result = null;
+
+        try {
+            FileInputStream fis;
+            fis = new FileInputStream(fileName);
+            ObjectInputStream ois = new ObjectInputStream(fis);
+            result = (Schedule) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException("Failed to read schedule from file " + fileName, e);
+        }
+
+        return result;
     }
 
     /**

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/Schedule.java
@@ -3,6 +3,7 @@ package pexplicit.runtime.scheduler;
 import lombok.Getter;
 import lombok.Setter;
 import pexplicit.runtime.PExplicitGlobal;
+import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.choice.Choice;
 import pexplicit.runtime.scheduler.choice.DataChoice;
@@ -11,7 +12,12 @@ import pexplicit.runtime.scheduler.explicit.StatefulBacktrackingMode;
 import pexplicit.runtime.scheduler.explicit.StepState;
 import pexplicit.values.PValue;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -145,5 +151,15 @@ public class Schedule implements Serializable {
      */
     public int size() {
         return choices.size();
+    }
+
+    public void writeToFile(String fileName) {
+        try {
+            FileOutputStream fos = new FileOutputStream(fileName);
+            ObjectOutputStream oos = new ObjectOutputStream(fos);
+            oos.writeObject(this);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write schedule in file " + fileName, e);
+        }
     }
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/SchedulerInterface.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/SchedulerInterface.java
@@ -2,7 +2,6 @@ package pexplicit.runtime.scheduler;
 
 import pexplicit.values.*;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.TimeoutException;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/choice/ScheduleChoice.java
@@ -20,7 +20,7 @@ public class ScheduleChoice extends Choice<PMachineId> {
     /**
      * Protocol state at the schedule step
      */
-    private StepState choiceState = null;
+    private transient StepState choiceState = null;
 
     /**
      * Constructor

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -475,7 +475,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             newTask.addPrefixChoice(schedule.getChoice(i));
         }
 
-        newTask.serializeTask();
+        newTask.writeToFile();
         parentTask.addChild(newTask);
         searchStrategy.addNewTask(newTask);
     }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -659,7 +659,7 @@ public class ExplicitSearchScheduler extends Scheduler {
     }
 
     protected void printProgress(boolean forcePrint) {
-        if (forcePrint || (TimeMonitor.findInterval(getLastReportTime()) > 5)) {
+        if (forcePrint || (TimeMonitor.findInterval(getLastReportTime()) > 10)) {
             setLastReportTime(Instant.now());
             double newRuntime = TimeMonitor.getRuntime();
             printCurrentStatus(newRuntime);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -22,7 +22,6 @@ import pexplicit.utils.monitor.TimeMonitor;
 import pexplicit.values.ComputeHash;
 import pexplicit.values.PValue;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -597,22 +596,15 @@ public class ExplicitSearchScheduler extends Scheduler {
     }
 
     public void recordStats() {
-        double timeUsed = (Duration.between(TimeMonitor.getStart(), Instant.now()).toMillis() / 1000.0);
-        double memoryUsed = MemoryMonitor.getMemSpent();
-
         printProgress(true);
 
         // print basic statistics
-        StatWriter.log("time-seconds", String.format("%.1f", timeUsed));
-        StatWriter.log("memory-max-MB", String.format("%.1f", MemoryMonitor.getMaxMemSpent()));
-        StatWriter.log("memory-current-MB", String.format("%.1f", memoryUsed));
         StatWriter.log("#-executions", String.format("%d", SearchStatistics.iteration));
         if (PExplicitGlobal.getConfig().getStateCachingMode() != StateCachingMode.None) {
             StatWriter.log("#-states", String.format("%d", SearchStatistics.totalStates));
             StatWriter.log("#-distinct-states", String.format("%d", SearchStatistics.totalDistinctStates));
         }
         StatWriter.log("steps-min", String.format("%d", SearchStatistics.minSteps));
-        StatWriter.log("max-depth-explored", String.format("%d", SearchStatistics.maxSteps));
         StatWriter.log("steps-avg", String.format("%d", SearchStatistics.totalSteps / SearchStatistics.iteration));
         StatWriter.log("#-choices-unexplored", String.format("%d", getNumUnexploredChoices()));
         StatWriter.log("%-choices-unexplored-data", String.format("%.1f", getUnexploredDataChoicesPercent()));

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
@@ -13,11 +13,6 @@ import java.util.*;
  */
 public class StepState implements Serializable {
     /**
-     * Mapping from machine type to list of machine instances
-     */
-    private Map<Class<? extends PMachine>, List<PMachine>> machineListByType = new HashMap<>();
-
-    /**
      * Set of machines
      */
     @Getter
@@ -31,7 +26,6 @@ public class StepState implements Serializable {
     public StepState copyState() {
         StepState stepState = new StepState();
 
-        stepState.machineListByType = new HashMap<>(this.machineListByType);
         stepState.machineSet = new TreeSet<>(this.machineSet);
 
         stepState.machineLocalStates = new HashMap<>();
@@ -44,7 +38,6 @@ public class StepState implements Serializable {
     }
 
     public void clear() {
-        machineListByType.clear();
         machineSet.clear();
         machineLocalStates.clear();
     }
@@ -54,12 +47,10 @@ public class StepState implements Serializable {
         for (PMachine machine : PExplicitGlobal.getMachineSet()) {
             machine.reset();
         }
-        machineListByType.clear();
         machineSet.clear();
     }
 
     public void setTo(StepState input) {
-        machineListByType = new HashMap<>(input.machineListByType);
         machineSet = new TreeSet<>(input.machineSet);
         machineLocalStates = new HashMap<>(input.machineLocalStates);
         assert (machineSet.size() == machineLocalStates.size());
@@ -80,10 +71,6 @@ public class StepState implements Serializable {
      * @param machine Machine to add
      */
     public void makeMachine(PMachine machine) {
-        if (!machineListByType.containsKey(machine.getClass())) {
-            machineListByType.put(machine.getClass(), new ArrayList<>());
-        }
-        machineListByType.get(machine.getClass()).add(machine);
         machineSet.add(machine);
     }
 
@@ -94,7 +81,13 @@ public class StepState implements Serializable {
      * @return Number of machine of a given type
      */
     public int getMachineCount(Class<? extends PMachine> type) {
-        return machineListByType.getOrDefault(type, new ArrayList<>()).size();
+        int result = 0;
+        for (PMachine m: machineSet) {
+            if (type.isInstance(m)) {
+                result++;
+            }
+        }
+        return result;
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/StepState.java
@@ -82,7 +82,7 @@ public class StepState implements Serializable {
      */
     public int getMachineCount(Class<? extends PMachine> type) {
         int result = 0;
-        for (PMachine m: machineSet) {
+        for (PMachine m : machineSet) {
             if (type.isInstance(m)) {
                 result++;
             }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -76,7 +76,7 @@ public abstract class SearchStrategy implements Serializable {
         }
 
         SearchTask nextTask = popNextTask();
-        nextTask.deserializeTask();
+        nextTask.readFromFile();
         setCurrTask(nextTask);
 
         return nextTask;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -110,7 +110,7 @@ public abstract class SearchStrategy implements Serializable {
         return numUnexplored;
     }
 
-    public abstract void addNewTask(SearchTask task);
-
     abstract SearchTask popNextTask();
+
+    public abstract void addNewTask(SearchTask task);
 }

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchStrategyMode.java
@@ -3,7 +3,8 @@ package pexplicit.runtime.scheduler.explicit.strategy;
 public enum SearchStrategyMode {
     DepthFirst("dfs"),
     Random("random"),
-    Astar("astar");
+    Astar("astar"),
+    Replay("replay");
 
     private String name;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -1,6 +1,7 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
+import org.apache.commons.io.FileUtils;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachineId;
@@ -220,6 +221,24 @@ public class SearchTask implements Serializable {
         searchUnits.remove(choiceNum);
     }
 
+    public static void Initialize() {
+        String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
+        try {
+            Files.createDirectories(Paths.get(taskPath));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize tasks at " + taskPath, e);
+        }
+    }
+
+    public static void Cleanup() {
+        String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
+        try {
+            FileUtils.deleteDirectory(new File(taskPath));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to cleanup tasks at " + taskPath, e);
+        }
+    }
+
     public void serializeTask() {
         assert (serializeFile == null);
         assert (prefixChoices != null);
@@ -227,7 +246,6 @@ public class SearchTask implements Serializable {
 
         serializeFile = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/" + this + ".ser";
         try {
-            Files.createDirectories(Paths.get(PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/"));
             FileOutputStream fos = new FileOutputStream(serializeFile);
             ObjectOutputStream oos = new ObjectOutputStream(fos);
             oos.writeObject(this.prefixChoices);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -1,7 +1,6 @@
 package pexplicit.runtime.scheduler.explicit.strategy;
 
 import lombok.Getter;
-import org.apache.commons.io.FileUtils;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.machine.PMachineId;
@@ -54,11 +53,13 @@ public class SearchTask implements Serializable {
 
     public static void Cleanup() {
         String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
-        try {
-            FileUtils.deleteDirectory(new File(taskPath));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to cleanup tasks at " + taskPath, e);
+        File taskDir = new File(taskPath);
+        String[] entries = taskDir.list();
+        for (String s : entries) {
+            File currentFile = new File(taskDir.getPath(), s);
+            currentFile.delete();
         }
+        taskDir.delete();
     }
 
     public boolean isInitialTask() {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -43,6 +43,24 @@ public class SearchTask implements Serializable {
         this.parentTask = parentTask;
     }
 
+    public static void Initialize() {
+        String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
+        try {
+            Files.createDirectories(Paths.get(taskPath));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize tasks at " + taskPath, e);
+        }
+    }
+
+    public static void Cleanup() {
+        String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
+        try {
+            FileUtils.deleteDirectory(new File(taskPath));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to cleanup tasks at " + taskPath, e);
+        }
+    }
+
     public boolean isInitialTask() {
         return id == 0;
     }
@@ -110,7 +128,6 @@ public class SearchTask implements Serializable {
             Collections.sort(keys);
         return keys;
     }
-
 
     /**
      * Get the number of search units in the task
@@ -211,7 +228,6 @@ public class SearchTask implements Serializable {
         return numUnexplored;
     }
 
-
     /**
      * Clear search unit at a choice depth
      *
@@ -219,24 +235,6 @@ public class SearchTask implements Serializable {
      */
     public void clearSearchUnit(int choiceNum) {
         searchUnits.remove(choiceNum);
-    }
-
-    public static void Initialize() {
-        String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
-        try {
-            Files.createDirectories(Paths.get(taskPath));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to initialize tasks at " + taskPath, e);
-        }
-    }
-
-    public static void Cleanup() {
-        String taskPath = PExplicitGlobal.getConfig().getOutputFolder() + "/tasks/";
-        try {
-            FileUtils.deleteDirectory(new File(taskPath));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to cleanup tasks at " + taskPath, e);
-        }
     }
 
     public void writeToFile() {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -239,7 +239,7 @@ public class SearchTask implements Serializable {
         }
     }
 
-    public void serializeTask() {
+    public void writeToFile() {
         assert (serializeFile == null);
         assert (prefixChoices != null);
         assert (searchUnits != null);
@@ -260,7 +260,7 @@ public class SearchTask implements Serializable {
         searchUnits = null;
     }
 
-    public void deserializeTask() {
+    public void readFromFile() {
         assert (serializeFile != null);
         assert (prefixChoices == null);
         assert (searchUnits == null);

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/replay/ReplayScheduler.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/runtime/scheduler/replay/ReplayScheduler.java
@@ -3,6 +3,7 @@ package pexplicit.runtime.scheduler.replay;
 import pexplicit.runtime.PExplicitGlobal;
 import pexplicit.runtime.logger.PExplicitLogger;
 import pexplicit.runtime.logger.ScheduleWriter;
+import pexplicit.runtime.logger.TextWriter;
 import pexplicit.runtime.machine.PMachine;
 import pexplicit.runtime.machine.PMachineId;
 import pexplicit.runtime.scheduler.Schedule;
@@ -21,6 +22,10 @@ public class ReplayScheduler extends Scheduler {
     @Override
     public void run() throws TimeoutException, InterruptedException {
         PExplicitLogger.logStartReplay();
+
+        ScheduleWriter.Initialize();
+        TextWriter.Initialize();
+
         ScheduleWriter.logHeader();
 
         // log run test

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PBool.java
@@ -98,6 +98,11 @@ public class PBool extends PValue<PBool> {
     }
 
     @Override
+    public PBool getDefault() {
+        return new PBool(false);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         else if (!(obj instanceof PBool)) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEnum.java
@@ -7,6 +7,8 @@ import lombok.Getter;
  */
 @Getter
 public class PEnum extends PValue<PEnum> {
+    static PEnum min = null;
+
     private final String type;
     private final String name;
     private final int value;
@@ -21,6 +23,9 @@ public class PEnum extends PValue<PEnum> {
         this.type = type;
         this.name = name;
         this.value = val;
+        if (min == null || this.value < min.value) {
+            min = this;
+        }
         initialize();
     }
 
@@ -33,6 +38,9 @@ public class PEnum extends PValue<PEnum> {
         type = val.type;
         name = val.name;
         value = val.value;
+        if (min == null || this.value < min.value) {
+            min = this;
+        }
         initialize();
     }
 
@@ -53,6 +61,11 @@ public class PEnum extends PValue<PEnum> {
     @Override
     protected String _asString() {
         return name;
+    }
+
+    @Override
+    public PEnum getDefault() {
+        return min.clone();
     }
 
     @Override

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEvent.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PEvent.java
@@ -58,6 +58,11 @@ public class PEvent extends PValue<PEvent> {
     }
 
     @Override
+    public PEvent getDefault() {
+        return null;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         else if (!(obj instanceof PEvent)) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PFloat.java
@@ -163,6 +163,11 @@ public class PFloat extends PValue<PFloat> {
     }
 
     @Override
+    public PFloat getDefault() {
+        return new PFloat(0.0);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this)
             return true;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PInt.java
@@ -161,6 +161,11 @@ public class PInt extends PValue<PInt> {
     }
 
     @Override
+    public PInt getDefault() {
+        return new PInt(0);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this)
             return true;

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMachineValue.java
@@ -45,6 +45,11 @@ public class PMachineValue extends PValue<PMachineValue> {
     }
 
     @Override
+    public PMachineValue getDefault() {
+        return null;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         else if (!(obj instanceof PMachineValue)) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMap.java
@@ -183,6 +183,11 @@ public class PMap extends PValue<PMap> implements PCollection {
     }
 
     @Override
+    public PMap getDefault() {
+        return new PMap();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMessage.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PMessage.java
@@ -46,6 +46,11 @@ public class PMessage extends PValue<PMessage> {
     }
 
     @Override
+    public PMessage getDefault() {
+        return null;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PNamedTuple.java
@@ -128,6 +128,20 @@ public class PNamedTuple extends PValue<PNamedTuple> {
     }
 
     @Override
+    public PNamedTuple getDefault() {
+        Map<String, PValue<?>> defaultValues = new HashMap<>();
+        for (Map.Entry<String, PValue<?>> entry : values.entrySet()) {
+            PValue<?> val = entry.getValue();
+            if (val == null) {
+                defaultValues.put(entry.getKey(), null);
+            } else {
+                defaultValues.put(entry.getKey(), val.getDefault());
+            }
+        }
+        return new PNamedTuple(defaultValues);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSeq.java
@@ -126,6 +126,11 @@ public class PSeq extends PValue<PSeq> implements PCollection {
     }
 
     @Override
+    public PSeq getDefault() {
+        return new PSeq();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PSet.java
@@ -123,6 +123,11 @@ public class PSet extends PValue<PSet> implements PCollection {
     }
 
     @Override
+    public PSet getDefault() {
+        return new PSet();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PString.java
@@ -107,6 +107,11 @@ public class PString extends PValue<PString> {
     }
 
     @Override
+    public PString getDefault() {
+        return new PString("");
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         else if (!(obj instanceof PString)) {

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PTuple.java
@@ -75,6 +75,20 @@ public class PTuple extends PValue<PTuple> {
     }
 
     @Override
+    public PTuple getDefault() {
+        PValue<?>[] defaultFields = new PValue<?>[fields.length];
+        for (int i = 0; i < fields.length; i++) {
+            PValue<?> val = fields[i];
+            if (val == null) {
+                defaultFields[i] = null;
+            } else {
+                defaultFields[i] = val.getDefault();
+            }
+        }
+        return new PTuple(defaultFields);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
 

--- a/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
+++ b/Src/PRuntimes/PExplicitRuntime/src/main/java/pexplicit/values/PValue.java
@@ -89,6 +89,13 @@ public abstract class PValue<T extends PValue<T>> implements Serializable {
     protected abstract String _asString();
 
     /**
+     * Function to create a default value of the PValue
+     *
+     * @return default value
+     */
+    public abstract T getDefault();
+
+    /**
      * Function to create a deep clone of the PValue
      *
      * @return deep clone of the PValue


### PR DESCRIPTION
Updates include:

[PEx IR]
- Several changes to avoid generating unnecessary code relating to machine-specific fields (now inferred directly in PEx RT using Reflections)
- Revamped how fields specific to a continuation are stored (now directly in `PContinuation` from PEx RT), instead of directly adding as machine field
- Simplified code generator dealing with continuations
- Minor bug correction relating to FFI

[PEx RT]
- Adds support for accessing machine-specific fields directly from runtime
- Adds storing `PContinuation` specific variables directly through PEx RT interface
- Adds `getDefault` function in `PValue` to get the default value for each P data type
- Updates default PEx RT config based on experiments (now using 500 schedules per `SearchTask` as limit)
- Adds dumping buggy schedule in file when bug is found
- Adds CLI option --replay <.schedule file> to replay a buggy schedule
- Minor cleanup and removing redundancies
- Corrects serialization errors 