### PR TITLE
[feature] Checking individual proof blocks via `-pb`

### DIFF
--- a/.github/workflows/macosci.yml
+++ b/.github/workflows/macosci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ubuntuci.yml
+++ b/.github/workflows/ubuntuci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/Src/PCompiler/CompilerCore/Backend/PVerifier/Uclid5CodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PVerifier/Uclid5CodeGenerator.cs
@@ -324,7 +324,8 @@ public class PVerifierCodeGenerator : ICodeGenerator
         else
         {
             // otherwise, go through all the proof commands (or ones that are specified in the compiler config)
-            bool emitCode (ProofCommand cmd) => job.TargetProofBlocks.Count == 0 || job.TargetProofBlocks.Contains(cmd.ProofBlock);
+            bool emitCode (ProofCommand cmd) => job.TargetProofBlocks.Count == 0 ||
+                                                    (cmd.ProofBlock != null && job.TargetProofBlocks.Contains(cmd.ProofBlock));
             foreach (var pbname in job.TargetProofBlocks)
             {
                 if (!globalScope.Get(pbname, out ProofBlock pb))

--- a/Src/PCompiler/CompilerCore/Backend/PVerifier/Uclid5CodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PVerifier/Uclid5CodeGenerator.cs
@@ -323,8 +323,16 @@ public class PVerifierCodeGenerator : ICodeGenerator
         }
         else
         {
-            // otherwise, go through all the proof commands 
-            foreach (var proofCmd in globalScope.ProofCommands)
+            // otherwise, go through all the proof commands (or ones that are specified in the compiler config)
+            bool emitCode (ProofCommand cmd) => job.TargetProofBlocks.Count == 0 || job.TargetProofBlocks.Contains(cmd.ProofBlock);
+            foreach (var pbname in job.TargetProofBlocks)
+            {
+                if (!globalScope.Get(pbname, out ProofBlock pb))
+                {
+                    job.Output.WriteWarning($"Warning: proof block {pbname} not found. Skipping ...");
+                }
+            }
+            foreach (var proofCmd in globalScope.ProofCommands.Where(emitCode))
             {
                 // if one of them is the default, rename it to default so that we can generate the init, next, and invs in compileToFile
                 // TODO: ensure that default can only happen on its own?
@@ -1127,6 +1135,8 @@ public class PVerifierCodeGenerator : ICodeGenerator
             $"define {InvariantPrefix}Received_Subset_Sent(): boolean = forall (a: {LabelAdt}) :: {StateAdtSelectReceived(StateVar)}[a] ==> {StateAdtSelectSent(StateVar)}[a];");
         EmitLine($"invariant _{InvariantPrefix}Received_Subset_Sent: {InvariantPrefix}Received_Subset_Sent();");
         EmitLine("");
+        GenerateOptionTypes();
+        EmitLine("");
 
         if (cmd.Name == "default")
         {
@@ -1162,7 +1172,6 @@ public class PVerifierCodeGenerator : ICodeGenerator
             EmitLine("");
 
             // These have to be done at the end because we don't know what we need until we generate the rest of the code
-            GenerateOptionTypes();
             EmitLine("");
             GenerateCheckerVars();
             EmitLine("");

--- a/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/CompilerConfiguration.cs
@@ -26,6 +26,7 @@ namespace Plang.Compiler
             Debug = false;
             Timeout = 600;
             CheckOnly = null;
+            TargetProofBlocks = new List<string>();
             Parallelism = Math.Max(Environment.ProcessorCount / 2, 1);
         }
         public CompilerConfiguration(ICompilerOutput output, DirectoryInfo outputDir, IList<CompilerOutput> outputLanguages, IList<string> inputFiles,
@@ -78,6 +79,7 @@ namespace Plang.Compiler
         public bool Debug { get; set; }
         public int Timeout { get; set; }
         public string CheckOnly { get; set; }
+        public IList<string> TargetProofBlocks { get; set; }
         public int Parallelism { get; set; }
 
         public void Copy(CompilerConfiguration parsedConfig)

--- a/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
+++ b/Src/PCompiler/CompilerCore/ICompilerConfiguration.cs
@@ -22,6 +22,7 @@ namespace Plang.Compiler
         bool Debug { get; }
         int Timeout { get; }
         string CheckOnly { get; }
+        IList<string> TargetProofBlocks { get; }
         int Parallelism { get; }
     }
 }

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -72,7 +72,7 @@ invariantGroupDecl : LEMMA name=iden LBRACE invariantDecl* RBRACE
                 |    THEOREM name=iden LBRACE invariantDecl* RBRACE
                 ;
 
-proofBlockDecl : PROOF LBRACE proofBody RBRACE ;
+proofBlockDecl : PROOF (name=iden)? LBRACE proofBody RBRACE # ProofBlock ;
 proofBody : proofItem* ;
 proofItem : PROVE (targets+=expr (COMMA targets+=expr)* | goalsAll=MUL | goalsDefault=DEFAULT) (USING ((premises+=expr (COMMA premises+=expr)*) | premisesAll=MUL))? (EXCEPT excludes+=expr (COMMA excludes+=expr)*)? SEMI # ProveUsingCmd ; 
 

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofBlock.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofBlock.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Antlr4.Runtime;
+
+namespace Plang.Compiler.TypeChecker.AST.Declarations
+{
+    public class ProofBlock : IPDecl
+    {
+        public ProofBlock(string name, ParserRuleContext sourceNode)
+        {
+            Debug.Assert(sourceNode is PParser.ProofBlockContext);
+            SourceLocation = sourceNode;
+            Name = name;
+        }
+        public ParserRuleContext SourceLocation { get; }
+        public List<ProofCommand> Commands { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/ProofCommand.cs
@@ -18,5 +18,6 @@ namespace Plang.Compiler.TypeChecker.AST.Declarations
         public List<Invariant> Excepts { get; set; }
         public ParserRuleContext SourceLocation { get; }
         public string Name { get; set; }
+        public string ProofBlock { get; set; }
     }
 }

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
@@ -58,6 +58,16 @@ namespace Plang.Compiler.TypeChecker
             return null;
         }
 
+        public override object VisitProofBlock(PParser.ProofBlockContext context)
+        {
+
+            var name = context.name == null ? $"ProofBlock_{CurrentScope.ProofBlocks.Count()}" : context.name.GetText();
+            var decl = CurrentScope.Put(name, context);
+            nodesToDeclarations.Put(context, decl);
+            context.proofBody().proofItem().Select(Visit).ToList();
+            return null;
+        }
+
         public override object VisitProveUsingCmd(PParser.ProveUsingCmdContext context)
         {
             var name = string.Join(", ", context._targets.Select(t => t.GetText()));

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -712,6 +712,14 @@ namespace Plang.Compiler.TypeChecker
             return [inv];
         }
 
+        public override object VisitProofBlock(PParser.ProofBlockContext context)
+        {
+            var proofBlock = (ProofBlock) nodesToDeclarations.Get(context);
+            proofBlock.Commands = context.proofBody().proofItem().Select(Visit).Cast<ProofCommand>().ToList();
+            proofBlock.Commands.ForEach(x => x.ProofBlock = proofBlock.Name);
+            return proofBlock;
+        }
+
         public override object VisitProveUsingCmd(PParser.ProveUsingCmdContext context)
         {
             var proofCmd = (ProofCommand) nodesToDeclarations.Get(context);

--- a/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
@@ -26,6 +26,7 @@ namespace Plang.Compiler.TypeChecker
         private readonly IDictionary<string, Invariant> invariants = new Dictionary<string, Invariant>();
         private readonly IDictionary<string, Axiom> axioms = new Dictionary<string, Axiom>();
         private readonly List<(string, ProofCommand)> proofCommands = new List<(string, ProofCommand)>();
+        private readonly IDictionary<string, ProofBlock> proofBlocks = new Dictionary<string, ProofBlock>();
         private readonly IDictionary<string, InvariantGroup> invariantGroups = new Dictionary<string, InvariantGroup>();
         private readonly IDictionary<string, AssumeOnStart> assumeOnStarts = new Dictionary<string, AssumeOnStart>();
         private readonly ICompilerConfiguration config;
@@ -95,6 +96,7 @@ namespace Plang.Compiler.TypeChecker
         public IEnumerable<RefinementTest> RefinementTests => refinementTests.Values;
         public IEnumerable<Implementation> Implementations => implementations.Values;
         public IEnumerable<NamedModule> NamedModules => namedModules.Values;
+        public IEnumerable<ProofBlock> ProofBlocks => proofBlocks.Values;
         public IEnumerable<ProofCommand> ProofCommands => proofCommands.Select(p => p.Item2);
         public IEnumerable<InvariantGroup> InvariantGroups => invariantGroups.Values;
 
@@ -190,6 +192,11 @@ namespace Plang.Compiler.TypeChecker
         public bool Get(string name, out Axiom tree)
         {
             return axioms.TryGetValue(name, out tree);
+        }
+
+        public bool Get(string name, out ProofBlock pb)
+        {
+            return proofBlocks.TryGetValue(name, out pb);
         }
 
         public bool Get(string name, out ProofCommand tree)
@@ -728,6 +735,14 @@ namespace Plang.Compiler.TypeChecker
             var proofCommand = new ProofCommand(name, tree);
             proofCommands.Add((name, proofCommand));
             return proofCommand;
+        }
+
+        public ProofBlock Put(string name, PParser.ProofBlockContext tree)
+        {
+            var proofBlock = new ProofBlock(name, tree);
+            CheckConflicts(proofBlock, Namespace(proofBlocks));
+            proofBlocks.Add(name, proofBlock);
+            return proofBlock;
         }
         
         public AssumeOnStart Put(string name, PParser.AssumeOnStartDeclContext tree)

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -46,12 +46,13 @@ namespace Plang.Options
 
             Parser.AddArgument("debug", "d", "Enable debug logs", typeof(bool)).IsHidden = true;
             
-            Parser.AddArgument("timeout", "t", "Set SMT solver timeout in seconds", typeof(int)).IsHidden = true;
+            var pvGroup = Parser.GetOrCreateGroup("pverifier", "PVerifier options");
+            pvGroup.AddArgument("timeout", "t", "Set SMT solver timeout in seconds", typeof(int)).IsHidden = true;
             
-            Parser.AddArgument("no-event-handler-checks", "nch", "Do not check that all events are handled", typeof(bool)).IsHidden = true;
-            Parser.AddArgument("proof-blocks", "pb", "List of proof blocks to check").IsMultiValue = true;
-            Parser.AddArgument("check-only", "co", "Check only the specified machine", typeof(string)).IsHidden = true;
-            Parser.AddArgument("jobs", "j", "Number of parallel processes to use", typeof(int)).IsHidden = true;
+            pvGroup.AddArgument("no-event-handler-checks", "nch", "Do not check that all events are handled", typeof(bool)).IsHidden = true;
+            pvGroup.AddArgument("proof-blocks", "pb", "List of proof blocks to check").IsMultiValue = true;
+            pvGroup.AddArgument("check-only", "co", "Check only the specified machine", typeof(string)).IsHidden = true;
+            pvGroup.AddArgument("jobs", "j", "Number of parallel processes to use", typeof(int)).IsHidden = true;
         }
 
         /// <summary>
@@ -208,7 +209,7 @@ namespace Plang.Options
                     break;
                 case "proof-blocks":
                 {
-                    var proofBlocks = ((string)option.Value).Split(' ');
+                    var proofBlocks = (string[])option.Value;
                     foreach (var block in proofBlocks.Distinct())
                     {
                         compilerConfiguration.TargetProofBlocks.Add(block);

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -49,6 +49,7 @@ namespace Plang.Options
             Parser.AddArgument("timeout", "t", "Set SMT solver timeout in seconds", typeof(int)).IsHidden = true;
             
             Parser.AddArgument("no-event-handler-checks", "nch", "Do not check that all events are handled", typeof(bool)).IsHidden = true;
+            Parser.AddArgument("proof-blocks", "pb", "List of proof blocks to check").IsMultiValue = true;
             Parser.AddArgument("check-only", "co", "Check only the specified machine", typeof(string)).IsHidden = true;
             Parser.AddArgument("jobs", "j", "Number of parallel processes to use", typeof(int)).IsHidden = true;
         }
@@ -205,6 +206,15 @@ namespace Plang.Options
                 case "pobserve-package":
                     compilerConfiguration.PObservePackageName = (string)option.Value;
                     break;
+                case "proof-blocks":
+                {
+                    var proofBlocks = ((string)option.Value).Split(' ');
+                    foreach (var block in proofBlocks.Distinct())
+                    {
+                        compilerConfiguration.TargetProofBlocks.Add(block);
+                    }
+                    break;
+                }
                 case "pfiles":
                 {
                     var files = (string[])option.Value;

--- a/Tutorial/Advanced/2_TwoPhaseCommitVerification/Single/PSrc/System.p
+++ b/Tutorial/Advanced/2_TwoPhaseCommitVerification/Single/PSrc/System.p
@@ -118,9 +118,12 @@ Lemma kondo {
     invariant  a6: coordinator() is Committed ==> (forall (p: Participant) :: p in participants() ==> preference(p));
 }
 
-Proof {
+Proof system_configs {
     prove system_config;
+    prove default using system_config;
+}
+
+Proof kondo_proof {
     prove kondo using system_config;
     prove safety using kondo, system_config_participant_set;
-    prove default using system_config;
 }


### PR DESCRIPTION
This PR adds the support of *named proof blocks*.
For instance (snippet from 2PC proof from Tutorial):
```
Proof system_configs {
    prove system_config;
    prove default using system_config;
}

Proof kondo_proof {
    prove kondo using system_config;
    prove safety using kondo, system_config_participant_set;
}
```
Now, we can run PVerifier with `p compile -pb system_configs`, which will only emit UCLID queries for proof commands in `system_configs`.