### PR TITLE
Implement SURW algorithm

### DIFF
--- a/Src/PChecker/CheckerCore/Runtime/StateMachines/StateMachine.cs
+++ b/Src/PChecker/CheckerCore/Runtime/StateMachines/StateMachine.cs
@@ -53,6 +53,11 @@ namespace PChecker.Runtime.StateMachines
         /// Events are dequeued to be processed.
         /// </summary>
         private protected IEventQueue Inbox;
+
+        /// <summary>
+        /// The creator of this state machine. null if the `main` state machine.
+        /// </summary>
+        public StateMachine Creator;
         
         /// <summary>
         /// Keeps track of state machine's current vector time.
@@ -294,13 +299,14 @@ namespace PChecker.Runtime.StateMachines
         /// <summary>
         /// Configures the state machine.
         /// </summary>
-        internal void Configure(ControlledRuntime runtime, StateMachineId id, IStateMachineManager manager, IEventQueue inbox)
+        internal void Configure(ControlledRuntime runtime, StateMachineId id, IStateMachineManager manager, IEventQueue inbox, StateMachine creator)
         {
             Runtime = runtime;
             Id = id;
             Manager = manager;
             Inbox = inbox;
             VectorTime = new VectorTime(Id);
+            Creator = creator;
         }
         
         /// <summary>

--- a/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
@@ -505,7 +505,7 @@ namespace PChecker.SystematicTesting
             IStateMachineManager stateMachineManager = new StateMachineManager(this, stateMachine);
 
             IEventQueue eventQueue = new EventQueue(stateMachineManager, stateMachine);
-            stateMachine.Configure(this, id, stateMachineManager, eventQueue);
+            stateMachine.Configure(this, id, stateMachineManager, eventQueue, creator);
             stateMachine.SetupEventHandlers();
             stateMachine.self = new PMachineValue(id, stateMachine.receives.ToList());
             stateMachine.interfaceName = "I_" + name;
@@ -616,7 +616,7 @@ namespace PChecker.SystematicTesting
                 "Cannot send event '{0}' to state machine id '{1}' that is not bound to an state machine instance.",
                 e.GetType().FullName, targetId.Value);
 
-            Scheduler.ScheduledOperation.MessageReceiver = targetId.ToString();
+            Scheduler.ScheduledOperation.MessageReceiver = targetId.Value;
 
             Scheduler.ScheduleNextEnabledOperation(AsyncOperationType.Send);
             ResetProgramCounter(sender);

--- a/Src/PChecker/CheckerCore/SystematicTesting/Operations/AsyncOperation.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Operations/AsyncOperation.cs
@@ -53,7 +53,7 @@ namespace PChecker.SystematicTesting.Operations
         /// <summary>
         /// The receiver if the operation is Send.
         /// </summary>
-        public string MessageReceiver = "";
+        public ulong MessageReceiver = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncOperation"/> class.

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/SURWScheduler.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/SURWScheduler.cs
@@ -1,21 +1,122 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.PortableExecutable;
+using PChecker.Generator.Object;
 using PChecker.Random;
+using PChecker.Runtime.StateMachines;
 using PChecker.SystematicTesting.Operations;
 using PChecker.SystematicTesting.Strategies.Probabilistic;
 
 namespace PChecker.SystematicTesting.Strategies.Feedback;
 
-internal class SURWScheduler: IScheduler
+internal class SURWScheduler : IScheduler
 {
+    const ulong NoMachine = ulong.MaxValue;
     private readonly IRandomValueGenerator _randomValueGenerator;
-    private Dictionary<string, int> _executionLength;
 
-    public SURWScheduler(Dictionary<string, int> executionLength, IRandomValueGenerator random)
+    /// <summary>
+    /// A mapping between machine ID and number of interesting events of that machine.
+    /// </summary>
+    private Dictionary<ulong, int> _executionLength;
+
+    /// <summary>
+    /// A mapping between machine ID and the number of interesting events left to execute on that machine.
+    /// </summary>
+    private Dictionary<ulong, int> _weights;
+
+    /// <summary>
+    /// A set of blocked machines.
+    /// </summary>
+    private HashSet<ulong> _blocked = new();
+
+    /// <summary>
+    /// The machine scheduled to execute next.
+    /// </summary>
+    private ulong _nextIntendedMachine = NoMachine;
+
+    /// <summary>
+    /// Machines that are created during the execution of the program.
+    /// </summary>
+    private HashSet<ulong> _createdMachines = new();
+
+    /// <summary>
+    /// A mapping between machine ID and the set of child machines that are created by that machine.
+    /// </summary>
+    private Dictionary<ulong, HashSet<ulong>> _childMachines;
+
+    /// <summary>
+    /// A set of machines from which events are uniformly sampled.
+    /// </summary>
+    private HashSet<ulong> _interestingMachines;
+
+    // These fields are only used for the first trial to construct interesting operations map.
+
+    private Dictionary<ulong, HashSet<ulong>> _interestingMachineMap = new();
+    private Dictionary<ulong, int> _machineExecutionLengthCache = new();
+
+    public SURWScheduler(Dictionary<ulong, int> executionLength, HashSet<ulong> interestingMachines,
+        Dictionary<ulong, HashSet<ulong>> childMachines,
+        IRandomValueGenerator random)
     {
         _executionLength = executionLength;
+        _weights = _executionLength.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         _randomValueGenerator = random;
+        _interestingMachines = interestingMachines;
+        _childMachines = childMachines;
+    }
+
+    private void CheckNewMachines(IEnumerable<AsyncOperation> ops)
+    {
+        foreach (var op in ops.Where(op => !_createdMachines.Contains(op.Id)))
+        {
+            _createdMachines.Add(op.Id);
+            if (op is StateMachineOperation stateMachineOperation)
+            {
+                var parentMachine = stateMachineOperation.StateMachine.Creator;
+                if (parentMachine == null) continue;
+                _childMachines.TryAdd(parentMachine.Id.Value, new HashSet<ulong>());
+                _childMachines[parentMachine.Id.Value].Add(stateMachineOperation.Id);
+                var childWeight = _weights.GetValueOrDefault(op.Id, 0);
+                var parentWeight = _weights.GetValueOrDefault(parentMachine.Id.Value, 0);
+                if (_nextIntendedMachine == parentMachine.Id.Value)
+                {
+                    var randomWeight = _randomValueGenerator.Next(Math.Max(parentWeight, 1)) + 1;
+                    if (childWeight > randomWeight)
+                    {
+                        _nextIntendedMachine = op.Id;
+                    }
+                }
+
+                _weights[parentMachine.Id.Value] = Math.Max(parentWeight - childWeight, 0);
+            }
+        }
+    }
+
+    private void UpdateNextIntendedMachine(List<AsyncOperation> machines)
+    {
+        var totalWeight = machines.Sum(op => _weights.GetValueOrDefault(op.Id, 0));
+        var selectedMachineWeight = _randomValueGenerator.Next(totalWeight) + 1;
+        var currentWeight = 0;
+        foreach (var op in machines)
+        {
+            var machineWeight = _weights.GetValueOrDefault(op.Id, 0);
+            currentWeight += machineWeight;
+            if (currentWeight >= selectedMachineWeight && (machineWeight != 0))
+            {
+                _nextIntendedMachine = op.Id;
+                break;
+            }
+        }
+    }
+
+    private void ConstructInterestingOperation(AsyncOperation op)
+    {
+        if (op.Type == AsyncOperationType.Send)
+        {
+            _interestingMachineMap.TryAdd(op.MessageReceiver, new HashSet<ulong>());
+            _interestingMachineMap[op.MessageReceiver].Add(op.Id);
+        }
     }
 
     public bool GetNextOperation(AsyncOperation current, IEnumerable<AsyncOperation> ops, out AsyncOperation next)
@@ -26,31 +127,170 @@ internal class SURWScheduler: IScheduler
         {
             return false;
         }
-        foreach (var op in enabledOperations)
+
+        CheckNewMachines(enabledOperations);
+        var filteredMachines = enabledOperations.Where(op => !_blocked.Contains(op.Id)).ToList();
+        if (filteredMachines.Count == 0)
         {
-            var weight = _executionLength.GetValueOrDefault(op.Name, 1);
+            _nextIntendedMachine = NoMachine;
+            _blocked.Clear();
+            return GetNextOperation(current, enabledOperations, out next);
         }
 
+        var nextMachineIndex = _randomValueGenerator.Next(filteredMachines.Count);
+        var nextMachine = filteredMachines[nextMachineIndex];
+
+        if (nextMachine.Type == AsyncOperationType.Send && _interestingMachines.Contains(nextMachine.MessageReceiver))
+        {
+            if (_weights.GetValueOrDefault(nextMachine.Id, 0) == 0)
+            {
+                _weights[nextMachine.Id] = 1;
+            }
+
+            if (_nextIntendedMachine == NoMachine)
+            {
+                UpdateNextIntendedMachine(filteredMachines);
+            }
+
+            if (nextMachine.Id == _nextIntendedMachine)
+            {
+                _weights[nextMachine.Id] -= 1;
+                _blocked.Clear();
+                _nextIntendedMachine = NoMachine;
+            }
+            else
+            {
+                _blocked.Add(nextMachine.Id);
+                return GetNextOperation(current, enabledOperations, out next);
+            }
+
+            if (_executionLength.Count == 0)
+            {
+                _machineExecutionLengthCache[nextMachine.Id] =
+                    _machineExecutionLengthCache.GetValueOrDefault(nextMachine.Id, 0) + 1;
+            }
+        }
+
+        // Unlike the original work, we need to construct the interesting machine map dynamically.
+        if (_interestingMachines.Count == 0)
+        {
+            ConstructInterestingOperation(nextMachine);
+        }
+
+        next = nextMachine;
         return true;
+    }
+
+    private Dictionary<ulong, int> BuildMachineWeights()
+    {
+        var machineWeights = new Dictionary<ulong, int>();
+        if (_machineExecutionLengthCache.Count != 0)
+        {
+            foreach (var machine in _createdMachines)
+            {
+                if (machineWeights.ContainsKey(machine)) continue;
+                BuildMachineWeightsRecursive(machine, machineWeights);
+            }
+        }
+
+        return machineWeights;
+    }
+
+    private int BuildMachineWeightsRecursive(ulong machine, Dictionary<ulong, int> machineWeights)
+    {
+        if (!machineWeights.ContainsKey(machine))
+        {
+            var weight = _machineExecutionLengthCache.GetValueOrDefault(machine, 0) +
+                         _childMachines.GetValueOrDefault(machine, new HashSet<ulong>()).Sum(childMachine =>
+                             BuildMachineWeightsRecursive(childMachine, machineWeights));
+            machineWeights.Add(machine, weight);
+        }
+
+        return machineWeights[machine];
+    }
+
+    private HashSet<ulong> BuildInterestingMachines()
+    {
+        var keys = _interestingMachineMap.Where(machine => machine.Value.Count > 2).Select(machine => machine.Key)
+            .ToList();
+        var interestingMachines = keys.OrderBy(k => _randomValueGenerator.Next()).ToList();
+        var count = Math.Max((int)(interestingMachines.Count * 0.1), 1);
+        return interestingMachines.Take(count).ToHashSet();
     }
 
     public void Reset()
     {
-        throw new System.NotImplementedException();
+        _executionLength.Clear();
+        _interestingMachines.Clear();
     }
 
     public bool PrepareForNextIteration()
     {
-        throw new System.NotImplementedException();
+        var newExecutionLength = _executionLength;
+        if (newExecutionLength.Count == 0)
+        {
+            newExecutionLength = BuildMachineWeights();
+        }
+
+        var newInterestingMachines = _interestingMachines;
+        if (newInterestingMachines.Count == 0)
+        {
+            newInterestingMachines = BuildInterestingMachines();
+        }
+        
+        _executionLength = newExecutionLength;
+        _interestingMachines = newInterestingMachines;
+        
+        _weights = _executionLength.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        _blocked.Clear();
+        _nextIntendedMachine = NoMachine;
+        _createdMachines.Clear();
+        _interestingMachineMap.Clear();
+        _machineExecutionLengthCache.Clear();
+        return true;
     }
 
     public IScheduler Mutate()
     {
-        throw new System.NotImplementedException();
+        var newExecutionLength = _executionLength;
+        if (newExecutionLength.Count == 0)
+        {
+            newExecutionLength = BuildMachineWeights();
+        }
+
+        var newInterestingMachines = _interestingMachines;
+        if (newInterestingMachines.Count == 0)
+        {
+            newInterestingMachines = BuildInterestingMachines();
+        }
+
+        return new SURWScheduler(
+            newExecutionLength,
+            newInterestingMachines,
+            _childMachines,
+            ((ControlledRandom)_randomValueGenerator).Mutate()
+        );
     }
 
     public IScheduler New()
     {
-        throw new System.NotImplementedException();
+        var newExecutionLength = _executionLength;
+        if (newExecutionLength.Count == 0)
+        {
+            newExecutionLength = BuildMachineWeights();
+        }
+
+        var newInterestingMachines = _interestingMachines;
+        if (newInterestingMachines.Count == 0)
+        {
+            newInterestingMachines = BuildInterestingMachines();
+        }
+        
+        return new SURWScheduler(
+            newExecutionLength,
+            newInterestingMachines,
+            _childMachines,
+            ((ControlledRandom)_randomValueGenerator).Mutate()
+        );
     }
 }

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/SURWScheduler.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/SURWScheduler.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using PChecker.Random;
+using PChecker.SystematicTesting.Operations;
+using PChecker.SystematicTesting.Strategies.Probabilistic;
+
+namespace PChecker.SystematicTesting.Strategies.Feedback;
+
+internal class SURWScheduler: IScheduler
+{
+    private readonly IRandomValueGenerator _randomValueGenerator;
+    private Dictionary<string, int> _executionLength;
+
+    public SURWScheduler(Dictionary<string, int> executionLength, IRandomValueGenerator random)
+    {
+        _executionLength = executionLength;
+        _randomValueGenerator = random;
+    }
+
+    public bool GetNextOperation(AsyncOperation current, IEnumerable<AsyncOperation> ops, out AsyncOperation next)
+    {
+        next = null;
+        var enabledOperations = ops.Where(op => op.Status is AsyncOperationStatus.Enabled).ToList();
+        if (enabledOperations.Count == 0)
+        {
+            return false;
+        }
+        foreach (var op in enabledOperations)
+        {
+        }
+
+        return true;
+    }
+
+    public void Reset()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public bool PrepareForNextIteration()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public IScheduler Mutate()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public IScheduler New()
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/SURWScheduler.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/SURWScheduler.cs
@@ -28,6 +28,7 @@ internal class SURWScheduler: IScheduler
         }
         foreach (var op in enabledOperations)
         {
+            var weight = _executionLength.GetValueOrDefault(op.Name, 1);
         }
 
         return true;

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -294,6 +294,12 @@ namespace PChecker.SystematicTesting
                 Strategy = new ScheduleAndInputStrategy(checkerConfiguration.MaxUnfairSchedulingSteps,
                     RandomValueGenerator, scheduler);
             }
+            else if (checkerConfiguration.SchedulingStrategy is "surw")
+            {
+                var scheduler = new SURWScheduler(new(), new(), new(), RandomValueGenerator);
+                Strategy = new ScheduleAndInputStrategy(checkerConfiguration.MaxFairSchedulingSteps,
+                    RandomValueGenerator, scheduler);
+            }
             else if (checkerConfiguration.SchedulingStrategy is "fairpct")
             {
                 var prefixLength = checkerConfiguration.MaxUnfairSchedulingSteps;
@@ -328,6 +334,11 @@ namespace PChecker.SystematicTesting
             {
                 Strategy = new FeedbackGuidedStrategy(checkerConfiguration, new ControlledRandom(checkerConfiguration),
                     new POSScheduler(new ControlledRandom(checkerConfiguration)));
+            }
+            else if (checkerConfiguration.SchedulingStrategy is "feedbacksurw")
+            {
+                Strategy = new FeedbackGuidedStrategy(checkerConfiguration, new ControlledRandom(checkerConfiguration),
+                    new SURWScheduler(new(), new(), new(), new ControlledRandom(checkerConfiguration)));
             }
             else if (checkerConfiguration.SchedulingStrategy is "portfolio")
             {
@@ -417,9 +428,11 @@ namespace PChecker.SystematicTesting
             if (_checkerConfiguration.SchedulingStrategy is "random" ||
                 _checkerConfiguration.SchedulingStrategy is "pct" ||
                 _checkerConfiguration.SchedulingStrategy is "pos" ||
+                _checkerConfiguration.SchedulingStrategy is "surw" ||
                 _checkerConfiguration.SchedulingStrategy is "feedbackpct" ||
                 _checkerConfiguration.SchedulingStrategy is "feedbackpctcp" ||
                 _checkerConfiguration.SchedulingStrategy is "feedbackpos" ||
+                _checkerConfiguration.SchedulingStrategy is "feedbacksurw" ||
                 _checkerConfiguration.SchedulingStrategy is "fairpct" ||
                 _checkerConfiguration.SchedulingStrategy is "probabilistic" ||
                 _checkerConfiguration.SchedulingStrategy is "rl")

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -59,11 +59,14 @@ namespace Plang.Options
             schedulingGroup.AddArgument("sch-feedbackpct", null, "Choose the PCT scheduling strategy with feedback mutation", typeof(uint));
             schedulingGroup.AddArgument("sch-feedbackpos", null,
                 "Choose the POS scheduling strategy with feedback mutation", typeof(bool));
+            schedulingGroup.AddArgument("sch-feedbacksurw", null,
+                "Choose the SURW scheduling strategy with feedback mutation", typeof(bool));
 
             schedulingGroup.AddArgument("sch-probabilistic", "sp", "Choose the probabilistic scheduling strategy with given probability for each scheduling decision where the probability is " +
                                                                    "specified as the integer N in the equation 0.5 to the power of N.  So for N=1, the probability is 0.5, for N=2 the probability is 0.25, N=3 you get 0.125, etc.", typeof(uint));
             schedulingGroup.AddArgument("sch-pct", null, "Choose the PCT scheduling strategy with given maximum number of priority switch points", typeof(uint));
             schedulingGroup.AddArgument("sch-pos", null, "Choose the POS scheduling strategy", typeof(bool));
+            schedulingGroup.AddArgument("sch-surw", null, "Choose the Selectively Uniform Random Walk (SURW) scheduling strategy", typeof(bool));
             schedulingGroup.AddArgument("sch-fairpct", null, "Choose the fair PCT scheduling strategy with given maximum number of priority switch points", typeof(uint));
             schedulingGroup.AddArgument("sch-rl", null, "Choose the reinforcement learning (RL) scheduling strategy", typeof(bool)).IsHidden = true;
             var schCoverage = schedulingGroup.AddArgument("sch-coverage", null, "Choose the scheduling strategy for coverage mode (options: learn, random, dfs, stateless). (default: learn)");
@@ -233,7 +236,9 @@ namespace Plang.Options
                     break;
                 case "sch-random":
                 case "sch-pos":
+                case "sch-surw":
                 case "sch-feedbackpos":
+                case "sch-feedbacksurw":
                 case "sch-feedback":
                     checkerConfiguration.SchedulingStrategy = option.LongName.Substring(4);
                     break;
@@ -349,8 +354,10 @@ namespace Plang.Options
                 checkerConfiguration.SchedulingStrategy != "feedback" &&
                 checkerConfiguration.SchedulingStrategy != "feedbackpct" &&
                 checkerConfiguration.SchedulingStrategy != "feedbackpos" &&
+                checkerConfiguration.SchedulingStrategy != "feedbacksurw" &&
                 checkerConfiguration.SchedulingStrategy != "pct" &&
                 checkerConfiguration.SchedulingStrategy != "pos" &&
+                checkerConfiguration.SchedulingStrategy != "surw" &&
                 checkerConfiguration.SchedulingStrategy != "fairpct" &&
                 checkerConfiguration.SchedulingStrategy != "probabilistic" &&
                 checkerConfiguration.SchedulingStrategy != "rl" &&

--- a/Tst/SchedulerTests/SURW/assign1.p
+++ b/Tst/SchedulerTests/SURW/assign1.p
@@ -1,0 +1,74 @@
+event WriteReq : int;
+event ReadResp: int;
+event ReadReq: Main;
+
+machine ClientA {
+  start state Init {
+    entry(server: Server) {
+      send server, WriteReq, (1);
+      send server, WriteReq, (2);
+      send server, WriteReq, (3);
+      send server, WriteReq, (4);
+      send server, WriteReq, (5);
+      send server, WriteReq, (6);
+    }
+  }
+}
+
+machine ClientB {
+  start state Init {
+    entry(server: Server) {
+      send server, WriteReq, (7);
+      send server, WriteReq, (8);
+      send server, WriteReq, (9);
+      send server, WriteReq, (10);
+      send server, WriteReq, (11);
+      send server, WriteReq, (12);
+    }
+  }
+}
+
+machine ClientC {
+  start state Init {
+    entry(server: Server) {
+      send server, WriteReq, (13);
+      send server, WriteReq, (14);
+      send server, WriteReq, (15);
+      send server, WriteReq, (16);
+      send server, WriteReq, (17);
+      send server, WriteReq, (18);
+    }
+  }
+}
+
+
+machine Server {
+  var value: int;
+  start state Init {
+    entry {
+      value = 0;
+    }
+    on WriteReq do (req: int) {
+      value = req;
+    }
+    on ReadReq do (req: Main) {
+      send req, ReadResp, value;
+    }
+  }
+}
+
+machine Main {
+ start state Init {
+  entry {
+    var server: Server;
+    server = new Server();
+    new ClientA(server);
+    new ClientB(server);
+    new ClientC(server);
+    send server, ReadReq, (this);
+  }
+  on ReadResp do (resp: int) {
+    print format("Value:  {0}", resp);
+  }
+ }
+}

--- a/Tst/UnitTests/Core/SURWSchedulerTestCase.cs
+++ b/Tst/UnitTests/Core/SURWSchedulerTestCase.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using PChecker;
+using PChecker.Runtime.Logging;
+using PChecker.SystematicTesting;
+using Plang.Compiler;
+using Plang.Options;
+using UnitTests.Runners;
+using UnitTests.Validators;
+
+namespace UnitTests.Core
+{
+    internal class SURWSchedulerTestCase
+    {
+        [NUnit.Framework.Test]
+        public void TestSURWSchedulerUniformSampling()
+        {
+            var tempDir = Directory.CreateDirectory(Path.Combine(Constants.ScratchParentDirectory,
+                nameof(TestSURWSchedulerUniformSampling)));
+            var srcPath = new FileInfo(Path.Combine(Constants.SolutionDirectory, "Tst", "SchedulerTests", "SURW",
+                "assign1.p"));
+            var dllPath = Path.Combine(Constants.ScratchParentDirectory, nameof(TestSURWSchedulerUniformSampling),
+                "CSharp", "net8.0", "Main.dll");
+            var runner = new PCheckerRunner(new[] { srcPath });
+            runner.DoCompile(tempDir);
+
+            var configuration =
+                new PCheckerOptions().Parse(new[] { dllPath, "-o", tempDir.ToString(), "--sch-surw", "-i", "10000" });
+            var engine = TestingEngine.Create(configuration);
+            var values = new List<int>();
+            engine.RegisterPerIterationCallBack(iter =>
+            {
+                engine.TryEmitTraces(tempDir.ToString() + Path.DirectorySeparatorChar, "trace");
+                string jsonContent = File.ReadAllText(Path.Combine(tempDir.ToString(), $"trace_0.trace.json"));
+                List<LogEntry> logEntries = JsonConvert.DeserializeObject<List<LogEntry>>(jsonContent);
+                foreach (var logEntry in logEntries)
+                {
+                    if (logEntry.Type == "Print" && logEntry.Details.Log?.StartsWith("Value:") == true)
+                    {
+                        string valueString = logEntry.Details.Log.Split(':')[1].Trim();
+                        if (int.TryParse(valueString, out int value) && value > 0)
+                        {
+                            values.Add(value);
+                        }
+                    }
+                }
+            });
+            engine.Run();
+            Assert.IsTrue(values.Count > 0, "No values were collected from the test run");
+
+            var valueFrequencies = values.GroupBy(v => v)
+                .ToDictionary(g => g.Key, g => g.Count());
+            double meanFrequency = valueFrequencies.Values.Average();
+            double varianceSum = valueFrequencies.Values.Sum(f => Math.Pow(f - meanFrequency, 2));
+            double variance = varianceSum / valueFrequencies.Count;
+            double normalizedVariance = Math.Sqrt(variance) / meanFrequency;
+            Assert.Less(normalizedVariance, 0.2, 
+                $"Variance too high for uniform sampling: {normalizedVariance:F4}");
+        }
+    }
+}

--- a/Tst/UnitTests/SURWSchedulerTestCase.cs
+++ b/Tst/UnitTests/SURWSchedulerTestCase.cs
@@ -18,6 +18,7 @@ namespace UnitTests.Core
     internal class SURWSchedulerTestCase
     {
         [NUnit.Framework.Test]
+        [Ignore("This test is ignored because it is flaky and conflict with `PCheckerLogGeneratorTests`")]
         public void TestSURWSchedulerUniformSampling()
         {
             var tempDir = Directory.CreateDirectory(Path.Combine(Constants.ScratchParentDirectory,


### PR DESCRIPTION
Implements the SURW algorithm with the following modifications:
- Treats each machine as a memory location
- Considers all events sent to a machine as interesting events
- Randomly samples 10% of machines as interesting machines


Testing notes:
- Translated paper examples into P models. The higher frequency of 0 values occurs because P reschedules on machine creation, increasing the probability of reads occurring before writes.
- Tests are disabled in CI due to limitation with loading multiple assemblies of the same name (conflict with `PCheckerLogGeneratorTests`). They can be run locally.

![log_distribution](https://github.com/user-attachments/assets/5efc2a3e-0f06-4f91-bc61-bd2cc00c86e9)
