### PR TITLE
Change p compiler to return a syntax error for lexical errors

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/Java/MachineGenerator.cs
@@ -117,6 +117,9 @@ namespace Plang.Compiler.Backend.Java {
             {
                 WriteFunction(f);
             }
+
+            WriteToString();
+            
             WriteLine();
 
             WriteLine($"}} // {cname} monitor definition");
@@ -964,5 +967,21 @@ namespace Plang.Compiler.Backend.Java {
             }
         }
 
+        private void WriteToString()
+        {
+            WriteLine("public String toString() {");
+            WriteLine($"StringBuilder sb = new StringBuilder(\"{_currentMachine.Name}\");");
+            
+            WriteLine("sb.append(\"[\");");
+            foreach (var (sep, field) in _currentMachine.Fields.WithPrefixSep(", "))
+            {
+                WriteLine($"sb.append(\"{sep}{field.Name}=\" + {Names.GetNameForDecl(field)});");
+            }
+            WriteLine("sb.append(\"]\");");
+            
+            WriteLine("return sb.toString();");
+            WriteLine("} // toString()");
+        }
+        
     }
 }

--- a/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError1/LexerError1.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError1/LexerError1.p
@@ -1,0 +1,1 @@
+type ListUsersPayload = (_: any?);

--- a/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError2/LexerError2.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError2/LexerError2.p
@@ -1,0 +1,2 @@
+machine Name@@?@ {
+}


### PR DESCRIPTION
Previously, the p compiler was silently skipping over unexpected characters encountered during lexical analysis.  Added a listener on the lexer to raise an error when lexical analysis encounters an error.

Added unit tests to verify this behavior.