### PR TITLE
Dev p3.0/event bag

### DIFF
--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventBag.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventBag.cs
@@ -287,22 +287,7 @@ internal sealed class EventBag : IEventQueue
         StateMachineManager.OnReceiveEventWithoutWaiting(receivedEvent.e, receivedEvent.info);
         return Task.FromResult(receivedEvent.e);
     }
-
-    /// <inheritdoc/>
-    public int GetCachedState()
-    {
-        unchecked
-        {
-            var hash = 19;
-            foreach (var (_, info) in Bag)
-            {
-                hash = (hash * 31) + info.EventName.GetHashCode();
-            }
-
-            return hash;
-        }
-    }
-
+    
     /// <inheritdoc/>
     public void Close()
     {

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventBag.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventBag.cs
@@ -262,7 +262,7 @@ internal sealed class EventBag : IEventQueue
 
         (Event e, EventInfo info) receivedEvent = default;
         int index = 0;
-        while (Bag.Count != 0)
+        while (index < Bag.Count)
         {
             receivedEvent = Bag[index];
             // Dequeue the first event that the caller waits to receive, if there is one in the queue.

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventBag.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventBag.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PChecker.Runtime.Events;
+using PChecker.Runtime.StateMachines.Managers;
+
+
+namespace PChecker.Runtime.StateMachines.EventQueues;
+
+/// <summary>
+/// Implements a bag of events that is used during testing.
+/// </summary>
+internal sealed class EventBag : IEventQueue
+{
+    /// <summary>
+    /// Manages the state machine that owns this queue.
+    /// </summary>
+    private readonly IStateMachineManager StateMachineManager;
+
+    /// <summary>
+    /// The state machine that owns this queue.
+    /// </summary>
+    private readonly StateMachine StateMachine;
+
+    /// <summary>
+    /// The internal queue that contains events with their metadata.
+    /// </summary>
+    private readonly List<(Event e, EventInfo info)> Bag;
+
+    /// <summary>
+    /// The raised event and its metadata, or null if no event has been raised.
+    /// </summary>
+    private (Event e, EventInfo info) RaisedEvent;
+
+    /// <summary>
+    /// Map from the types of events that the owner of the queue is waiting to receive
+    /// to an optional predicate. If an event of one of these types is enqueued, then
+    /// if there is no predicate, or if there is a predicate and evaluates to true, then
+    /// the event is received, else the event is deferred.
+    /// </summary>
+    private Dictionary<Type, Func<Event, bool>> EventWaitTypes;
+
+    /// <summary>
+    /// Task completion source that contains the event obtained using an explicit receive.
+    /// </summary>
+    private TaskCompletionSource<Event> ReceiveCompletionSource;
+
+    /// <summary>
+    /// Checks if the queue is accepting new events.
+    /// </summary>
+    private bool IsClosed;
+
+    /// <summary>
+    /// The size of the queue.
+    /// </summary>
+    public int Size => Bag.Count;
+
+    /// <summary>
+    /// Checks if an event has been raised.
+    /// </summary>
+    public bool IsEventRaised => RaisedEvent != default;
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventBag"/> class.
+    /// </summary>
+    internal EventBag(IStateMachineManager stateMachineManager, StateMachine stateMachine)
+    {
+        StateMachineManager = stateMachineManager;
+        StateMachine = stateMachine;
+        Bag = new List<(Event, EventInfo)>();
+        EventWaitTypes = new Dictionary<Type, Func<Event, bool>>();
+        IsClosed = false;
+    }
+    
+    /// <inheritdoc/>
+    public EnqueueStatus Enqueue(Event e, EventInfo info)
+    {
+        if (IsClosed)
+        {
+            return EnqueueStatus.Dropped;
+        }
+
+        if (EventWaitTypes.TryGetValue(e.GetType(), out var predicate) &&
+            (predicate is null || predicate(e)))
+        {
+            EventWaitTypes.Clear();
+            StateMachineManager.OnReceiveEvent(e, info);
+            ReceiveCompletionSource.SetResult(e);
+            return EnqueueStatus.EventHandlerRunning;
+        }
+
+        StateMachineManager.OnEnqueueEvent(e, info);
+        Bag.Add((e, info));
+
+        if (!StateMachineManager.IsEventHandlerRunning)
+        {
+            if (TryDequeueEvent(true).e is null)
+            {
+                return EnqueueStatus.NextEventUnavailable;
+            }
+            else
+            {
+                StateMachineManager.IsEventHandlerRunning = true;
+                return EnqueueStatus.EventHandlerNotRunning;
+            }
+        }
+
+        return EnqueueStatus.EventHandlerRunning;
+    }
+    
+    /// <inheritdoc/>
+        public (DequeueStatus status, Event e, EventInfo info) Dequeue()
+        {
+            // Try to get the raised event, if there is one. Raised events
+            // have priority over the events in the inbox.
+            if (RaisedEvent != default)
+            {
+                if (StateMachineManager.IsEventIgnored(RaisedEvent.e, RaisedEvent.info))
+                {
+                    // TODO: should the user be able to raise an ignored event?
+                    // The raised event is ignored in the current state.
+                    RaisedEvent = default;
+                }
+                else
+                {
+                    var raisedEvent = RaisedEvent;
+                    RaisedEvent = default;
+                    return (DequeueStatus.Raised, raisedEvent.e, raisedEvent.info);
+                }
+            }
+
+            var hasDefaultHandler = StateMachineManager.IsDefaultHandlerAvailable();
+            if (hasDefaultHandler)
+            {
+                StateMachine.Runtime.NotifyDefaultEventHandlerCheck(StateMachine);
+            }
+
+            // Try to dequeue the next event, if there is one.
+            var (e, info) = TryDequeueEvent();
+            if (e != null)
+            {
+                // Found next event that can be dequeued.
+                return (DequeueStatus.Success, e, info);
+            }
+
+            // No event can be dequeued, so check if there is a default event handler.
+            if (!hasDefaultHandler)
+            {
+                // There is no default event handler installed, so do not return an event.
+                StateMachineManager.IsEventHandlerRunning = false;
+                return (DequeueStatus.NotAvailable, null, null);
+            }
+
+            // TODO: check op-id of default event.
+            // A default event handler exists.
+            var stateName = StateMachine.CurrentState.GetType().Name;
+            var eventOrigin = new EventOriginInfo(StateMachine.Id, StateMachine.GetType().FullName, stateName);
+            return (DequeueStatus.Default, DefaultEvent.Instance, new EventInfo(DefaultEvent.Instance, eventOrigin, StateMachine.VectorTime));
+        }
+        
+    /// <summary>
+    /// Dequeues the next event and its metadata, if there is one available, else returns null.
+    /// </summary>
+    private (Event e, EventInfo info) TryDequeueEvent(bool checkOnly = false)
+    {
+        (Event e, EventInfo info) availableEvent = default;
+        List<(Event, EventInfo)> deferredEvents = new List<(Event, EventInfo)>();
+
+        // Iterates through the events and metadata in the inbox.
+        while (availableEvent == default)
+        {
+            if (Bag.Count == 0)
+            {
+                break;
+            }
+            var index = StateMachine.RandomInteger(Bag.Count);
+            availableEvent = Bag[index];
+
+            if (StateMachineManager.IsEventIgnored(availableEvent.e, availableEvent.info))
+            {
+                if (!checkOnly)
+                {
+                    // Removes an ignored event.
+                    Bag.Remove(availableEvent);
+                    availableEvent = default;
+                }
+
+                continue;
+            }
+
+            // Skips a deferred event.
+            if (StateMachineManager.IsEventDeferred(availableEvent.Item1, availableEvent.Item2))
+            {
+                Bag.Remove(availableEvent);
+                deferredEvents.Add(availableEvent);
+                availableEvent = default;
+                
+            }
+
+        }
+        
+        Bag.AddRange(deferredEvents);
+        if (!checkOnly)
+        {
+            Bag.Remove(availableEvent);
+        }
+
+        return availableEvent;
+    }
+    
+    /// <inheritdoc/>
+    public void RaiseEvent(Event e)
+    {
+        var stateName = StateMachine.CurrentState.GetType().Name;
+        var eventOrigin = new EventOriginInfo(StateMachine.Id, StateMachine.GetType().FullName, stateName);
+        var info = new EventInfo(e, eventOrigin, StateMachine.VectorTime);
+        RaisedEvent = (e, info);
+        StateMachineManager.OnRaiseEvent(e, info);
+    }
+
+    /// <inheritdoc/>
+    public Task<Event> ReceiveEventAsync(Type eventType, Func<Event, bool> predicate = null)
+    {
+        var eventWaitTypes = new Dictionary<Type, Func<Event, bool>>
+        {
+            { eventType, predicate }
+        };
+
+        return ReceiveEventAsync(eventWaitTypes);
+    }
+
+    /// <inheritdoc/>
+    public Task<Event> ReceiveEventAsync(params Type[] eventTypes)
+    {
+        var eventWaitTypes = new Dictionary<Type, Func<Event, bool>>();
+        foreach (var type in eventTypes)
+        {
+            eventWaitTypes.Add(type, null);
+        }
+
+        return ReceiveEventAsync(eventWaitTypes);
+    }
+    
+    /// <inheritdoc/>
+    public Task<Event> ReceiveEventAsync(params Tuple<Type, Func<Event, bool>>[] events)
+    {
+        var eventWaitTypes = new Dictionary<Type, Func<Event, bool>>();
+        foreach (var e in events)
+        {
+            eventWaitTypes.Add(e.Item1, e.Item2);
+        }
+
+        return ReceiveEventAsync(eventWaitTypes);
+    }
+    
+    /// <summary>
+    /// Waits for an event to be enqueued.
+    /// </summary>
+    private Task<Event> ReceiveEventAsync(Dictionary<Type, Func<Event, bool>> eventWaitTypes)
+    {
+        StateMachine.Runtime.NotifyReceiveCalled(StateMachine);
+
+        (Event e, EventInfo info) receivedEvent = default;
+        int index = 0;
+        while (Bag.Count != 0)
+        {
+            receivedEvent = Bag[index];
+            // Dequeue the first event that the caller waits to receive, if there is one in the queue.
+            if (eventWaitTypes.TryGetValue(receivedEvent.e.GetType(), out var predicate) &&
+                (predicate is null || predicate(receivedEvent.e)))
+            {
+                Bag.Remove(receivedEvent);
+                break;
+            }
+
+            index++;
+        }
+
+        if (receivedEvent == default)
+        {
+            ReceiveCompletionSource = new TaskCompletionSource<Event>();
+            EventWaitTypes = eventWaitTypes;
+            StateMachineManager.OnWaitEvent(EventWaitTypes.Keys);
+            return ReceiveCompletionSource.Task;
+        }
+
+        StateMachineManager.OnReceiveEventWithoutWaiting(receivedEvent.e, receivedEvent.info);
+        return Task.FromResult(receivedEvent.e);
+    }
+
+    /// <inheritdoc/>
+    public int GetCachedState()
+    {
+        unchecked
+        {
+            var hash = 19;
+            foreach (var (_, info) in Bag)
+            {
+                hash = (hash * 31) + info.EventName.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Close()
+    {
+        IsClosed = true;
+    }
+    
+    /// <summary>
+    /// Disposes the queue resources.
+    /// </summary>
+    private void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        foreach (var (e, info) in Bag)
+        {
+            StateMachineManager.OnDropEvent(e, info);
+        }
+
+        Bag.Clear();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+    
+}

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventChannel.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventChannel.cs
@@ -1,0 +1,349 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PChecker.Runtime.Events;
+using PChecker.Runtime.StateMachines.Managers;
+
+namespace PChecker.Runtime.StateMachines.EventQueues
+{
+    /// <summary>
+    /// Implements a queue of events that is used during testing.
+    /// </summary>
+    internal sealed class EventChannel : IEventQueue
+    {
+        /// <summary>
+        /// Manages the state machine that owns this queue.
+        /// </summary>
+        private readonly IStateMachineManager StateMachineManager;
+
+        /// <summary>
+        /// The state machine that owns this queue.
+        /// </summary>
+        private readonly StateMachine StateMachine;
+
+        /// <summary>
+        /// The internal queue that contains events with their metadata.
+        /// </summary>
+        private readonly Dictionary<string, LinkedList<(Event e, EventInfo info)>> Map;
+        
+        
+        /// <summary>
+        /// The list of event sender state machines.
+        /// </summary>
+        private Queue<string> SenderMachineNames;
+        
+        /// <summary>
+        /// The raised event and its metadata, or null if no event has been raised.
+        /// </summary>
+        private (Event e, EventInfo info) RaisedEvent;
+
+        /// <summary>
+        /// Map from the types of events that the owner of the queue is waiting to receive
+        /// to an optional predicate. If an event of one of these types is enqueued, then
+        /// if there is no predicate, or if there is a predicate and evaluates to true, then
+        /// the event is received, else the event is deferred.
+        /// </summary>
+        private Dictionary<Type, Func<Event, bool>> EventWaitTypes;
+
+        /// <summary>
+        /// Checks if the queue is accepting new events.
+        /// </summary>
+        private bool IsClosed;
+
+        /// <summary>
+        /// The size of the queue.
+        /// </summary>
+        public int Size => Map.Count;
+
+        /// <summary>
+        /// Checks if an event has been raised.
+        /// </summary>
+        public bool IsEventRaised => RaisedEvent != default;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventQueue"/> class.
+        /// </summary>
+        internal EventChannel(IStateMachineManager stateMachineManager, StateMachine stateMachine)
+        {
+            StateMachineManager = stateMachineManager;
+            StateMachine = stateMachine;
+            Map = new Dictionary<string, LinkedList<(Event e, EventInfo info)>>();
+            SenderMachineNames = new Queue<string>();
+            EventWaitTypes = new Dictionary<Type, Func<Event, bool>>();
+            IsClosed = false;
+        }
+
+        /// <inheritdoc/>
+        public EnqueueStatus Enqueue(Event e, EventInfo info)
+        {
+            if (IsClosed)
+            {
+                return EnqueueStatus.Dropped;
+            }
+
+            if (EventWaitTypes.TryGetValue(e.GetType(), out var predicate) &&
+                (predicate is null || predicate(e)))
+            {
+                EventWaitTypes.Clear();
+                StateMachineManager.OnReceiveEvent(e, info);
+                return EnqueueStatus.EventHandlerRunning;
+            }
+
+            StateMachineManager.OnEnqueueEvent(e, info);
+            string senderStateMachineName = info.OriginInfo.SenderStateMachineId.ToString();
+            if (!Map.ContainsKey(senderStateMachineName))
+            {
+                Map[senderStateMachineName] = new LinkedList<(Event e, EventInfo info)>();
+                SenderMachineNames.Enqueue(senderStateMachineName);
+            }
+            Map[senderStateMachineName].AddLast((e, info));
+            
+            if (!StateMachineManager.IsEventHandlerRunning)
+            {
+                if (TryDequeueEvent(true).e is null)
+                {
+                    return EnqueueStatus.NextEventUnavailable;
+                }
+                else
+                {
+                    StateMachineManager.IsEventHandlerRunning = true;
+                    return EnqueueStatus.EventHandlerNotRunning;
+                }
+            }
+
+            return EnqueueStatus.EventHandlerRunning;
+        }
+
+        /// <inheritdoc/>
+        public (DequeueStatus status, Event e, EventInfo info) Dequeue()
+        {
+            // Try to get the raised event, if there is one. Raised events
+            // have priority over the events in the inbox.
+            if (RaisedEvent != default)
+            {
+                if (StateMachineManager.IsEventIgnored(RaisedEvent.e, RaisedEvent.info))
+                {
+                    // TODO: should the user be able to raise an ignored event?
+                    // The raised event is ignored in the current state.
+                    RaisedEvent = default;
+                }
+                else
+                {
+                    var raisedEvent = RaisedEvent;
+                    RaisedEvent = default;
+                    return (DequeueStatus.Raised, raisedEvent.e, raisedEvent.info);
+                }
+            }
+
+            var hasDefaultHandler = StateMachineManager.IsDefaultHandlerAvailable();
+            if (hasDefaultHandler)
+            {
+                StateMachine.Runtime.NotifyDefaultEventHandlerCheck(StateMachine);
+            }
+
+            // Try to dequeue the next event, if there is one.
+            var (e, info) = TryDequeueEvent();
+            if (e != null)
+            {
+                // Found next event that can be dequeued.
+                return (DequeueStatus.Success, e, info);
+            }
+
+            // No event can be dequeued, so check if there is a default event handler.
+            if (!hasDefaultHandler)
+            {
+                // There is no default event handler installed, so do not return an event.
+                StateMachineManager.IsEventHandlerRunning = false;
+                return (DequeueStatus.NotAvailable, null, null);
+            }
+
+            // TODO: check op-id of default event.
+            // A default event handler exists.
+            var stateName = StateMachine.CurrentState.GetType().Name;
+            var eventOrigin = new EventOriginInfo(StateMachine.Id, StateMachine.GetType().FullName, stateName);
+            return (DequeueStatus.Default, DefaultEvent.Instance, new EventInfo(DefaultEvent.Instance, eventOrigin, StateMachine.VectorTime));
+        }
+
+        /// <summary>
+        /// Dequeues the next event and its metadata, if there is one available, else returns null.
+        /// </summary>
+        private (Event e, EventInfo info) TryDequeueEvent(bool checkOnly = false)
+        {
+            int checkedCount = 0;
+            int totalMachines = SenderMachineNames.Count;
+            (Event, EventInfo) nextAvailableEvent = default;
+
+            while (checkedCount < totalMachines)
+            {
+                if (SenderMachineNames.TryDequeue(out string stateMachine))
+                {
+                    if (Map.TryGetValue(stateMachine, out var eventList) && eventList.Count > 0)
+                    {
+                        nextAvailableEvent = TryDequeueEvent(stateMachine, checkOnly);
+                        SenderMachineNames.Enqueue(stateMachine);
+                        break;
+                    }
+                    SenderMachineNames.Enqueue(stateMachine);
+                    checkedCount++;
+                }
+            }
+            return nextAvailableEvent;
+        }
+
+        /// <summary>
+        /// Dequeues the next event and its metadata, if there is one available, else returns null.
+        /// </summary>
+        private (Event e, EventInfo info) TryDequeueEvent(string stateMachineName, bool checkOnly = false)
+        {
+            (Event, EventInfo) nextAvailableEvent = default;
+
+            // Iterates through the events and metadata in the inbox.
+            var node = Map[stateMachineName].First;
+            while (node != null)
+            {
+                var nextNode = node.Next;
+                var currentEvent = node.Value;
+
+                if (StateMachineManager.IsEventIgnored(currentEvent.e, currentEvent.info))
+                {
+                    if (!checkOnly)
+                    {
+                        // Removes an ignored event.
+                        Map[stateMachineName].Remove(node);
+                    }
+
+                    node = nextNode;
+                    continue;
+                }
+
+                // Skips a deferred event.
+                if (!StateMachineManager.IsEventDeferred(currentEvent.e, currentEvent.info))
+                {
+                    nextAvailableEvent = currentEvent;
+                    if (!checkOnly)
+                    {
+                        Map[stateMachineName].Remove(node);
+                    }
+
+                    break;
+                }
+
+                node = nextNode;
+            }
+
+            return nextAvailableEvent;
+        }
+
+        /// <inheritdoc/>
+        public void RaiseEvent(Event e)
+        {
+            var stateName = StateMachine.CurrentState.GetType().Name;
+            var eventOrigin = new EventOriginInfo(StateMachine.Id, StateMachine.GetType().FullName, stateName);
+            var info = new EventInfo(e, eventOrigin, StateMachine.VectorTime);
+            RaisedEvent = (e, info);
+            StateMachineManager.OnRaiseEvent(e, info);
+        }
+
+        /// <inheritdoc/>
+        public Task<Event> ReceiveEventAsync(Type eventType, Func<Event, bool> predicate = null)
+        {
+            var eventWaitTypes = new Dictionary<Type, Func<Event, bool>>
+            {
+                { eventType, predicate }
+            };
+
+            return ReceiveEventAsync(eventWaitTypes);
+        }
+
+        /// <inheritdoc/>
+        public Task<Event> ReceiveEventAsync(params Type[] eventTypes)
+        {
+            var eventWaitTypes = new Dictionary<Type, Func<Event, bool>>();
+            foreach (var type in eventTypes)
+            {
+                eventWaitTypes.Add(type, null);
+            }
+
+            return ReceiveEventAsync(eventWaitTypes);
+        }
+
+        /// <inheritdoc/>
+        public Task<Event> ReceiveEventAsync(params Tuple<Type, Func<Event, bool>>[] events)
+        {
+            var eventWaitTypes = new Dictionary<Type, Func<Event, bool>>();
+            foreach (var e in events)
+            {
+                eventWaitTypes.Add(e.Item1, e.Item2);
+            }
+
+            return ReceiveEventAsync(eventWaitTypes);
+        }
+
+        /// <summary>
+        /// Waits for an event to be enqueued.
+        /// </summary>
+        private Task<Event> ReceiveEventAsync(Dictionary<Type, Func<Event, bool>> eventWaitTypes)
+        {
+            StateMachine.Runtime.NotifyReceiveCalled(StateMachine);
+
+            (Event e, EventInfo info) receivedEvent = default;
+            return Task.FromResult(receivedEvent.e);
+        }
+
+        /// <inheritdoc/>
+        public int GetCachedState()
+        {
+            unchecked
+            {
+                var hash = 19;
+
+                foreach (var (_, linkedList) in Map)
+                {
+                    foreach (var (_, info) in linkedList)
+                    {
+                        hash = (hash * 31) + (info.EventName?.GetHashCode() ?? 0);
+                    }
+                }
+
+                return hash;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Close()
+        {
+            IsClosed = true;
+        }
+
+        /// <summary>
+        /// Disposes the queue resources.
+        /// </summary>
+        private void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            foreach (var (_, linkedList) in Map)
+            {
+                foreach (var (e, info) in linkedList)
+                {
+                    StateMachineManager.OnDropEvent(e, info);
+                }
+            }
+
+            Map.Clear();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventChannel.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventChannel.cs
@@ -292,25 +292,6 @@ namespace PChecker.Runtime.StateMachines.EventQueues
         }
 
         /// <inheritdoc/>
-        public int GetCachedState()
-        {
-            unchecked
-            {
-                var hash = 19;
-
-                foreach (var (_, linkedList) in Map)
-                {
-                    foreach (var (_, info) in linkedList)
-                    {
-                        hash = (hash * 31) + (info.EventName?.GetHashCode() ?? 0);
-                    }
-                }
-
-                return hash;
-            }
-        }
-
-        /// <inheritdoc/>
         public void Close()
         {
             IsClosed = true;

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventQueue.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/EventQueue.cs
@@ -285,21 +285,6 @@ namespace PChecker.Runtime.StateMachines.EventQueues
         }
 
         /// <inheritdoc/>
-        public int GetCachedState()
-        {
-            unchecked
-            {
-                var hash = 19;
-                foreach (var (_, info) in Queue)
-                {
-                    hash = (hash * 31) + info.EventName.GetHashCode();
-                }
-
-                return hash;
-            }
-        }
-
-        /// <inheritdoc/>
         public void Close()
         {
             IsClosed = true;

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/IEventQueue.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/EventQueues/IEventQueue.cs
@@ -53,11 +53,6 @@ namespace PChecker.Runtime.StateMachines.EventQueues
         Task<Event> ReceiveEventAsync(params Tuple<Type, Func<Event, bool>>[] events);
 
         /// <summary>
-        /// Returns the cached state of the queue.
-        /// </summary>
-        int GetCachedState();
-
-        /// <summary>
         /// Closes the queue, which stops any further event enqueues.
         /// </summary>
         void Close();

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/StateMachine.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/StateMachine.cs
@@ -1386,8 +1386,6 @@ namespace PChecker.Runtime.StateMachines
 
                 hash = (hash * 31) + Manager.GetCachedState();
                 
-                hash = (hash * 31) + Inbox.GetCachedState();
-
                 return hash;
             }
         }

--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/StateMachine.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/StateMachine.cs
@@ -55,6 +55,11 @@ namespace PChecker.Runtime.StateMachines
         private protected IEventQueue Inbox;
         
         /// <summary>
+        /// Event inbox type.
+        /// </summary>
+        public string InboxType;
+        
+        /// <summary>
         /// Keeps track of state machine's current vector time.
         /// </summary>
         public VectorTime VectorTime;

--- a/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
@@ -269,7 +269,7 @@ namespace PChecker.SystematicTesting
         public StateMachineId CreateStateMachineId(Type type, string name = null) => new StateMachineId(type, name, this);
 
         /// <summary>
-        /// Creates an state machine id that is uniquely tied to the specified unique name. The
+        /// Creates a state machine id that is uniquely tied to the specified unique name. The
         /// returned state machine id can either be a fresh id (not yet bound to any state machine), or
         /// it can be bound to a previously created state machine. In the second case, this state machine
         /// id can be directly used to communicate with the corresponding state machine.
@@ -506,7 +506,12 @@ namespace PChecker.SystematicTesting
             var stateMachine = Create(type);
             IStateMachineManager stateMachineManager = new StateMachineManager(this, stateMachine);
 
-            IEventQueue eventQueue = new EventQueue(stateMachineManager, stateMachine);
+            IEventQueue eventQueue = stateMachine.InboxType! switch
+            {
+                "eventbag" => new EventBag(stateMachineManager, stateMachine),
+                "eventchannel" => new EventChannel(stateMachineManager, stateMachine),
+                _ => new EventQueue(stateMachineManager, stateMachine)
+            };
             stateMachine.Configure(this, id, stateMachineManager, eventQueue);
             stateMachine.SetupEventHandlers();
             stateMachine.self = new PMachineValue(id, stateMachine.receives.ToList());

--- a/Src/PCompiler/CompilerCore/Backend/CSharp/CSharpCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/CSharp/CSharpCodeGenerator.cs
@@ -553,6 +553,11 @@ namespace Plang.Compiler.Backend.CSharp
                 context.WriteLine(output, $"this.creates.Add(nameof({context.Names.GetNameForDecl(iCreate)}));");
             }
 
+            if (machine.DequeueOption != null)
+            {
+                context.WriteLine(output, $"this.InboxType=\"{machine.DequeueOption}\";");
+            }
+
             context.WriteLine(output, "}");
             context.WriteLine(output);
         }

--- a/Src/PCompiler/CompilerCore/Parser/PLexer.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PLexer.g4
@@ -84,6 +84,11 @@ MAIN		   : 'main' ;
 RECEIVES  : 'receives' ;
 SENDS     : 'sends' ;
 
+// machine declarations
+EVENTQUEUE: 'eventqueue' ;
+EVENTBAG: 'eventbag' ;
+EVENTCHANNEL: 'eventchannel' ;
+
 // Common keywords
 CREATES : 'creates' ;
 TO      : 'to' ;

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -86,7 +86,11 @@ eventSetLiteral : events+=nonDefaultEvent (COMMA events+=nonDefaultEvent)* ;
 interfaceDecl : INTERFACE name=iden LPAREN type? RPAREN (RECEIVES nonDefaultEventList?) SEMI ;
 
 // has scope
-implMachineDecl : MACHINE name=iden cardinality? receivesSends* machineBody ;
+dequeueOption : EVENTBAG
+                | EVENTCHANNEL
+                | EVENTQUEUE
+                ;             
+implMachineDecl : dequeueOption? MACHINE name=iden cardinality? receivesSends* machineBody ;
 idenList : names+=iden (COMMA names+=iden)* ;
 
 receivesSends : RECEIVES eventSetLiteral? SEMI # MachineReceive

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/Machine.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/Machine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -38,6 +39,7 @@ namespace Plang.Compiler.TypeChecker.AST.Declarations
         public string Name { get; }
         public IStateContainer ParentStateContainer { get; } = null;
         public IEnumerable<State> States => states.Values;
+        public string DequeueOption { get; set;}
 
         public State GetState(string stateName)
         {

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -269,6 +269,18 @@ namespace Plang.Compiler.TypeChecker
             if (cardinality > uint.MaxValue) throw Handler.ValueOutOfRange(context.cardinality(), "uint32");
             machine.Assume = hasAssume ? (uint?) cardinality : null;
             machine.Assert = hasAssert ? (uint?) cardinality : null;
+            
+            // dequeueOption?
+            if (context.dequeueOption() != null)
+            {
+                var dequeueOption = context.dequeueOption().GetText();
+                if (dequeueOption != "eventqueue" && dequeueOption != "eventbag" && dequeueOption != "eventchannel")
+                {
+                    Debug.Fail($"Invalid dequeue option: {dequeueOption}. Allowed: 'eventqueue', 'eventbag', 'eventchannel'.");
+                }
+                machine.DequeueOption = dequeueOption;
+            }
+
 
             // receivesSends*
             foreach (var receivesSends in context.receivesSends())

--- a/Tst/RegressionTests/Feature1SMLevelDecls/Correct/EventChannel/EventChannel.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/Correct/EventChannel/EventChannel.p
@@ -1,0 +1,67 @@
+event e: int;
+event e2: int;
+
+eventchannel machine Main {
+	var m1: M1;
+	var m2: M2;
+	var i: int;
+	var count1: int;
+	var count2: int;
+	start state Init {
+		
+		entry {
+			count1 = 0;
+			count2 = 10;
+			m1 = new M1((sender= this, num= count1));
+			m2 = new M2((sender= this, num= count2));
+			i = 0;
+			while (i < 10)
+			{
+				print format("Waiting {0}", i);
+				i = i + 1;
+			}
+		}
+		on e do (p: int) {
+			assert p == count1;
+			count1 = count1 + 1;
+		}
+		on e2 do (p: int) {
+			assert p == count2;
+			count2 = count2 + 1;
+		}
+	}
+}
+
+machine M1 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e, i;
+				i = i + 1;
+			}
+		}
+	}
+}
+
+machine M2 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e2, i;
+				i = i + 1;
+			}
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature1SMLevelDecls/DynamicError/EvengBag/EventBag.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/DynamicError/EvengBag/EventBag.p
@@ -1,0 +1,41 @@
+event e: int;
+
+eventbag machine Main {
+	var m1: M1;
+	var i: int;
+	var prev: int;
+	start state Init {
+
+		entry {
+			m1 = new M1((sender= this, num= 0));
+			i = 0;
+			prev = 0;
+			while (i < 100)
+			{
+				print format("Waiting for events to pile up {0}", i);
+				i = i + 1;
+			}
+		}
+		on e do (p: int) {
+			assert p >= prev;
+			prev = p;
+		}
+	}
+}
+
+machine M1 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e, i;
+				i = i + 1;
+			}
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature1SMLevelDecls/DynamicError/EventChannel/EventChannel.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/DynamicError/EventChannel/EventChannel.p
@@ -1,0 +1,67 @@
+event e: int;
+event e2: int;
+
+eventchannel machine Main {
+	var m1: M1;
+	var m2: M2;
+	var i: int;
+	var count1: int;
+	var count2: int;
+	start state Init {
+		
+		entry {
+			count1 = 0;
+			count2 = 10;
+			m1 = new M1((sender= this, num= count1));
+			m2 = new M2((sender= this, num= count2));
+			i = 0;
+			while (i < 10)
+			{
+				print format("Waiting {0}", i);
+				i = i + 1;
+			}
+		}
+		on e do (p: int) {
+			assert p != count1;
+			count1 = count1 + 1;
+		}
+		on e2 do (p: int) {
+			assert p != count2;
+			count2 = count2 + 1;
+		}
+	}
+}
+
+machine M1 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e, i;
+				i = i + 1;
+			}
+		}
+	}
+}
+
+machine M2 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e2, i;
+				i = i + 1;
+			}
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/EvengBag/EventBag.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/EvengBag/EventBag.p
@@ -1,0 +1,41 @@
+event e: int;
+
+eventBag machine Main {
+	var m1: M1;
+	var i: int;
+	var prev: int;
+	start state Init {
+
+		entry {
+			m1 = new M1((sender= this, num= 0));
+			i = 0;
+			prev = 0;
+			while (i < 100)
+			{
+				print format("Waiting for events to pile up {0}", i);
+				i = i + 1;
+			}
+		}
+		on e do (p: int) {
+			assert p >= prev;
+			prev = p;
+		}
+	}
+}
+
+machine M1 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e, i;
+				i = i + 1;
+			}
+		}
+	}
+}

--- a/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/EventChannel/EventChannel.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/EventChannel/EventChannel.p
@@ -1,0 +1,67 @@
+event e: int;
+event e2: int;
+
+eventChannel machine Main {
+	var m1: M1;
+	var m2: M2;
+	var i: int;
+	var count1: int;
+	var count2: int;
+	start state Init {
+		
+		entry {
+			count1 = 0;
+			count2 = 10;
+			m1 = new M1((sender= this, num= count1));
+			m2 = new M2((sender= this, num= count2));
+			i = 0;
+			while (i < 10)
+			{
+				print format("Waiting {0}", i);
+				i = i + 1;
+			}
+		}
+		on e do (p: int) {
+			assert p == count1;
+			count1 = count1 + 1;
+		}
+		on e2 do (p: int) {
+			assert p == count2;
+			count2 = count2 + 1;
+		}
+	}
+}
+
+machine M1 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e, i;
+				i = i + 1;
+			}
+		}
+	}
+}
+
+machine M2 {
+	var i: int;
+	var j: int;
+	start state Init {
+		entry (payload: (sender: Main, num: int)) {
+			print format("sender: {0}", payload.sender);
+			i = payload.num;
+			j = i + 10;
+			while (i < j)
+			{
+				send payload.sender, e2, i;
+				i = i + 1;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added event bag and event channel option for state machine inbox. Users can change the state machine's inbox by putting "eventbag", "eventchannel", and "eventqueue" in front of machine declaration in p code.  If nothing is put, then it's default to "eventqueue".

Example usage: 
- eventchannel machine Main {}
- eventbag machine Main {}
- eventqueue machine Main {}