### PR TITLE
Remove feedback strategy stats dump in console

### DIFF
--- a/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
@@ -241,13 +241,12 @@ namespace PChecker.SystematicTesting
                 totalExploredSchedules,
                 totalExploredSchedules == 1 ? string.Empty : "s");
             
-            // Comment out this part until feedback strategy error is fixed
-            // report.AppendLine();
-            // report.AppendFormat(
-            //     "{0} Explored {1} timeline{2}",
-            //     prefix.Equals("...") ? "....." : prefix,
-            //     ExploredTimelines.Count,
-            //     ExploredTimelines.Count == 1 ? string.Empty : "s");
+            report.AppendLine();
+            report.AppendFormat(
+                "{0} Explored {1} timeline{2}",
+                prefix.Equals("...") ? "....." : prefix,
+                ExploredTimelines.Count,
+                ExploredTimelines.Count == 1 ? string.Empty : "s");
 
             if (totalExploredSchedules > 0 &&
                 NumOfFoundBugs > 0)

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -644,10 +644,6 @@ namespace PChecker.SystematicTesting
                 if (ShouldPrintIteration(schedule))
                 {
                     var seconds = watch.Elapsed.TotalSeconds;
-                    if (Strategy is IFeedbackGuidedStrategy s)
-                    {
-                        s.DumpStats(Logger);
-                    }
                 }
 
                 if (!IsReplayModeEnabled && _checkerConfiguration.PerformFullExploration && runtime.Scheduler.BugFound)

--- a/Tst/CorrectLogs/bugs2/Main_0_0.txt
+++ b/Tst/CorrectLogs/bugs2/Main_0_0.txt
@@ -12,5 +12,6 @@
 <StrategyLog> Found 1 bug.
 <StrategyLog> Scheduling statistics:
 <StrategyLog> Explored 1 schedule
+<StrategyLog> Explored 1 timeline
 <StrategyLog> Found 100.00% buggy schedules.
 <StrategyLog> Number of scheduling points in terminating schedules: 2 (min), 2 (avg), 2 (max).


### PR DESCRIPTION
- Removed console output that contains feedback strategy stats
- Before:
``` 
... Checker is using 'feedbackpct' strategy (seed:3297452164).
..... Schedule #1
..... Total saved: 1, pending mutations: 0, visited generators: 0
..... Schedule #2
..... Total saved: 2, pending mutations: 49, visited generators: 1
..... Schedule #3
..... Total saved: 3, pending mutations: 48, visited generators: 1 
```
- After:
```
... Checker is using 'feedbackpct' strategy (seed:3938377194).
..... Schedule #1
..... Schedule #2
..... Schedule #3
```
- Uncommented timeline console output since the feedbackpct issue is fixed