### PR TITLE
Use foreground color in p cli text for theme compatibility

### DIFF
--- a/Src/PCompiler/CompilerCore/DefaultCompilerOutput.cs
+++ b/Src/PCompiler/CompilerCore/DefaultCompilerOutput.cs
@@ -19,7 +19,7 @@ namespace Plang.Compiler
             switch (severity)
             {
                 case SeverityKind.Info:
-                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.ForegroundColor = defaultColor;
                     break;
 
                 case SeverityKind.Warning:
@@ -31,7 +31,7 @@ namespace Plang.Compiler
                     break;
 
                 default:
-                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.ForegroundColor = defaultColor;
                     break;
             }
 
@@ -55,10 +55,7 @@ namespace Plang.Compiler
 
         public void WriteInfo(string msg)
         {
-            var defaultColor = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.White;
             Console.WriteLine(msg);
-            Console.ForegroundColor = defaultColor;
         }
 
         public void WriteWarning(string msg)

--- a/Src/PCompiler/PCommandLine/CommandLineOutput.cs
+++ b/Src/PCompiler/PCommandLine/CommandLineOutput.cs
@@ -14,10 +14,7 @@ public static class CommandLineOutput
 
     public static void WriteInfo(string msg)
     {
-        var defaultColor = Console.ForegroundColor;
-        Console.ForegroundColor = ConsoleColor.White;
         Console.WriteLine(msg);
-        Console.ForegroundColor = defaultColor;
     }
 
     public static void WriteWarning(string msg)


### PR DESCRIPTION
Use console default color instead of white for p cli info messages. This will make the info messages easier to read, regardless of the user's theme.