### PR TITLE
[PEx] Adds limiting data choices and sharing feedback to user

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/PEx/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/Constants.cs
@@ -62,7 +62,7 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         <dependency>
             <groupId>io.github.p-org</groupId>
             <artifactId>pex</artifactId>
-            <version>[0.0.1,)</version>
+            <version>[0.2.0,)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->

--- a/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
@@ -1664,37 +1664,45 @@ internal class PExCodeGenerator : ICodeGenerator
                 break;
             case NondetExpr _:
             case FairNondetExpr _:
-                context.Write(output, $"{CompilationContext.SchedulerVar}.getRandomBool()");
+            {
+                var loc = $"\"{context.LocationResolver.GetLocation(expr.SourceLocation).ToString()
+                    .Replace(@"\", @"\\")}\"";
+                context.Write(output, $"{CompilationContext.SchedulerVar}.getRandomBool({loc})");
                 break;
+            }
             case ChooseExpr chooseExpr:
+            {
+                var loc = $"\"{context.LocationResolver.GetLocation(chooseExpr.SourceLocation).ToString()
+                    .Replace(@"\", @"\\")}\"";
+
                 if (chooseExpr.SubExpr == null)
                 {
-                    context.Write(output, $"({CompilationContext.SchedulerVar}.getRandomBool())");
+                    context.Write(output, $"{CompilationContext.SchedulerVar}.getRandomBool({loc})");
                     return;
                 }
 
                 switch (chooseExpr.SubExpr.Type.Canonicalize())
                 {
                     case PrimitiveType primitiveType when primitiveType.IsSameTypeAs(PrimitiveType.Int):
-                        context.Write(output, $"{CompilationContext.SchedulerVar}.getRandomInt(");
+                        context.Write(output, $"{CompilationContext.SchedulerVar}.getRandomInt({loc}, ");
                         WriteExpr(context, output, chooseExpr.SubExpr);
                         context.Write(output, ")");
                         break;
                     case SequenceType sequenceType:
                         context.Write(output,
-                            $"({GetPExType(sequenceType.ElementType)}) {CompilationContext.SchedulerVar}.getRandomEntry(");
+                            $"({GetPExType(sequenceType.ElementType)}) {CompilationContext.SchedulerVar}.getRandomEntry({loc}, ");
                         WriteExpr(context, output, chooseExpr.SubExpr);
                         context.Write(output, ")");
                         break;
                     case SetType setType:
                         context.Write(output,
-                            $"({GetPExType(setType.ElementType)}) {CompilationContext.SchedulerVar}.getRandomEntry(");
+                            $"({GetPExType(setType.ElementType)}) {CompilationContext.SchedulerVar}.getRandomEntry({loc}, ");
                         WriteExpr(context, output, chooseExpr.SubExpr);
                         context.Write(output, ")");
                         break;
                     case MapType mapType:
                         context.Write(output,
-                            $"({GetPExType(mapType.KeyType)}) {CompilationContext.SchedulerVar}.getRandomEntry(");
+                            $"({GetPExType(mapType.KeyType)}) {CompilationContext.SchedulerVar}.getRandomEntry({loc}, ");
                         WriteExpr(context, output, chooseExpr.SubExpr);
                         context.Write(output, ")");
                         break;
@@ -1704,6 +1712,7 @@ internal class PExCodeGenerator : ICodeGenerator
                 }
 
                 break;
+            }
             case SizeofExpr sizeOfExpr:
                 WriteExpr(context, output, sizeOfExpr.Expr);
                 context.Write(output, ".size()");

--- a/Src/PRuntimes/PExRuntime/pom.xml
+++ b/Src/PRuntimes/PExRuntime/pom.xml
@@ -274,7 +274,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <log4j2.configurationFile>${project.basedir}/src/main/resources/log4j2.xml</log4j2.configurationFile>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>0.1.0</revision>
+        <revision>0.2.0</revision>
     </properties>
 
 </project>

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/PEx.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/PEx.java
@@ -9,6 +9,7 @@ import pex.runtime.logger.PExLogger;
 import pex.runtime.logger.StatWriter;
 import pex.runtime.machine.PTestDriver;
 import pex.utils.exceptions.BugFoundException;
+import pex.utils.exceptions.TooManyChoicesException;
 import pex.utils.monitor.MemoryMonitor;
 import pex.utils.monitor.TimeMonitor;
 import pex.utils.random.RandomNumberGenerator;
@@ -67,19 +68,21 @@ public class PEx {
 
             // run the analysis
             RuntimeExecutor.run();
+        } catch (TooManyChoicesException e) {
+            exit_code = 3;
         } catch (BugFoundException e) {
             exit_code = 2;
         } catch (InvocationTargetException ex) {
             ex.printStackTrace();
-            exit_code = 5;
+            exit_code = 6;
         } catch (Exception ex) {
             if (ex.getMessage().equals("TIMEOUT")) {
-                exit_code = 3;
-            } else if (ex.getMessage().equals("MEMOUT")) {
                 exit_code = 4;
+            } else if (ex.getMessage().equals("MEMOUT")) {
+                exit_code = 5;
             } else {
                 ex.printStackTrace();
-                exit_code = 5;
+                exit_code = 6;
             }
         } finally {
             // log end-of-run metrics

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/PEx.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/PEx.java
@@ -92,7 +92,7 @@ public class PEx {
 
     /**
      * Sets up the runtime before the run.
-     * Initializes loggers, random number generator, time.memory monitors.
+     * Initializes loggers, random number generator, time/memory monitors.
      */
     private static void setup() {
         RandomNumberGenerator.setup(PExGlobal.getConfig().getRandomSeed());

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/PEx.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/PEx.java
@@ -69,20 +69,20 @@ public class PEx {
             // run the analysis
             RuntimeExecutor.run();
         } catch (TooManyChoicesException e) {
-            exit_code = 3;
+            exit_code = 2;
         } catch (BugFoundException e) {
             exit_code = 2;
         } catch (InvocationTargetException ex) {
             ex.printStackTrace();
-            exit_code = 6;
+            exit_code = 5;
         } catch (Exception ex) {
             if (ex.getMessage().equals("TIMEOUT")) {
-                exit_code = 4;
+                exit_code = 3;
             } else if (ex.getMessage().equals("MEMOUT")) {
-                exit_code = 5;
+                exit_code = 4;
             } else {
                 ex.printStackTrace();
-                exit_code = 6;
+                exit_code = 5;
             }
         } finally {
             // log end-of-run metrics

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/RuntimeExecutor.java
@@ -29,12 +29,11 @@ import java.util.concurrent.*;
  * Represents the runtime executor that executes the analysis engine
  */
 public class RuntimeExecutor {
+    private static final List<Future<Integer>> futures = new ArrayList<>();
     private static ExecutorService executor;
-    private static List<Future<Integer>> futures = new ArrayList<>();
 
     private static void cancelAllThreads() {
-        for (int i = 0; i < futures.size(); i++) {
-            Future<Integer> f = futures.get(i);
+        for (Future<Integer> f : futures) {
             if (!f.isDone() && !f.isCancelled()) {
                 f.cancel(true);
             }
@@ -147,7 +146,7 @@ public class RuntimeExecutor {
         StatWriter.log("memory-limit-MB", String.format("%.1f", PExGlobal.getConfig().getMemLimit()));
     }
 
-    private static void process(boolean resume) throws Exception {
+    private static void process() throws Exception {
         try {
             runWithTimeout();
         } catch (TimeoutException e) {
@@ -212,7 +211,7 @@ public class RuntimeExecutor {
             PExGlobal.addSearchScheduler(scheduler);
         }
 
-        process(false);
+        process();
     }
 
     private static void replaySchedule(String fileName) throws Exception {

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/RuntimeExecutor.java
@@ -162,6 +162,7 @@ public class RuntimeExecutor {
                 PExGlobal.setResult(PExGlobal.getResult() + " (too many choices)");
             }
             e.getScheduler().getLogger().logStackTrace(e);
+            PExLogger.logBugFoundInfo(e.getScheduler());
 
             String schFile = PExGlobal.getConfig().getOutputFolder() + "/" + PExGlobal.getConfig().getProjectName() + "_0_0.schedule";
             PExLogger.logInfo(String.format("Writing buggy trace in %s", schFile));

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/RuntimeExecutor.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/RuntimeExecutor.java
@@ -12,6 +12,7 @@ import pex.runtime.scheduler.explicit.strategy.SearchTask;
 import pex.runtime.scheduler.replay.ReplayScheduler;
 import pex.utils.exceptions.BugFoundException;
 import pex.utils.exceptions.MemoutException;
+import pex.utils.exceptions.TooManyChoicesException;
 import pex.utils.monitor.MemoryMonitor;
 import pex.utils.monitor.TimeMonitor;
 import pex.utils.monitor.TimedCall;
@@ -158,6 +159,9 @@ public class RuntimeExecutor {
         } catch (BugFoundException e) {
             PExGlobal.setStatus(STATUS.BUG_FOUND);
             PExGlobal.setResult(String.format("found cex of length %d", e.getScheduler().getStepNumber()));
+            if (e instanceof TooManyChoicesException) {
+                PExGlobal.setResult(PExGlobal.getResult() + " (too many choices)");
+            }
             e.getScheduler().getLogger().logStackTrace(e);
 
             String schFile = PExGlobal.getConfig().getOutputFolder() + "/" + PExGlobal.getConfig().getProjectName() + "_0_0.schedule";
@@ -226,6 +230,9 @@ public class RuntimeExecutor {
         } catch (BugFoundException replayException) {
             PExGlobal.setStatus(STATUS.BUG_FOUND);
             PExGlobal.setResult(String.format("found cex of length %d", replayer.getStepNumber()));
+            if (replayException instanceof TooManyChoicesException) {
+                PExGlobal.setResult(PExGlobal.getResult() + " (too many choices)");
+            }
             PExLogger.logStackTrace(replayException);
             throw replayException;
         } catch (Exception replayException) {

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExConfig.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExConfig.java
@@ -75,4 +75,10 @@ public class PExConfig {
     //max number of children search tasks
     @Setter
     int maxChildrenPerTask = 2;
+    //max number of choices per choose(.) operation per call
+    @Setter
+    int maxChoiceBoundPerCall = 10000;
+    //max number of choices per choose(.) operation in total
+    @Setter
+    int maxChoiceBoundTotal = 0;
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExConfig.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExConfig.java
@@ -77,8 +77,8 @@ public class PExConfig {
     int maxChildrenPerTask = 2;
     //max number of choices per choose(.) operation per call
     @Setter
-    int maxChoiceBoundPerCall = 10000;
+    int maxChoicesPerStmtPerCall = 10;
     //max number of choices per choose(.) operation in total
     @Setter
-    int maxChoiceBoundTotal = 0;
+    int maxChoicesPerStmtPerSchedule = 100;
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExOptions.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExOptions.java
@@ -537,7 +537,7 @@ public class PExOptions {
             config.setNumThreads(1);
         }
 
-        if (config.getReplayFile() != "") {
+        if (!config.getReplayFile().equals("")) {
             config.setSearchStrategyMode(SearchStrategyMode.Replay);
             config.setNumThreads(1);
             if (config.getVerbosity() == 0) {

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExOptions.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExOptions.java
@@ -237,7 +237,7 @@ public class PExOptions {
                         .build();
         addHiddenOption(choiceSelect);
 
-        // max number of choices per choose(.) call
+        // max number of choices per choose(.) per call
         Option maxChoicesPerCall =
                 Option.builder()
                         .longOpt("max-choices-per-call")
@@ -248,10 +248,10 @@ public class PExOptions {
                         .build();
         addHiddenOption(maxChoicesPerCall);
 
-        // max number of choices in total
+        // max number of choices per choose(.) per schedule
         Option maxChoicesTotal =
                 Option.builder()
-                        .longOpt("max-choices-total")
+                        .longOpt("max-choices-per-schedule")
                         .desc("Max number of choices allowed per choose statement in total (default: no bound)")
                         .numberOfArgs(1)
                         .hasArg()
@@ -494,15 +494,15 @@ public class PExOptions {
                     }
                 case "max-choices-per-call":
                     try {
-                        config.setMaxChoiceBoundPerCall(Integer.parseInt(option.getValue()));
+                        config.setMaxChoicesPerStmtPerCall(Integer.parseInt(option.getValue()));
                     } catch (NumberFormatException ex) {
                         optionError(
                                 option, String.format("Expected an integer value, got %s", option.getValue()));
                     }
                     break;
-                case "max-choices-total":
+                case "max-choices-per-schedule":
                     try {
-                        config.setMaxChoiceBoundTotal(Integer.parseInt(option.getValue()));
+                        config.setMaxChoicesPerStmtPerSchedule(Integer.parseInt(option.getValue()));
                     } catch (NumberFormatException ex) {
                         optionError(
                                 option, String.format("Expected an integer value, got %s", option.getValue()));

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExOptions.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/commandline/PExOptions.java
@@ -237,6 +237,28 @@ public class PExOptions {
                         .build();
         addHiddenOption(choiceSelect);
 
+        // max number of choices per choose(.) call
+        Option maxChoicesPerCall =
+                Option.builder()
+                        .longOpt("max-choices-per-call")
+                        .desc("Max number of choices allowed per choose statement per call (default: 10000)")
+                        .numberOfArgs(1)
+                        .hasArg()
+                        .argName("(integer)")
+                        .build();
+        addHiddenOption(maxChoicesPerCall);
+
+        // max number of choices in total
+        Option maxChoicesTotal =
+                Option.builder()
+                        .longOpt("max-choices-total")
+                        .desc("Max number of choices allowed per choose statement in total (default: no bound)")
+                        .numberOfArgs(1)
+                        .hasArg()
+                        .argName("(integer)")
+                        .build();
+        addHiddenOption(maxChoicesTotal);
+
         /*
          * Help menu options
          */
@@ -469,6 +491,21 @@ public class PExOptions {
                             optionError(
                                     option,
                                     String.format("Unrecognized choice selection mode, got %s", option.getValue()));
+                    }
+                case "max-choices-per-call":
+                    try {
+                        config.setMaxChoiceBoundPerCall(Integer.parseInt(option.getValue()));
+                    } catch (NumberFormatException ex) {
+                        optionError(
+                                option, String.format("Expected an integer value, got %s", option.getValue()));
+                    }
+                    break;
+                case "max-choices-total":
+                    try {
+                        config.setMaxChoiceBoundTotal(Integer.parseInt(option.getValue()));
+                    } catch (NumberFormatException ex) {
+                        optionError(
+                                option, String.format("Expected an integer value, got %s", option.getValue()));
                     }
                     break;
                 case "h":

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/PExGlobal.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/PExGlobal.java
@@ -58,6 +58,21 @@ public class PExGlobal {
     @Getter
     private static final Set<SearchTask> runningTasks = ConcurrentHashMap.newKeySet();
     /**
+     * Explicit search schedulers
+     **/
+    @Getter
+    private static final Map<Integer, ExplicitSearchScheduler> searchSchedulers = new ConcurrentHashMap<>();
+    @Getter
+    private static final Map<Long, Integer> threadToSchedulerId = new ConcurrentHashMap<>();
+    /**
+     * Map from scheduler to global machine id
+     */
+    private static final Map<Scheduler, Integer> globalMachineId = new ConcurrentHashMap<>();
+    /**
+     * Map from scheduler to global monitor id
+     */
+    private static final Map<Scheduler, Integer> globalMonitorId = new ConcurrentHashMap<>();
+    /**
      * PModel
      **/
     @Getter
@@ -74,21 +89,6 @@ public class PExGlobal {
      */
     @Setter
     private static ReplayScheduler replayScheduler = null;
-    /**
-     * Explicit search schedulers
-     **/
-    @Getter
-    private static Map<Integer, ExplicitSearchScheduler> searchSchedulers = new ConcurrentHashMap<>();
-    @Getter
-    private static Map<Long, Integer> threadToSchedulerId = new ConcurrentHashMap<>();
-    /**
-     * Map from scheduler to global machine id
-     */
-    private static Map<Scheduler, Integer> globalMachineId = new ConcurrentHashMap<>();
-    /**
-     * Map from scheduler to global monitor id
-     */
-    private static Map<Scheduler, Integer> globalMonitorId = new ConcurrentHashMap<>();
     /**
      * Status of the run
      **/

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/PExGlobal.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/PExGlobal.java
@@ -296,10 +296,10 @@ public class PExGlobal {
         StringBuilder s = new StringBuilder(100);
         s.append(StringUtils.center("Time", 11));
         s.append(StringUtils.center("Memory", 9));
+        s.append(StringUtils.center("Tasks (run/fin/pen)", 24));
 
         s.append(StringUtils.center("Schedules", 12));
         s.append(StringUtils.center("Timelines", 12));
-        s.append(StringUtils.center("Tasks (run/fin/pen)", 24));
 //        s.append(StringUtils.center("Unexplored", 24));
 
         if (config.getStateCachingMode() != StateCachingMode.None) {
@@ -332,12 +332,12 @@ public class PExGlobal {
             s.append(StringUtils.center(String.format("%s", runtimeHms), 11));
             s.append(
                     StringUtils.center(String.format("%.1f GB", MemoryMonitor.getMemSpent() / 1024), 9));
-
-            s.append(StringUtils.center(String.format("%d", getTotalSchedules()), 12));
-            s.append(StringUtils.center(String.format("%d", timelines.size()), 12));
             s.append(StringUtils.center(String.format("%d / %d / %d",
                             runningTasks.size(), finishedTasks.size(), pendingTasks.size()),
                     24));
+
+            s.append(StringUtils.center(String.format("%d", getTotalSchedules()), 12));
+            s.append(StringUtils.center(String.format("%d", timelines.size()), 12));
 //                s.append(
 //                        StringUtils.center(
 //                                String.format(

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/PExLogger.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/PExLogger.java
@@ -61,7 +61,6 @@ public class PExLogger {
     /**
      * Logs message at the end of a run.
      *
-     * @param scheduler Explicit state search scheduler
      * @param timeSpent Time spent in seconds
      */
     public static void logEndOfRun(long timeSpent) {

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/PExLogger.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/PExLogger.java
@@ -88,7 +88,7 @@ public class PExLogger {
                     PExGlobal.getMinSteps(), (PExGlobal.getTotalSteps() / PExGlobal.getTotalSchedules()), PExGlobal.getMaxSteps()));
         }
         log.info(String.format("... Elapsed %d seconds and used %.1f GB", timeSpent, MemoryMonitor.getMaxMemSpent() / 1000.0));
-        log.info(String.format(".. Result: " + PExGlobal.getResult()));
+        log.info(String.format(".. \033[0;30;47m Result: %s \033[m", PExGlobal.getResult()));
         log.info(". Done");
     }
 

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/PExLogger.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/PExLogger.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import pex.runtime.PExGlobal;
 import pex.runtime.STATUS;
+import pex.runtime.scheduler.Scheduler;
 import pex.runtime.scheduler.explicit.StateCachingMode;
 import pex.runtime.scheduler.explicit.strategy.SearchStrategyMode;
 import pex.utils.monitor.MemoryMonitor;
@@ -102,5 +103,15 @@ public class PExLogger {
         e.printStackTrace(pw);
         log.info("--------------------");
         log.info(sw.toString());
+    }
+
+    /**
+     * Prints bug found info
+     *
+     * @param sch Scheduler that found the bug
+     */
+    public static void logBugFoundInfo(Scheduler sch) {
+        log.info("--------------------");
+        log.info(String.format("Thread %d found a bug. Details in %s", sch.getSchedulerId(), sch.getLogger().getFileName()));
     }
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/SchedulerLogger.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/logger/SchedulerLogger.java
@@ -1,5 +1,6 @@
 package pex.runtime.logger;
 
+import lombok.Getter;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,6 +36,8 @@ public class SchedulerLogger {
     LoggerContext context = null;
     @Setter
     int verbosity;
+    @Getter
+    String fileName = null;
 
     /**
      * Initializes the logger with the given verbosity level.
@@ -48,7 +51,7 @@ public class SchedulerLogger {
 
         try {
             // get new file name
-            String fileName = PExGlobal.getConfig().getOutputFolder() + "/threads/" + schId + ".log";
+            fileName = PExGlobal.getConfig().getOutputFolder() + "/threads/" + schId + ".log";
             File file = new File(fileName);
             file.getParentFile().mkdirs();
             file.createNewFile();

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/machine/MachineLocalState.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/machine/MachineLocalState.java
@@ -1,26 +1,14 @@
 package pex.runtime.machine;
 
-import lombok.Getter;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Represents the local state of a machine
+ *
+ * @param locals List of values of all local variables (including internal variables like currentState, FIFO queue, etc.)
  */
-@Getter
-public class MachineLocalState implements Serializable {
-    /**
-     * List of values of all local variables (including internal variables like currentState, FIFO queue, etc.)
-     */
-    private final List<Object> locals;
-    private final Set<String> observedEvents;
-    private final Set<String> happensBeforePairs;
-
-    public MachineLocalState(List<Object> locals, Set<String> observedEvents, Set<String> happensBeforePairs) {
-        this.locals = locals;
-        this.observedEvents = observedEvents;
-        this.happensBeforePairs = happensBeforePairs;
-    }
+public record MachineLocalState(List<Object> locals, Set<String> observedEvents,
+                                Set<String> happensBeforePairs) implements Serializable {
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/machine/PMachine.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/machine/PMachine.java
@@ -324,9 +324,9 @@ public abstract class PMachine implements Serializable, Comparable<PMachine> {
     }
 
     public void setMachineState(MachineLocalState input) {
-        setLocalVarValues(input.getLocals());
-        observedEvents = input.getObservedEvents();
-        happensBeforePairs = input.getHappensBeforePairs();
+        setLocalVarValues(input.locals());
+        observedEvents = input.observedEvents();
+        happensBeforePairs = input.happensBeforePairs();
     }
 
     /**

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/Scheduler.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/Scheduler.java
@@ -8,7 +8,6 @@ import pex.runtime.machine.PMachine;
 import pex.runtime.machine.PMachineId;
 import pex.runtime.machine.PMonitor;
 import pex.runtime.scheduler.explicit.StepState;
-import pex.utils.exceptions.BugFoundException;
 import pex.utils.exceptions.NotImplementedException;
 import pex.utils.misc.Assert;
 import pex.values.*;
@@ -145,8 +144,10 @@ public abstract class Scheduler implements SchedulerInterface {
      *
      * @return boolean data choice
      */
-    public PBool getRandomBool() {
+    public PBool getRandomBool(String loc) {
         List<PValue<?>> choices = new ArrayList<>();
+        stepState.updateChoiceStats(loc, 2);
+
         choices.add(PBool.PTRUE);
         choices.add(PBool.PFALSE);
         return (PBool) getNextDataChoice(choices);
@@ -158,15 +159,14 @@ public abstract class Scheduler implements SchedulerInterface {
      * @param bound upper bound (exclusive) on the integer.
      * @return integer data choice
      */
-    public PInt getRandomInt(PInt bound) {
+    public PInt getRandomInt(String loc, PInt bound) {
         List<PValue<?>> choices = new ArrayList<>();
         int boundInt = bound.getValue();
-        if (boundInt > 10000) {
-            throw new BugFoundException(String.format("choose expects a parameter with at most 10,000 choices, got %d choices instead.", boundInt));
-        }
         if (boundInt == 0) {
             boundInt = 1;
         }
+        stepState.updateChoiceStats(loc, boundInt);
+
         for (int i = 0; i < boundInt; i++) {
             choices.add(new PInt(i));
         }
@@ -179,8 +179,8 @@ public abstract class Scheduler implements SchedulerInterface {
      * @param choices List of data choices
      * @return data choice
      */
-    protected PValue<?> getRandomEntry(List<PValue<?>> choices) {
-        PInt randomEntryIdx = getRandomInt(new PInt(choices.size()));
+    protected PValue<?> getRandomEntry(String loc, List<PValue<?>> choices) {
+        PInt randomEntryIdx = getRandomInt(loc, new PInt(choices.size()));
         return choices.get(randomEntryIdx.getValue());
     }
 
@@ -190,8 +190,8 @@ public abstract class Scheduler implements SchedulerInterface {
      * @param seq PSeq object
      * @return data choice
      */
-    public PValue<?> getRandomEntry(PSeq seq) {
-        return getRandomEntry(seq.toList());
+    public PValue<?> getRandomEntry(String loc, PSeq seq) {
+        return getRandomEntry(loc, seq.toList());
     }
 
     /**
@@ -200,8 +200,8 @@ public abstract class Scheduler implements SchedulerInterface {
      * @param set PSet object
      * @return data choice
      */
-    public PValue<?> getRandomEntry(PSet set) {
-        return getRandomEntry(set.toList());
+    public PValue<?> getRandomEntry(String loc, PSet set) {
+        return getRandomEntry(loc, set.toList());
     }
 
     /**
@@ -210,8 +210,8 @@ public abstract class Scheduler implements SchedulerInterface {
      * @param map PMap object
      * @return data choice
      */
-    public PValue<?> getRandomEntry(PMap map) {
-        return getRandomEntry(map.toList());
+    public PValue<?> getRandomEntry(String loc, PMap map) {
+        return getRandomEntry(loc, map.toList());
     }
 
     /**

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/SchedulerInterface.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/SchedulerInterface.java
@@ -18,40 +18,45 @@ public interface SchedulerInterface extends Serializable {
     /**
      * Return a random PBool based on the search and strategy.
      *
+     * @param loc location in P model
      * @return a boolean choice.
      */
-    PBool getRandomBool();
+    PBool getRandomBool(String loc);
 
     /**
      * Return a random PInt (within a bound) based on the search and strategy.
      *
+     * @param loc   location in P model
      * @param bound upper bound (exclusive) on the integer.
      * @return a integer
      */
-    PInt getRandomInt(PInt bound);
+    PInt getRandomInt(String loc, PInt bound);
 
     /**
      * Return a random element of a PSeq based on the search and strategy.
      *
+     * @param loc      location in P model
      * @param elements list to choose from
      * @return a integer
      */
-    PValue<?> getRandomEntry(PSeq elements);
+    PValue<?> getRandomEntry(String loc, PSeq elements);
 
     /**
      * Return a random element of a PSet based on the search and strategy.
      *
+     * @param loc      location in P model
      * @param elements set to choose from
      * @return a integer
      */
-    PValue<?> getRandomEntry(PSet elements);
+    PValue<?> getRandomEntry(String loc, PSet elements);
 
     /**
      * Return a random key of a PMap based on the search and strategy.
      *
+     * @param loc      location in P model
      * @param elements map to choose from
      * @return a integer
      */
-    PValue<?> getRandomEntry(PMap elements);
+    PValue<?> getRandomEntry(String loc, PMap elements);
 
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/ExplicitSearchScheduler.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/ExplicitSearchScheduler.java
@@ -275,7 +275,7 @@ public class ExplicitSearchScheduler extends Scheduler {
             // present in state cache
 
             // check if possible cycle
-            if (visitedAt == stateVal) {
+            if (visitedAt.equals(stateVal)) {
                 if (PExGlobal.getConfig().isFailOnMaxStepBound()) {
                     // cycle detected since revisited same state at a different step in the same schedule
                     Assert.cycle("Cycle detected: Infinite loop found due to revisiting a state multiple times in the same schedule");

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/StepState.java
@@ -129,10 +129,10 @@ public class StepState implements Serializable {
             choicesNumCalls.put(loc, choicesNumCalls.get(loc) + 1);
             choicesNumChoices.put(loc, choicesNumChoices.get(loc) + num);
         }
-        if (PExGlobal.getConfig().getMaxChoiceBoundPerCall() > 0 && num > PExGlobal.getConfig().getMaxChoiceBoundPerCall()) {
+        if (PExGlobal.getConfig().getMaxChoicesPerStmtPerCall() > 0 && num > PExGlobal.getConfig().getMaxChoicesPerStmtPerCall()) {
             throw new TooManyChoicesException(loc, num);
         }
-        if (PExGlobal.getConfig().getMaxChoiceBoundTotal() > 0 && choicesNumChoices.get(loc) > PExGlobal.getConfig().getMaxChoiceBoundTotal()) {
+        if (PExGlobal.getConfig().getMaxChoicesPerStmtPerSchedule() > 0 && choicesNumChoices.get(loc) > PExGlobal.getConfig().getMaxChoicesPerStmtPerSchedule()) {
             throw new TooManyChoicesException(loc, choicesNumChoices.get(loc), choicesNumCalls.get(loc));
         }
     }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/StepState.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/StepState.java
@@ -115,7 +115,7 @@ public class StepState implements Serializable {
         for (PMachine m : machines) {
             MachineLocalState ms = machineLocalStates.get(m);
             if (ms != null) {
-                s.append(String.format("%s -> %s, ", m, ms.getHappensBeforePairs()));
+                s.append(String.format("%s -> %s, ", m, ms.happensBeforePairs()));
             }
         }
         return s.toString();
@@ -147,7 +147,7 @@ public class StepState implements Serializable {
         for (PMachine machine : machines) {
             s.append(String.format("%s:\n", machine));
             List<String> fields = machine.getLocalVarNames();
-            List<Object> values = machineLocalStates.get(machine).getLocals();
+            List<Object> values = machineLocalStates.get(machine).locals();
             int j = 0;
             for (String field : fields) {
                 Object val = values.get(j++);

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/choiceselector/ChoiceQL.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/choiceselector/ChoiceQL.java
@@ -33,8 +33,7 @@ public class ChoiceQL<S> implements Serializable {
         // Compute the total and minimum weight
         double totalWeight = 0.0;
         double minWeight = Double.MAX_VALUE;
-        for (int i = 0; i < choices.size(); i++) {
-            Object choice = choices.get(i);
+        for (Object choice : choices) {
             double weight = qValues.get(state, choice.getClass(), choice);
             totalWeight += weight;
             if (weight < minWeight) {

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/strategy/SearchStrategy.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/strategy/SearchStrategy.java
@@ -52,7 +52,7 @@ public abstract class SearchStrategy implements Serializable {
     }
 
     public void createFirstTask() throws InterruptedException {
-        assert (PExGlobal.getAllTasks().size() == 0);
+        assert (PExGlobal.getAllTasks().isEmpty());
         SearchTask firstTask = createTask(null);
         addNewTask(firstTask);
     }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/strategy/SearchStrategyAStar.java
@@ -2,18 +2,13 @@ package pex.runtime.scheduler.explicit.strategy;
 
 import pex.runtime.PExGlobal;
 
-import java.util.Comparator;
 import java.util.concurrent.PriorityBlockingQueue;
 
 public class SearchStrategyAStar extends SearchStrategy {
     private static final PriorityBlockingQueue<SearchTask> elements =
-            new PriorityBlockingQueue<SearchTask>(
+            new PriorityBlockingQueue<>(
                     100,
-                    new Comparator<SearchTask>() {
-                        public int compare(SearchTask a, SearchTask b) {
-                            return Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber());
-                        }
-                    });
+                    (a, b) -> Integer.compare(a.getCurrChoiceNumber(), b.getCurrChoiceNumber()));
 
     public SearchStrategyAStar() {
     }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/strategy/SearchTask.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/runtime/scheduler/explicit/strategy/SearchTask.java
@@ -123,7 +123,7 @@ public class SearchTask implements Serializable {
     public List<Integer> getSearchUnitKeys(boolean reversed) {
         List<Integer> keys = new ArrayList<>(searchUnits.keySet());
         if (reversed)
-            Collections.sort(keys, Collections.reverseOrder());
+            keys.sort(Collections.reverseOrder());
         else
             Collections.sort(keys);
         return keys;

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/exceptions/TooManyChoicesException.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/exceptions/TooManyChoicesException.java
@@ -1,0 +1,31 @@
+package pex.utils.exceptions;
+
+import pex.runtime.PExGlobal;
+
+public class TooManyChoicesException extends BugFoundException {
+    /**
+     * Constructs a new TooManyChoicesException for choose(.) with too choices in a single call.
+     *
+     * @param loc        location of the choice
+     * @param numChoices number of choices in given choose(.) call from this location
+     */
+    public TooManyChoicesException(String loc, int numChoices) {
+        super(String.format("%s: choose expects a parameter with at most %d choices, got %d choices instead.",
+                loc, PExGlobal.getConfig().getMaxChoiceBoundPerCall(), numChoices));
+    }
+
+    /**
+     * Constructs a new TooManyChoicesException for choose(.) with too choices across calls.
+     *
+     * @param loc        location of the choice
+     * @param numChoices number of choices in total from this location
+     * @param numCalls   number of choose(.) calls from this location
+     */
+    public TooManyChoicesException(String loc, int numChoices, int numCalls) {
+        super(String.format("""
+                        %s: too many choices generated from this location - total %d choices after %d choose calls.
+                        Reduce the total number of choices generated here to at most %d, by reducing the number times this choose statement is called.
+                        For example, limit the number of transactions/requests etc.""",
+                loc, numChoices, numCalls, PExGlobal.getConfig().getMaxChoiceBoundTotal()));
+    }
+}

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/exceptions/TooManyChoicesException.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/exceptions/TooManyChoicesException.java
@@ -23,9 +23,8 @@ public class TooManyChoicesException extends BugFoundException {
      */
     public TooManyChoicesException(String loc, int numChoices, int numCalls) {
         super(String.format("""
-                        %s: too many choices generated from this location - total %d choices after %d choose calls.
-                        Reduce the total number of choices generated here to at most %d, by reducing the number times this choose statement is called.
-                        For example, limit the number of transactions/requests etc.""",
+                        %s: too many choices generated from this statement - total %d choices after %d choose calls.
+                        Reduce the total number of choices generated here to at most %d, by reducing the number of times this choose statement is called.""",
                 loc, numChoices, numCalls, PExGlobal.getConfig().getMaxChoicesPerStmtPerSchedule()));
     }
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/exceptions/TooManyChoicesException.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/exceptions/TooManyChoicesException.java
@@ -11,7 +11,7 @@ public class TooManyChoicesException extends BugFoundException {
      */
     public TooManyChoicesException(String loc, int numChoices) {
         super(String.format("%s: choose expects a parameter with at most %d choices, got %d choices instead.",
-                loc, PExGlobal.getConfig().getMaxChoiceBoundPerCall(), numChoices));
+                loc, PExGlobal.getConfig().getMaxChoicesPerStmtPerCall(), numChoices));
     }
 
     /**
@@ -26,6 +26,6 @@ public class TooManyChoicesException extends BugFoundException {
                         %s: too many choices generated from this location - total %d choices after %d choose calls.
                         Reduce the total number of choices generated here to at most %d, by reducing the number times this choose statement is called.
                         For example, limit the number of transactions/requests etc.""",
-                loc, numChoices, numCalls, PExGlobal.getConfig().getMaxChoiceBoundTotal()));
+                loc, numChoices, numCalls, PExGlobal.getConfig().getMaxChoicesPerStmtPerSchedule()));
     }
 }

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/monitor/MemoryMonitor.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/utils/monitor/MemoryMonitor.java
@@ -4,7 +4,6 @@ import com.sun.management.GarbageCollectionNotificationInfo;
 import lombok.Getter;
 import pex.utils.exceptions.MemoutException;
 
-import javax.management.Notification;
 import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
 import java.lang.management.GarbageCollectorMXBean;
@@ -25,16 +24,13 @@ public class MemoryMonitor {
         memLimit = ml;
 
         notificationListener =
-                new NotificationListener() {
-                    @Override
-                    public void handleNotification(Notification notification, Object handback) {
-                        if (notification
-                                .getType()
-                                .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
-                            Runtime runtime = Runtime.getRuntime();
-                            memSpent = (runtime.totalMemory() - runtime.freeMemory()) / 1000000.0;
-                            if (maxMemSpent < memSpent) maxMemSpent = memSpent;
-                        }
+                (notification, handback) -> {
+                    if (notification
+                            .getType()
+                            .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
+                        Runtime runtime = Runtime.getRuntime();
+                        memSpent = (runtime.totalMemory() - runtime.freeMemory()) / 1000000.0;
+                        if (maxMemSpent < memSpent) maxMemSpent = memSpent;
                     }
                 };
 

--- a/Src/PRuntimes/PExRuntime/src/main/java/pex/values/PMap.java
+++ b/Src/PRuntimes/PExRuntime/src/main/java/pex/values/PMap.java
@@ -56,11 +56,11 @@ public class PMap extends PValue<PMap> implements PCollection {
     }
 
     /**
-     * Get the mapped value corresponding to a key or a given default value if key doesn't exists
+     * Get the mapped value corresponding to a key or a given default value if key doesn't exist
      *
      * @param key input key
      * @param def input default value
-     * @return value corresponding to the key or default value if key does not exists
+     * @return value corresponding to the key or default value if key does not exist
      */
     public PValue<?> getOrDefault(PValue<?> key, PValue<?> def) {
         try {

--- a/Src/PRuntimes/PExRuntime/src/test/java/pex/TestCaseExecutor.java
+++ b/Src/PRuntimes/PExRuntime/src/test/java/pex/TestCaseExecutor.java
@@ -114,11 +114,9 @@ public class TestCaseExecutor {
             } else if (resultCode == 2) {
                 PExTestLogger.log("      bug");
             } else if (resultCode == 3) {
-                PExTestLogger.log("      too_many_choices");
-            } else if (resultCode == 4) {
                 PExTestLogger.log("      timeout");
                 resultCode = 0;
-            } else if (resultCode == 5) {
+            } else if (resultCode == 4) {
                 PExTestLogger.log("      memout");
             } else {
                 PExTestLogger.log("      error");

--- a/Src/PRuntimes/PExRuntime/src/test/java/pex/TestCaseExecutor.java
+++ b/Src/PRuntimes/PExRuntime/src/test/java/pex/TestCaseExecutor.java
@@ -37,7 +37,7 @@ public class TestCaseExecutor {
             List<String> testCaseRelPaths =
                     testCasePaths.stream()
                             .map(p -> p.substring(p.indexOf(testCasePathPrefix) + testCasePathPrefix.length()))
-                            .collect(Collectors.toList());
+                            .toList();
             testName = Paths.get(testCaseRelPaths.get(0)).getFileName().toString();
         }
         testName = testName.replaceAll("_", "");
@@ -192,14 +192,7 @@ public class TestCaseExecutor {
         }
     }
 
-    private static class StreamGobbler implements Runnable {
-        private final InputStream inputStream;
-        private final Consumer<String> consumer;
-
-        StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
-            this.inputStream = inputStream;
-            this.consumer = consumer;
-        }
+    private record StreamGobbler(InputStream inputStream, Consumer<String> consumer) implements Runnable {
 
         @Override
         public void run() {

--- a/Src/PRuntimes/PExRuntime/src/test/java/pex/TestCaseExecutor.java
+++ b/Src/PRuntimes/PExRuntime/src/test/java/pex/TestCaseExecutor.java
@@ -114,9 +114,11 @@ public class TestCaseExecutor {
             } else if (resultCode == 2) {
                 PExTestLogger.log("      bug");
             } else if (resultCode == 3) {
+                PExTestLogger.log("      too_many_choices");
+            } else if (resultCode == 4) {
                 PExTestLogger.log("      timeout");
                 resultCode = 0;
-            } else if (resultCode == 4) {
+            } else if (resultCode == 5) {
                 PExTestLogger.log("      memout");
             } else {
                 PExTestLogger.log("      error");

--- a/Src/PRuntimes/PExRuntime/src/test/java/pex/TestPEx.java
+++ b/Src/PRuntimes/PExRuntime/src/test/java/pex/TestPEx.java
@@ -165,7 +165,7 @@ public class TestPEx {
                                             f.endsWith("Correct")
                                                     || f.endsWith("DynamicError")
                                                     || f.endsWith("StaticError"))
-                            .collect(Collectors.toList());
+                            .toList();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -173,7 +173,7 @@ public class TestPEx {
         for (String testDir : testDirs) {
             Map<String, List<String>> paths = getFiles(testDir);
             List<String> pathKeys = new ArrayList<>(paths.keySet());
-            Collections.sort(pathKeys, String.CASE_INSENSITIVE_ORDER);
+            pathKeys.sort(String.CASE_INSENSITIVE_ORDER);
 
             if (testDir.contains("Correct")) {
                 for (String key : pathKeys) {

--- a/Src/PRuntimes/PExRuntime/src/test/java/pex/TestPEx.java
+++ b/Src/PRuntimes/PExRuntime/src/test/java/pex/TestPEx.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 public class TestPEx {
     private static final String outputDirectory = "output/testCases";
     private static final List<String> excluded = new ArrayList<>();
-    private static String timeout = "30";
+    private static String timeout = "15";
     private static String schedules = "100";
     private static String maxSteps = "10000";
     private static String runArgs = "--checker-args :--schedules-per-task:10:--nproc:3";

--- a/Tst/RegressionTests/Feature3Exprs/Correct/ModExpr1/modexpr1.p
+++ b/Tst/RegressionTests/Feature3Exprs/Correct/ModExpr1/modexpr1.p
@@ -4,7 +4,7 @@ machine Main {
 			var x, y : int;
 			var z, w : float;
 			var ys: set[int];
-			x = choose(100);
+			x = choose(10);
 			ys += (113);
 			ys += (123);
 			ys += (113);

--- a/Tst/RegressionTests/Feature3Exprs/DynamicError/ModExpr1/modexpr1.p
+++ b/Tst/RegressionTests/Feature3Exprs/DynamicError/ModExpr1/modexpr1.p
@@ -4,7 +4,7 @@ machine Main {
 			var x, y : int;
 			var z, w : float;
 			var ys: set[int];
-			x = choose(100);
+			x = choose(10);
 			ys += (113);
 			ys += (123);
 			ys += (113);

--- a/Tutorial/1_ClientServer/PSrc/Client.p
+++ b/Tutorial/1_ClientServer/PSrc/Client.p
@@ -70,7 +70,10 @@ machine Client
         print format ("Withdrawal with rId = {0} failed, account balance = {1}", resp.rId, resp.balance);
       }
 
+      if (currentBalance > 10)
+/* Hint 3: Reduce the number of times WithdrawAmount() is called by changing the above line to the following:
       if (currentBalance > 10 && nextReqId < (accountId*100 + 5))
+*/
       {
         print format ("Still have account balance = {0}, lets try and withdraw more", currentBalance);
         goto WithdrawMoney;
@@ -81,9 +84,9 @@ machine Client
   // function that returns a random integer between (1 to current balance + 1)
   fun WithdrawAmount() : int {
     return choose(currentBalance) + 1;
-    /* Hint 2: Decrease the amount of data non-determinism by changing the above line to the following:
-       return ((choose(5) * currentBalance) / 4) + 1;
-    */
+/* Hint 2: Reduce the number of choices by changing the above line to the following:
+    return ((choose(5) * currentBalance) / 4) + 1;
+*/
   }
 
   state NoMoneyToWithDraw {

--- a/Tutorial/1_ClientServer/PTst/TestDriver.p
+++ b/Tutorial/1_ClientServer/PTst/TestDriver.p
@@ -28,9 +28,9 @@ fun CreateRandomInitialAccounts(numAccounts: int) : map[int, int]
   var bankBalance: map[int, int];
   while(i < numAccounts) {
     bankBalance[i] = choose(100) + 10; // min 10 in the account
-    /* Hint 1: Decrease the amount of data non-determinism by changing the above line to the following:
-       bankBalance[i] = choose(5) + 10; // min 10 in the account
-    */
+/* Hint 1: Reduce the number of choices by changing the above line to the following:
+    bankBalance[i] = choose(10) + 10; // min 10 in the account
+*/
     i = i + 1;
   }
   return bankBalance;

--- a/Tutorial/2_TwoPhaseCommit/PForeign/PExForeignCode.java
+++ b/Tutorial/2_TwoPhaseCommit/PForeign/PExForeignCode.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.Random;
 
 public class PExForeignCode {
-    /* Not recommended to use data non-determinism in PEx foreign code
+/* Not allowed to use data non-determinism in PEx foreign code. So we cannot do the following:
     public static PNamedTuple ChooseRandomTransaction(PInt uniqueId) {
         Map<String, PValue<?>> values = new HashMap<>();
         Random rand = new Random();
@@ -18,5 +18,5 @@ public class PExForeignCode {
 
         return new PNamedTuple(values);
     }
-    */
+*/
 }


### PR DESCRIPTION
This PR adds a new bug type to PEx, called `TooManyChoicesException`, which differs it from C# backend. This exception is triggered if any of the following happens:
1. a statement with choose(.) expression gets triggered and the number of choices exceeds `--max-choices-per-call` hidden CLI option (default: 10).
2. a statement with choose(.) expression gets triggered multiple times in a single schedule and the total number of choices across these calls exceeeds `--max-choices-per-schedule` hidden CLI option (default: 100).

PEx result in these cases is a replayable buggy schedule with result `found bug of length N (too many choices)` and an exception raised with appropriate message and source code location to rectify the issue.

The rationale for this exception is to dynamically pinpoint the main sources of data non-determinism in the source code that usually blows up the state space for exhaustive search, and self-guide user to rectify this for PEx.

Updates include:
[PEx RT]
- Adds tracking number of calls and total choices in a schedule from each choose expression in the source code, and triggering an exception if needed.
- Adds CLI option `--max-choices-per-schedule` and `--max-choices-per-call`. To match semantics with C# backend, use `--max-choices-per-schedule 0  --max-choices-per-call 10000` (i.e., only limit per call choices to 10K, no limit on per schedule). 
- Minor refactoring and cleanup
- Bump version to 0.2

[PEx IR]
- Pass source code location info for choose(.) expression

[Tst]
- Update some tests that have choose(100) to choose(10)

[Tutorial]
- Adds detailed hint in P tutorial examples to self-guide reducing data non-determinism. (TODO: More details to follow in PEx doc/tutorial).


Example:
1. Compile PEx on ClientServer from P tutorial with `pl compile -md pex`
2. Run PEx `pl check -md pex -tc tcSingleClient --timeout 30 --checker-args :--nproc:8` raises
````
pex.utils.exceptions.TooManyChoicesException: PTst/TestDriver.p:30:22: choose expects a parameter with at most 10 choices, got 100 choices instead.
````
3. Changing `choose(100)` in `PTst/TestDriver.p:30` to `choose(10)` and repeating 1-2 raises
````
pex.utils.exceptions.TooManyChoicesException: PSrc/Client.p:86:12: choose expects a parameter with at most 10 choices, got 12 choices instead.
````
4. Changing `choose(currentBalance)` in `PSrc/Client.p:86` to `(choose(5) * currentBalance) / 4` and repeating 1-2 raises
 ````
pex.utils.exceptions.TooManyChoicesException: PSrc/Client.p:86:14: too many choices generated from this statement - total 105 choices after 21 choose calls.
Reduce the total number of choices generated here to at most 100, by reducing the number of times this choose statement is called.
````
5. Using Hint 3 to reduce number of withdraw money requests to at most 5, and repeating 1-2 runs with output:
````
.. Test case :: tcSingleClient
... Checker is using 'random' strategy with 8 threads (seed:1725655975709)
--------------------
   Time     Memory    Tasks (run/fin/pen)    Schedules   Timelines     States   
 00:00:02   0.0 GB         0 / 17 / 0           4834         25        30601    

--------------------
... Checking statistics:
..... Found 0 bugs.
... Search statistics:
..... Explored 30601 distinct states over 25 timelines
..... Explored 4834 distinct schedules
..... Finished 17 search tasks (0 pending)
..... Number of steps explored: 0 (min), 17 (avg), 20 (max).
... Elapsed 2 seconds and used 0.1 GB
..  Result: correct for any depth 
. Done
````