### PR TITLE
Fix odd indenting of "else" in generated Java code

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -445,7 +445,8 @@ namespace Plang.Compiler.Backend.Java {
 
                     if (ifStmt.ThenBranch.Statements.Count == 0)
                     {
-                        Write("{}");
+                        WriteLine("{");
+                        WriteLine("}");
                     }
                     else
                     {
@@ -454,7 +455,7 @@ namespace Plang.Compiler.Backend.Java {
 
                     if (ifStmt.ElseBranch != null && ifStmt.ElseBranch.Statements.Count > 0)
                     {
-                        WriteLine(" else ");
+                        WriteLine("else");
                         WriteStmt(ifStmt.ElseBranch);
                     }
                     break;


### PR DESCRIPTION
Previously, normal if/else statements would be formatted like:

if..
{
}
 else
{
}

and if/else blocks with an empty if block would be formatted like: if...
{} else
{
}

Made all if/else statments be formatted like
if
{
}
else
{
}