### PR TITLE
Java code generation fixes

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/Constants.cs
@@ -52,7 +52,7 @@ namespace Plang.Compiler.Backend.Java
 
         #region Event source generation
 
-        public static readonly string EventNamespaceName = "Events";
+        public static readonly string EventNamespaceName = "PEvents";
         public static readonly string EventDefnFileName = $"{EventNamespaceName}.java";
 
         #endregion
@@ -227,9 +227,9 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         internal static readonly string PValueClass = "prt.values.PValue";
 
         /// <summary>
-        /// The fully-qualified class name of the Java P runtime's Event class.
+        /// The fully-qualified class name of the Java P runtime's PEvent class.
         /// </summary>
-        internal static readonly string EventsClass = "prt.events.Event";
+        internal static readonly string EventsClass = "prt.events.PEvent";
 
         #endregion
 

--- a/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/JavaSourceGenerator.cs
@@ -105,6 +105,7 @@ namespace Plang.Compiler.Backend.Java
                 case TypeManager.JType.JSet _:
                 case TypeManager.JType.JForeign _:
                 case TypeManager.JType.JNamedTuple _:
+                case TypeManager.JType.JEvent _:
                     Write($"{Constants.PrtDeepCloneMethodName}(");
                     writeTermToBeCloned();
                     Write(")");

--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -830,7 +830,7 @@ namespace Plang.Compiler.Backend.Java {
                     // construct a new List from that collection.
                     Write($"new {mt.ValueCollectionType}(");
                     WriteExpr(ve.Expr);
-                    Write($".{mt.KeysMethodName}()");
+                    Write($".{mt.ValuesMethodName}()");
                     Write(")");
                     break;
                 }

--- a/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/TypeManager.cs
@@ -234,6 +234,11 @@ namespace Plang.Compiler.Backend.Java
                 /// The type of a collection containing the keys of this Map.
                 /// </summary>
                 internal string KeyCollectionType => $"ArrayList<{_k.ReferenceTypeName}>";
+                
+                /// <summary>
+                /// The name of the () -> Set method that produces the values in the map.
+                /// </summary>
+                internal string ValuesMethodName => "values";
 
                 /// <summary>
                 /// The type of a collection containing the keys of this Map.
@@ -307,6 +312,7 @@ namespace Plang.Compiler.Backend.Java
                     _unboxedType = $"{Constants.EventsClass}<?>";
                 }
                 internal override bool IsPrimitive => false;
+                internal override string DefaultValue => "null";
             }
 
             internal class JVoid : JType


### PR DESCRIPTION
- Reverted PEvent Java code generation bug introduced in P Checker clean up
- Added the JEvent case to the existing handling of immutable types (like JString and JEnum)
- Changed the default value for JEvent to be null 
