### PR TITLE
Upgrade cache action to suggested version

### DIFF
--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ubuntuci.yml
+++ b/.github/workflows/ubuntuci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
cache-actions@v2 has been deprecated and is no longer working; upgraded to the suggested version v4