### PR TITLE
[FIX] Add sanity check to default

### DIFF
--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/Invariant.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/Invariant.cs
@@ -21,7 +21,7 @@ namespace Plang.Compiler.TypeChecker.AST.Declarations
         {
             SourceLocation = sourceNode;
             IsDefault = true;
-            Name = "defualt";
+            Name = "default";
         }
         
         public IPExpr Body { get; set; }


### PR DESCRIPTION
1. Add sanity checks (received is a subset of sent) as preconditions to each procedure.
2. Extend `default` with sanity checks.
3. Fix the missing remaining invariants (`LEMMA`) when `prove default using LEMMA`
4. Update received buffer after inlined procedure.