### PR TITLE
[PEx] Disable support for receive statement inside loop

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
@@ -108,7 +108,7 @@ internal class PExCodeGenerator : ICodeGenerator
 
         //context.WriteLine(source.Stream);
 
-        IEnumerable<IPDecl> decls = TransformASTPass.GetTransformedDecls(globalScope);
+        IEnumerable<IPDecl> decls = TransformASTPass.GetTransformedDecls(context, globalScope);
         //IEnumerable<IPDecl> decls = globalScope.AllDecls;
 
         var hasSafetyTest = false;

--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -64,7 +66,18 @@ namespace Plang.Compiler
                 job.Output.WriteInfo($"Code generation for {entry}...");
 
                 // Run the selected backend on the project and write the files.
-                var compiledFiles = job.Backend.GenerateCode(job, scope);
+                IEnumerable<CompiledFile> compiledFiles;
+                try
+                {
+                    compiledFiles = job.Backend.GenerateCode(job, scope);
+                }
+                catch (NotImplementedException e)
+                {
+                    job.Output.WriteError("[NotImplementedError:]\n" + e.Message);
+                    Environment.ExitCode = 1;
+                    return Environment.ExitCode;
+                }
+                
                 foreach (var file in compiledFiles)
                 {
                     job.Output.WriteInfo($"Generated {file.FileName}.");

--- a/Src/PRuntimes/PExRuntime/src/test/java/pex/TestPEx.java
+++ b/Src/PRuntimes/PExRuntime/src/test/java/pex/TestPEx.java
@@ -52,6 +52,16 @@ public class TestPEx {
 
     private static void createExcludeList() {
         /**
+         * TODO: Receive statement inside a loop
+         */
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/pingPongReceive4");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/DynamicError/pingPongReceive5");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/Correct/receive19");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/Correct/pingPongReceive4");
+        excluded.add("../../../Tst/RegressionTests/Feature2Stmts/Correct/pingPongReceive5");
+        excluded.add("../../../Tst/RegressionTests/Integration/Correct/pingPongReceive3");
+
+        /**
          * TODO: Null events
          */
         // TODO: Null events are not supported


### PR DESCRIPTION
Updates include:

[PEx IR]
- Throw compile-time exception for receive statement inside loop with appropriate message

[PEx RT]
- Exclude tests with receive inside loop

[PCompiler]
- Adds try/catch to gracefully report not-supported errors during compiling for PEx
