### PR TITLE
Fix PChecker .dll file not found

### DIFF
--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uuses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ubuntuci.yml
+++ b/.github/workflows/ubuntuci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -400,7 +400,7 @@ namespace Plang.Options
                 {
                     if (checkerConfiguration.Mode == CheckerMode.BugFinding)
                     {
-                        if (!fileName.Contains($"CSharp{pathSep}"))
+                        if (!fileName.Contains($"PChecker{pathSep}"))
                             continue;
                         if (fileName.EndsWith("PCheckerCore.dll")
                             || fileName.EndsWith("PCSharpRuntime.dll")


### PR DESCRIPTION
Fixed the error `Error: Could not find any *.dll file.` by changing the PChecker search directory name from `CSharp` to `PChecker` to match the generated `PGenerated/PChecker` directory name.
