### PR TITLE
Change p compiler to return a syntax error for lexical errors

### DIFF
--- a/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError1/LexerError1.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError1/LexerError1.p
@@ -1,0 +1,1 @@
+type ListUsersPayload = (_: any?);

--- a/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError2/LexerError2.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/StaticError/LexerError2/LexerError2.p
@@ -1,0 +1,2 @@
+machine Name@@?@ {
+}


### PR DESCRIPTION
Previously, the p compiler was silently skipping over unexpected characters encountered during lexical analysis.  Added a listener on the lexer to raise an error when lexical analysis encounters an error.

Added unit tests to verify this behavior.