### PR TITLE
[Feature] `prove * using *` command for incremental proof construction

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Uclid5/Uclid5CodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Uclid5/Uclid5CodeGenerator.cs
@@ -1337,25 +1337,6 @@ public class Uclid5CodeGenerator : ICodeGenerator
             EmitLine($"verify({m.Name}_{s.Name}_{e.Name});");
         }
 
-        // foreach (var m in machines)
-        // {
-        //     foreach (var s in m.States)
-        //     {
-        //         if (_ctx.Job.CheckOnly is null || _ctx.Job.CheckOnly == m.Name || _ctx.Job.CheckOnly == s.Name)
-        //         {
-        //             EmitLine($"verify({m.Name}_{s.Name});");
-        //         }
-
-        //         foreach (var e in events.Where(e => !e.IsNullEvent && !e.IsHaltEvent && s.HasHandler(e)))
-        //         {
-        //             if (_ctx.Job.CheckOnly is null || _ctx.Job.CheckOnly == m.Name || _ctx.Job.CheckOnly == s.Name || _ctx.Job.CheckOnly == e.Name)
-        //             {
-        //                 EmitLine($"verify({m.Name}_{s.Name}_{e.Name});");
-        //             }
-        //         }
-        //     }
-        // }
-
         EmitLine("check;");
         EmitLine("print_results;");
         EmitLine("}");

--- a/Src/PCompiler/CompilerCore/Backend/Uclid5/Uclid5CodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Uclid5/Uclid5CodeGenerator.cs
@@ -958,17 +958,6 @@ public class Uclid5CodeGenerator : ICodeGenerator
         {
             GenerateEntryHandler(state, goals, requires, generateSanityChecks);
         }
-        // foreach (var m in machines)
-        // {
-        //     foreach (var s in m.States)
-        //     {
-        //         GenerateEntryHandler(s, goals, requires, generateSanityChecks);
-        //         foreach (var e in events.Where(e => !e.IsNullEvent && s.HasHandler(e)))
-        //         {
-        //             GenerateEventHandler(s, e, goals, requires, generateSanityChecks);
-        //         }
-        //     }
-        // }
 
         EmitLine("");
 

--- a/Src/PCompiler/CompilerCore/Backend/Uclid5/Uclid5CodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Uclid5/Uclid5CodeGenerator.cs
@@ -936,17 +936,25 @@ public class Uclid5CodeGenerator : ICodeGenerator
         EmitLine("");
 
         // generate the handlers
-        foreach (var m in machines)
+        if (@event != null)
         {
-            foreach (var s in m.States)
-            {
-                GenerateEntryHandler(s, goals, requires, generateSanityChecks);
-                foreach (var e in events.Where(e => !e.IsNullEvent && s.HasHandler(e)))
-                {
-                    GenerateEventHandler(s, e, goals, requires, generateSanityChecks);
-                }
-            }
+            GenerateEventHandler(state, @event, goals, requires, generateSanityChecks);
         }
+        else
+        {
+            GenerateEntryHandler(state, goals, requires, generateSanityChecks);
+        }
+        // foreach (var m in machines)
+        // {
+        //     foreach (var s in m.States)
+        //     {
+        //         GenerateEntryHandler(s, goals, requires, generateSanityChecks);
+        //         foreach (var e in events.Where(e => !e.IsNullEvent && s.HasHandler(e)))
+        //         {
+        //             GenerateEventHandler(s, e, goals, requires, generateSanityChecks);
+        //         }
+        //     }
+        // }
 
         EmitLine("");
 

--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -78,7 +78,10 @@ namespace Plang.Compiler
                 var compiledFiles = job.Backend.GenerateCode(job, scope);
                 foreach (var file in compiledFiles)
                 {
-                    job.Output.WriteInfo($"Generated {file.FileName}.");
+                    if (entry != CompilerOutput.Uclid5)
+                    {
+                        job.Output.WriteInfo($"Generated {file.FileName}.");
+                    }
                     job.Output.WriteFile(file);
                 }
 

--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -167,6 +167,43 @@ namespace Plang.Compiler
             }
         }
 
+        public static Process NonBlockingRun(string activeDirectory, string exeName, params string[] argumentList)
+        {
+            var psi = new ProcessStartInfo(exeName)
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                WorkingDirectory = activeDirectory,
+                Arguments = string.Join(" ", argumentList)
+            };
+
+            var proc = new Process { StartInfo = psi };
+            proc.Start();
+            return proc;
+        }
+
+        public static int WaitForResult(Process proc, out string stdout, out string stderr)
+        {
+            string mStderr = "", mStdout = "";
+            proc.OutputDataReceived += (s, e) => { mStdout += $"{e.Data}\n"; };
+            proc.ErrorDataReceived += (s, e) =>
+            {
+                if (!string.IsNullOrWhiteSpace(e.Data))
+                {
+                    mStderr += $"{e.Data}\n";
+                }
+            };
+            proc.BeginErrorReadLine();
+            proc.BeginOutputReadLine();
+            proc.WaitForExit();
+            stdout = mStdout;
+            stderr = mStderr;
+            return proc.ExitCode;
+        }
+
         public static int RunWithOutput(string activeDirectory,
             out string stdout,
             out string stderr, string exeName,

--- a/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
@@ -27,7 +27,7 @@ namespace Plang.Compiler
             Timeout = 60;
             HandlesAll = true;
             CheckOnly = null;
-            Parallelism = Math.Max(Environment.ProcessorCount - 1, 1);
+            Parallelism = Math.Max(Environment.ProcessorCount / 2, 1);
         }
         public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IList<CompilerOutput> outputLanguages, IList<string> inputFiles,
             string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null, string pObservePackageName = null, bool debug = false)

--- a/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
@@ -27,6 +27,7 @@ namespace Plang.Compiler
             Timeout = 60;
             HandlesAll = true;
             CheckOnly = null;
+            Parallelism = Math.Max(Environment.ProcessorCount - 1, 1);
         }
         public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IList<CompilerOutput> outputLanguages, IList<string> inputFiles,
             string projectName, DirectoryInfo projectRoot = null, IList<string> projectDependencies = null, string pObservePackageName = null, bool debug = false)
@@ -79,6 +80,7 @@ namespace Plang.Compiler
         public int Timeout { get; set; }
         public bool HandlesAll { get; set; }
         public string CheckOnly { get; set; }
+        public int Parallelism { get; set; }
 
         public void Copy(CompilerConfiguration parsedConfig)
         {

--- a/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
@@ -23,5 +23,6 @@ namespace Plang.Compiler
         int Timeout { get; }
         bool HandlesAll { get; }
         string CheckOnly { get; }
+        int Parallelism { get; }
     }
 }

--- a/Src/PCompiler/CompilerCore/Parser/PLexer.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PLexer.g4
@@ -75,6 +75,7 @@ PROVE      : 'prove';
 USING      : 'using';
 LEMMA      : 'Lemma';
 THEOREM    : 'Theorem';
+EXCEPT     : 'except';
 
 // module-system-specific keywords
 

--- a/Src/PCompiler/CompilerCore/Parser/PLexer.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PLexer.g4
@@ -70,7 +70,7 @@ IS         : 'is';
 FLYING     : 'inflight';
 TARGETS    : 'targets';
 SENT       : 'sent';
-PROOF      : 'proof';
+PROOF      : 'Proof';
 PROVE      : 'prove';
 USING      : 'using';
 

--- a/Src/PCompiler/CompilerCore/Parser/PLexer.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PLexer.g4
@@ -73,6 +73,8 @@ SENT       : 'sent';
 PROOF      : 'Proof';
 PROVE      : 'prove';
 USING      : 'using';
+LEMMA      : 'Lemma';
+THEOREM    : 'Theorem';
 
 // module-system-specific keywords
 

--- a/Src/PCompiler/CompilerCore/Parser/PLexer.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PLexer.g4
@@ -70,6 +70,9 @@ IS         : 'is';
 FLYING     : 'inflight';
 TARGETS    : 'targets';
 SENT       : 'sent';
+PROOF      : 'proof';
+PROVE      : 'prove';
+USING      : 'using';
 
 // module-system-specific keywords
 

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -74,7 +74,7 @@ invariantGroupDecl : LEMMA name=iden LBRACE invariantDecl* RBRACE
 
 proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
 proofBody : proofItem* ;
-proofItem : PROVE (targets+=expr (COMMA targets+=expr)* | goalsAll=MUL) (USING ((premises+=expr (COMMA premises+=expr)*) | premisesAll=MUL))? SEMI # ProveUsingCmd ; 
+proofItem : PROVE (targets+=expr (COMMA targets+=expr)* | goalsAll=MUL) (USING ((premises+=expr (COMMA premises+=expr)*) | premisesAll=MUL))? (EXCEPT excludes+=expr (COMMA excludes+=expr)*)? SEMI # ProveUsingCmd ; 
 
 typeDefDecl : TYPE name=iden SEMI # ForeignTypeDef
             | TYPE name=iden ASSIGN type SEMI # PTypeDef

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -66,6 +66,11 @@ topDecl : typeDefDecl
         | assumeOnStartDecl
         ;
 
+proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
+proofBody : proofItem* ;
+proofItem : PROVE targets+=expr USING premises+=expr SEMI # ProveUsingCmd
+        |   PROVE targets+=expr SEMI                      # ProveCmd
+        ; 
 
 typeDefDecl : TYPE name=iden SEMI # ForeignTypeDef
             | TYPE name=iden ASSIGN type SEMI # PTypeDef

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -62,10 +62,15 @@ topDecl : typeDefDecl
         | testDecl
         | implementationDecl
         | invariantDecl
+        | invariantGroupDecl
         | axiomDecl
         | assumeOnStartDecl
         | proofBlockDecl
         ;
+
+invariantGroupDecl : LEMMA name=iden LBRACE invariantDecl* RBRACE
+                |    THEOREM name=iden LBRACE invariantDecl* RBRACE
+                ;
 
 proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
 proofBody : proofItem* ;

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -74,7 +74,7 @@ invariantGroupDecl : LEMMA name=iden LBRACE invariantDecl* RBRACE
 
 proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
 proofBody : proofItem* ;
-proofItem : PROVE (targets+=expr (COMMA targets+=expr)* | goalsAll=MUL) (USING (premises+=expr (COMMA premises+=expr)*) | premisesAll=MUL)? SEMI # ProveUsingCmd ; 
+proofItem : PROVE (targets+=expr (COMMA targets+=expr)* | goalsAll=MUL) (USING ((premises+=expr (COMMA premises+=expr)*) | premisesAll=MUL))? SEMI # ProveUsingCmd ; 
 
 typeDefDecl : TYPE name=iden SEMI # ForeignTypeDef
             | TYPE name=iden ASSIGN type SEMI # PTypeDef

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -69,7 +69,7 @@ topDecl : typeDefDecl
 
 proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
 proofBody : proofItem* ;
-proofItem : PROVE targets+=expr (COMMA targets+=expr)* (USING premises+=expr (COMMA premises+=expr)*)* SEMI # ProveUsingCmd ; 
+proofItem : PROVE (targets+=expr (COMMA targets+=expr)* | goalsAll=MUL) (USING (premises+=expr (COMMA premises+=expr)*) | premisesAll=MUL)? SEMI # ProveUsingCmd ; 
 
 typeDefDecl : TYPE name=iden SEMI # ForeignTypeDef
             | TYPE name=iden ASSIGN type SEMI # PTypeDef

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -64,13 +64,12 @@ topDecl : typeDefDecl
         | invariantDecl
         | axiomDecl
         | assumeOnStartDecl
+        | proofBlockDecl
         ;
 
 proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
 proofBody : proofItem* ;
-proofItem : PROVE targets+=expr USING premises+=expr SEMI # ProveUsingCmd
-        |   PROVE targets+=expr SEMI                      # ProveCmd
-        ; 
+proofItem : PROVE targets+=expr (COMMA targets+=expr)* (USING premises+=expr (COMMA premises+=expr)*)* SEMI # ProveUsingCmd ; 
 
 typeDefDecl : TYPE name=iden SEMI # ForeignTypeDef
             | TYPE name=iden ASSIGN type SEMI # PTypeDef

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/InvariantGroup.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/InvariantGroup.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Antlr4.Runtime;
+
+namespace Plang.Compiler.TypeChecker.AST.Declarations
+{
+    public class InvariantGroup : IPDecl
+    {
+        public InvariantGroup(string name, ParserRuleContext sourceNode)
+        {
+            Name = name;
+            SourceLocation = sourceNode;
+        }
+        public List<Invariant> Invariants { get; set; }
+        public ParserRuleContext SourceLocation { get; }
+        public string Name { get; set; }
+    }
+}

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
@@ -13,8 +13,8 @@ namespace Plang.Compiler.TypeChecker.AST.Declarations
             Name = name;
         }
 
-        public List<IPExpr> Goals { get; set; }
-        public List<IPExpr> Premises { get; set; }
+        public List<Invariant> Goals { get; set; }
+        public List<Invariant> Premises { get; set; }
         public ParserRuleContext SourceLocation { get; }
         public string Name { get; set; }
     }

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Antlr4.Runtime;
+
+namespace Plang.Compiler.TypeChecker.AST.Declarations
+{
+    public class ProofCommand : IPDecl
+    {
+        public ProofCommand(string name, ParserRuleContext sourceNode)
+        {
+            Debug.Assert(sourceNode is PParser.ProofItemContext);
+            SourceLocation = sourceNode;
+            Name = name;
+        }
+
+        public List<IPExpr> Goals { get; set; }
+        public List<IPExpr> Premises { get; set; }
+        public ParserRuleContext SourceLocation { get; }
+        public string Name { get; set; }
+    }
+}

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
@@ -15,6 +15,7 @@ namespace Plang.Compiler.TypeChecker.AST.Declarations
 
         public List<Invariant> Goals { get; set; }
         public List<Invariant> Premises { get; set; }
+        public List<Invariant> Excepts { get; set; }
         public ParserRuleContext SourceLocation { get; }
         public string Name { get; set; }
     }

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/InvariantRefExpr.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/InvariantRefExpr.cs
@@ -1,0 +1,20 @@
+using Antlr4.Runtime;
+using Plang.Compiler.TypeChecker.AST.Declarations;
+using Plang.Compiler.TypeChecker.Types;
+
+namespace Plang.Compiler.TypeChecker.AST.Expressions
+{
+    class InvariantRefExpr : IPExpr
+    {
+        public InvariantRefExpr(Invariant inv, ParserRuleContext sourceLocation)
+        {
+            Invariant = inv;
+            SourceLocation = sourceLocation;
+        }
+        public Invariant Invariant { get; set; }
+
+        public PLanguageType Type => PrimitiveType.Bool;
+
+        public ParserRuleContext SourceLocation { get; set; }
+    }
+}

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/InvariantRefExpr.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/InvariantRefExpr.cs
@@ -1,10 +1,11 @@
+using System.Collections.Generic;
 using Antlr4.Runtime;
 using Plang.Compiler.TypeChecker.AST.Declarations;
 using Plang.Compiler.TypeChecker.Types;
 
 namespace Plang.Compiler.TypeChecker.AST.Expressions
 {
-    class InvariantRefExpr : IPExpr
+    public class InvariantRefExpr : IPExpr
     {
         public InvariantRefExpr(Invariant inv, ParserRuleContext sourceLocation)
         {
@@ -12,6 +13,20 @@ namespace Plang.Compiler.TypeChecker.AST.Expressions
             SourceLocation = sourceLocation;
         }
         public Invariant Invariant { get; set; }
+
+        public PLanguageType Type => PrimitiveType.Bool;
+
+        public ParserRuleContext SourceLocation { get; set; }
+    }
+
+    public class InvariantGroupRefExpr : IPExpr {
+        public InvariantGroupRefExpr(InvariantGroup invGroup, ParserRuleContext sourceLocation)
+        {
+            InvariantGroup = invGroup;
+            SourceLocation = sourceLocation;
+        }
+        public InvariantGroup InvariantGroup { get; set; }
+        public List<Invariant> Invariants => InvariantGroup.Invariants;
 
         public PLanguageType Type => PrimitiveType.Bool;
 

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
@@ -47,6 +47,15 @@ namespace Plang.Compiler.TypeChecker
             return null;
         }
 
+        public override object VisitInvariantGroupDecl(PParser.InvariantGroupDeclContext context)
+        {
+            var name = context.name.GetText();
+            var decl = CurrentScope.Put(name, context);
+            nodesToDeclarations.Put(context, decl);
+            context.invariantDecl().Select(Visit).ToList();
+            return null;
+        }
+
         public override object VisitProveUsingCmd(PParser.ProveUsingCmdContext context)
         {
             var name = $"proof_cmd_{CurrentScope.ProofCommands.Count()}";

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
@@ -49,7 +49,7 @@ namespace Plang.Compiler.TypeChecker
 
         public override object VisitProveUsingCmd(PParser.ProveUsingCmdContext context)
         {
-            var name = $"prove{CurrentScope.ProofCommands.Count()}";
+            var name = $"proof_cmd_{CurrentScope.ProofCommands.Count()}";
             var decl = CurrentScope.Put(name, context);
             nodesToDeclarations.Put(context, decl);
             return null;

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
@@ -47,6 +47,14 @@ namespace Plang.Compiler.TypeChecker
             return null;
         }
 
+        public override object VisitProveUsingCmd(PParser.ProveUsingCmdContext context)
+        {
+            var name = $"prove{CurrentScope.ProofCommands.Count()}";
+            var decl = CurrentScope.Put(name, context);
+            nodesToDeclarations.Put(context, decl);
+            return null;
+        }
+
         public override object VisitAssumeOnStartDecl(PParser.AssumeOnStartDeclContext context)
         {
             var name = $"init{CurrentScope.AssumeOnStarts.Count()}";

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -693,6 +693,31 @@ namespace Plang.Compiler.TypeChecker
             
             return inv;
         }
+
+        public override object VisitProveUsingCmd(PParser.ProveUsingCmdContext context)
+        {
+            var proofCmd = (ProofCommand) nodesToDeclarations.Get(context);
+            var temporaryFunction = new Function(proofCmd.Name, context);
+            temporaryFunction.Scope = CurrentScope.MakeChildScope();
+            var exprVisitor = new ExprVisitor(temporaryFunction, Handler);
+            List<IPExpr> premises = context._targets.Select(exprVisitor.Visit).ToList();
+            List<IPExpr> goals = context._premises.Select(exprVisitor.Visit).ToList();
+            proofCmd.Premises = premises;
+            proofCmd.Goals = goals;
+            return proofCmd;
+        }
+
+        public override object VisitProveCmd(PParser.ProveCmdContext context)
+        {
+            var proofCmd = (ProofCommand) nodesToDeclarations.Get(context);
+            var temporaryFunction = new Function(proofCmd.Name, context);
+            temporaryFunction.Scope = CurrentScope.MakeChildScope();
+            var exprVisitor = new ExprVisitor(temporaryFunction, Handler);
+            List<IPExpr> goals = context._targets.Select(exprVisitor.Visit).ToList();
+            proofCmd.Goals = goals;
+            proofCmd.Premises = [];
+            return proofCmd;
+        }
         
         public override object VisitAssumeOnStartDecl(PParser.AssumeOnStartDeclContext context)
         {

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -755,6 +755,8 @@ namespace Plang.Compiler.TypeChecker
             {
                 proofCmd.Goals = goals.SelectMany(x => ToInvariant(x, context)).ToList();
             }
+            // exclude things appear in `goals` from `premises`
+            proofCmd.Premises = proofCmd.Premises.Except(proofCmd.Goals).ToList();
             return proofCmd;
         }
         

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -723,6 +723,7 @@ namespace Plang.Compiler.TypeChecker
             var exprVisitor = new ExprVisitor(temporaryFunction, Handler);
             List<IPExpr> premises = [];
             List<IPExpr> goals = [];
+            List<IPExpr> excepts = context._excludes.Select(exprVisitor.Visit).ToList();
             if (context.premisesAll == null)
             {
                 premises = context._premises.Select(exprVisitor.Visit).ToList();
@@ -755,8 +756,10 @@ namespace Plang.Compiler.TypeChecker
             {
                 proofCmd.Goals = goals.SelectMany(x => ToInvariant(x, context)).ToList();
             }
+            proofCmd.Excepts = excepts.Zip(context._excludes, (x, y) => ToInvariant(x, y)).SelectMany(x => x).ToList();
             // exclude things appear in `goals` from `premises`
-            proofCmd.Premises = proofCmd.Premises.Except(proofCmd.Goals).ToList();
+            proofCmd.Premises = proofCmd.Premises.Except(proofCmd.Goals).Except(proofCmd.Excepts).ToList();
+            proofCmd.Goals = proofCmd.Goals.Except(proofCmd.Excepts).ToList();
             return proofCmd;
         }
         

--- a/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
@@ -723,6 +723,11 @@ namespace Plang.Compiler.TypeChecker
                     return new InvariantRefExpr(inv, context);
                 }
 
+                if (table.Lookup(symbolName, out InvariantGroup invGroup))
+                {
+                    return new InvariantGroupRefExpr(invGroup, context);
+                }
+
                 throw handler.MissingDeclaration(context.iden(), "variable, enum element, spec machine, or event", symbolName);
             }
 

--- a/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
@@ -718,6 +718,11 @@ namespace Plang.Compiler.TypeChecker
                     return new SpecRefExpr(context, mac);
                 }
 
+                if (table.Lookup(symbolName, out Invariant inv))
+                {
+                    return new InvariantRefExpr(inv, context);
+                }
+
                 throw handler.MissingDeclaration(context.iden(), "variable, enum element, spec machine, or event", symbolName);
             }
 

--- a/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
@@ -25,7 +25,7 @@ namespace Plang.Compiler.TypeChecker
         private readonly IDictionary<string, Pure> pures = new Dictionary<string, Pure>();
         private readonly IDictionary<string, Invariant> invariants = new Dictionary<string, Invariant>();
         private readonly IDictionary<string, Axiom> axioms = new Dictionary<string, Axiom>();
-        private readonly IDictionary<string, ProofCommand> proofCommands = new Dictionary<string, ProofCommand>();
+        private readonly List<(string, ProofCommand)> proofCommands = new List<(string, ProofCommand)>();
         private readonly IDictionary<string, AssumeOnStart> assumeOnStarts = new Dictionary<string, AssumeOnStart>();
         private readonly ICompilerConfiguration config;
         private readonly IDictionary<string, Implementation> implementations = new Dictionary<string, Implementation>();
@@ -94,7 +94,7 @@ namespace Plang.Compiler.TypeChecker
         public IEnumerable<RefinementTest> RefinementTests => refinementTests.Values;
         public IEnumerable<Implementation> Implementations => implementations.Values;
         public IEnumerable<NamedModule> NamedModules => namedModules.Values;
-        public IEnumerable<ProofCommand> ProofCommands => proofCommands.Values;
+        public IEnumerable<ProofCommand> ProofCommands => proofCommands.Select(p => p.Item2);
 
         public static Scope CreateGlobalScope(ICompilerConfiguration config)
         {
@@ -187,7 +187,8 @@ namespace Plang.Compiler.TypeChecker
 
         public bool Get(string name, out ProofCommand tree)
         {
-            return proofCommands.TryGetValue(name, out tree);
+            tree = proofCommands.Find(x => x.Item1 == name).Item2;
+            return tree != null;
         }
         
         public bool Get(string name, out AssumeOnStart tree)
@@ -693,8 +694,7 @@ namespace Plang.Compiler.TypeChecker
         public ProofCommand Put(string name, PParser.ProofItemContext tree)
         {
             var proofCommand = new ProofCommand(name, tree);
-            CheckConflicts(proofCommand, Namespace(proofCommands));
-            proofCommands.Add(name, proofCommand);
+            proofCommands.Add((name, proofCommand));
             return proofCommand;
         }
         

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -50,6 +50,7 @@ namespace Plang.Options
             
             Parser.AddArgument("no-event-handler-checks", "nch", "Do not check that all events are handled", typeof(bool)).IsHidden = true;
             Parser.AddArgument("check-only", "co", "Check only the specified machine", typeof(string)).IsHidden = true;
+            Parser.AddArgument("jobs", "j", "Number of parallel processes to use", typeof(int)).IsHidden = true;
         }
 
         /// <summary>
@@ -174,6 +175,9 @@ namespace Plang.Options
                     break;
                 case "check-only":
                     compilerConfiguration.CheckOnly = (string)option.Value;
+                    break;
+                case "jobs":
+                    compilerConfiguration.Parallelism = (int)option.Value;
                     break;
                 case "mode":
                     compilerConfiguration.OutputLanguages = new List<CompilerOutput>();

--- a/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
+++ b/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
@@ -117,7 +117,7 @@ Lemma kondo_invs {
     invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p) == YES);
 }
 
-Proof {
-    // prove a1 using no_unexpected_messages;
-    prove safety using kondo_invs;
-}
+// Proof {
+//     // prove a1 using no_unexpected_messages;
+//     prove safety using kondo_invs;
+// }

--- a/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
+++ b/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
@@ -1,0 +1,116 @@
+enum Vote {YES, NO}
+type tVoteResp = (source: machine, vote: Vote);
+
+event eVoteReq;
+event eVoteResp: tVoteResp;
+event eAbort;
+event eCommit;
+
+machine Coordinator
+{
+    var yesVotes: set[machine];
+    
+    start state Init {
+        entry {
+            var p: machine;
+            foreach (p in participants()) 
+                invariant forall new (e: event) :: forall (m: machine) :: e targets m ==> m in participants();
+                invariant forall new (e: event) :: e is eVoteReq;
+            {
+                send p, eVoteReq;
+            }
+            goto WaitForResponses;
+        }
+    }
+    
+    state WaitForResponses {
+        on eVoteResp do (resp: tVoteResp) {
+            var p: machine;
+            
+            if (resp.vote == YES) {
+                yesVotes += (resp.source);
+                
+                if (yesVotes == participants()) {
+                    foreach (p in participants()) 
+                        invariant forall new (e: event) :: forall (m: machine) :: e targets m ==> m in participants();
+                        invariant forall new (e: event) :: e is eCommit;
+                    {
+                        send p, eCommit;
+                    }
+                    goto Committed;
+                }
+                
+            } else {
+                foreach (p in participants()) 
+                    invariant forall new (e: event) :: forall (m: machine) :: e targets m ==> m in participants();
+                    invariant forall new (e: event) :: e is eAbort;
+                {
+                    send p, eAbort;
+                }
+                goto Aborted;
+            }
+        }
+    }
+    
+    state Committed {ignore eVoteResp;}
+    state Aborted {ignore eVoteResp;}
+}
+
+machine Participant {
+    start state Undecided {
+        on eVoteReq do {
+            send coordinator(), eVoteResp, (source = this, vote = preference(this));
+        }
+        
+        on eCommit do {
+            goto Accepted;
+        }
+        
+        on eAbort do {
+            goto Rejected;
+        }
+    }
+    
+    state Accepted {ignore eVoteReq, eCommit, eAbort;}
+    state Rejected {ignore eVoteReq, eCommit, eAbort;}
+}
+
+// using these to avoid initialization
+pure participants(): set[machine];
+pure coordinator(): machine;
+pure preference(m: machine) : Vote;
+
+// assumptions about how the system is setup and the pure functions above
+init forall (m: machine) :: m == coordinator() == m is Coordinator;
+init forall (m: machine) :: m in participants() == m is Participant;
+
+// making sure that our assumptions about pure functions are not pulled out from underneath us
+invariant one_coordinator: forall (m: machine) :: m == coordinator() == m is Coordinator;
+invariant participant_set: forall (m: machine) :: m in participants() == m is Participant;
+
+// set all the fields to their default values
+init forall (c: Coordinator) :: c.yesVotes == default(set[machine]);
+
+// make sure we never get a message that we're not expecting
+invariant never_commit_to_coordinator: forall (e: event) :: e is eCommit && e targets coordinator() ==> !inflight e;
+invariant never_abort_to_coordinator: forall (e: event) :: e is eAbort && e targets coordinator() ==> !inflight e;
+invariant never_req_to_coordinator: forall (e: event) :: e is eVoteReq && e targets coordinator() ==> !inflight e;
+invariant never_resp_to_participant: forall (e: event, p: Participant) :: e is eVoteResp && e targets p ==> !inflight e;
+invariant never_resp_to_init: forall (e: event, c: Coordinator) :: e is eVoteResp && e targets c && c is Init ==> !inflight e;
+invariant req_implies_not_init: forall (e: event, c: Coordinator) :: e is eVoteReq && c is Init ==> !inflight e;
+
+// the main invariant we care about
+invariant safety: forall (p1: Participant) :: p1 is Accepted ==> (forall (p2: Participant) :: preference(p2) == YES);
+
+// supporting invariants, based on the Kondo paper
+invariant  a1: forall (e: eVoteResp) :: inflight e ==> e.source in participants();
+invariant  a2: forall (e: eVoteResp) :: inflight e ==> e.vote == preference(e.source);
+invariant a3b: forall (e: eAbort)    :: inflight e ==> coordinator() is Aborted;
+invariant a3a: forall (e: eCommit)   :: inflight e ==> coordinator() is Committed;
+invariant  a4: forall (p: Participant) :: p is Accepted ==> coordinator() is Committed;
+invariant  a5: forall (p: Participant, c: Coordinator) :: p in c.yesVotes ==> preference(p) == YES;
+invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p) == YES);
+
+Proof {
+    prove safety using a1, a2, a3a, a3b, a4, a5, a6;
+}

--- a/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
+++ b/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
@@ -112,5 +112,5 @@ invariant  a5: forall (p: Participant, c: Coordinator) :: p in c.yesVotes ==> pr
 invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p) == YES);
 
 Proof {
-    prove safety using a1, a2, a3a, a3b, a4, a5, a6;
+    prove a1;
 }

--- a/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
+++ b/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
@@ -85,32 +85,39 @@ init forall (m: machine) :: m == coordinator() == m is Coordinator;
 init forall (m: machine) :: m in participants() == m is Participant;
 
 // making sure that our assumptions about pure functions are not pulled out from underneath us
-invariant one_coordinator: forall (m: machine) :: m == coordinator() == m is Coordinator;
-invariant participant_set: forall (m: machine) :: m in participants() == m is Participant;
+Lemma system_config {
+    invariant one_coordinator: forall (m: machine) :: m == coordinator() == m is Coordinator;
+    invariant participant_set: forall (m: machine) :: m in participants() == m is Participant;
+}
 
 // set all the fields to their default values
 init forall (c: Coordinator) :: c.yesVotes == default(set[machine]);
 
 // make sure we never get a message that we're not expecting
-invariant never_commit_to_coordinator: forall (e: event) :: e is eCommit && e targets coordinator() ==> !inflight e;
-invariant never_abort_to_coordinator: forall (e: event) :: e is eAbort && e targets coordinator() ==> !inflight e;
-invariant never_req_to_coordinator: forall (e: event) :: e is eVoteReq && e targets coordinator() ==> !inflight e;
-invariant never_resp_to_participant: forall (e: event, p: Participant) :: e is eVoteResp && e targets p ==> !inflight e;
-invariant never_resp_to_init: forall (e: event, c: Coordinator) :: e is eVoteResp && e targets c && c is Init ==> !inflight e;
-invariant req_implies_not_init: forall (e: event, c: Coordinator) :: e is eVoteReq && c is Init ==> !inflight e;
+Lemma no_unexpected_messages {
+    invariant never_commit_to_coordinator: forall (e: event) :: e is eCommit && e targets coordinator() ==> !inflight e;
+    invariant never_abort_to_coordinator: forall (e: event) :: e is eAbort && e targets coordinator() ==> !inflight e;
+    invariant never_req_to_coordinator: forall (e: event) :: e is eVoteReq && e targets coordinator() ==> !inflight e;
+    invariant never_resp_to_participant: forall (e: event, p: Participant) :: e is eVoteResp && e targets p ==> !inflight e;
+    invariant never_resp_to_init: forall (e: event, c: Coordinator) :: e is eVoteResp && e targets c && c is Init ==> !inflight e;
+    invariant req_implies_not_init: forall (e: event, c: Coordinator) :: e is eVoteReq && c is Init ==> !inflight e;
+}
 
 // the main invariant we care about
 invariant safety: forall (p1: Participant) :: p1 is Accepted ==> (forall (p2: Participant) :: preference(p2) == YES);
 
 // supporting invariants, based on the Kondo paper
-invariant  a1: forall (e: eVoteResp) :: inflight e ==> e.source in participants();
-invariant  a2: forall (e: eVoteResp) :: inflight e ==> e.vote == preference(e.source);
-invariant a3b: forall (e: eAbort)    :: inflight e ==> coordinator() is Aborted;
-invariant a3a: forall (e: eCommit)   :: inflight e ==> coordinator() is Committed;
-invariant  a4: forall (p: Participant) :: p is Accepted ==> coordinator() is Committed;
-invariant  a5: forall (p: Participant, c: Coordinator) :: p in c.yesVotes ==> preference(p) == YES;
-invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p) == YES);
+Lemma kondo_invs {
+    invariant  a1: forall (e: eVoteResp) :: inflight e ==> e.source in participants();
+    invariant  a2: forall (e: eVoteResp) :: inflight e ==> e.vote == preference(e.source);
+    invariant a3b: forall (e: eAbort)    :: inflight e ==> coordinator() is Aborted;
+    invariant a3a: forall (e: eCommit)   :: inflight e ==> coordinator() is Committed;
+    invariant  a4: forall (p: Participant) :: p is Accepted ==> coordinator() is Committed;
+    invariant  a5: forall (p: Participant, c: Coordinator) :: p in c.yesVotes ==> preference(p) == YES;
+    invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p) == YES);
+}
 
 Proof {
-    prove a1;
+    // prove a1 using no_unexpected_messages;
+    prove safety using kondo_invs;
 }

--- a/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
+++ b/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p
@@ -117,7 +117,8 @@ Lemma kondo_invs {
     invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p) == YES);
 }
 
-// Proof {
-//     // prove a1 using no_unexpected_messages;
-//     prove safety using kondo_invs;
-// }
+Proof {
+    prove safety using kondo_invs;
+    prove no_unexpected_messages, system_config;
+    prove kondo_invs using no_unexpected_messages, system_config;
+}

--- a/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/TwoPhaseCommitVerification.pproj
+++ b/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/TwoPhaseCommitVerification.pproj
@@ -1,0 +1,8 @@
+<Project>
+<ProjectName>TwoPhaseCommitVerification</ProjectName>
+<InputFiles>
+	<PFile>./PSrc/</PFile>
+</InputFiles>
+<OutputDir>./PGenerated/</OutputDir>
+<Target>UCLID5</Target>
+</Project>


### PR DESCRIPTION
New features:
- `prove X using Y`, which is equivalent to `requires X, Y; ensures X`; You can write `prove X using *` which will put all invariants other than X to the `requires`. Similarly, you can write `prove *;` which is equivalent to proving all invariants in one shot.
- Parallelization: `verify()` calls in Uclid5 are parallelized now; by default, it uses half the host machine's cores. You can specify the number of cores to use by passing `-j <num cores>` in the command line argument.
- `Lemma` and `Theorem` block for bundling invariant declarations, which can be referred to in the `prove X using Y` commands
Please see the example [here](https://github.com/AD1024/P/blob/83cdec91339330bd927485f9444712046223edb7/Tutorial/6_TwoPhaseCommitVerification/Single_Incremental/PSrc/System.p#L88-L124)

Other features:
- Separate the presentation of "failed" and "undefs"; the latter one might be due to a solver timeout.
- Show remaining goals if there are unproven premises. If you comment out the second `prove` command in the example, you will get results look like this:
![image](https://github.com/user-attachments/assets/2dd3fb0e-431e-4337-ba77-7625e4c0712d)
