### PR TITLE
Expand installation instructions for PVerifier on Amazon Linux 2

### DIFF
--- a/Docs/docs/advanced/PVerifierLanguageExtensions/install-pverifier.md
+++ b/Docs/docs/advanced/PVerifierLanguageExtensions/install-pverifier.md
@@ -9,8 +9,8 @@ PVerifier requires several dependencies to be installed. Follow the steps below 
 
 ```sh
 sudo rpm --import https://yum.corretto.aws/corretto.key
-sudo curl -L-o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo 
-sudo yum install java-11-amazon-corretto-devel
+sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+sudo yum install java-11-amazon-corretto-devel maven
 ```
 
 ??? hint "Troubleshoot: Confirm that java is correctly installed on your machine."
@@ -31,26 +31,50 @@ sudo yum install sbt
 
 ??? hint "Troubleshoot: Confirm that sbt is correctly installed on your machine."
     ```shell
-    sbt sbtVersion
+    sbt --version
     ```
 
     If you get `sbt` command not found error, most likely, you need to add the path to `sbt` in your `PATH`.
 
-### [Step 3] Install Z3
+### [Step 3] Install .NET 8.0
+
+Install .NET 8.0 from Microsoft:
+
+```sh
+wget https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh
+bash ./dotnet-install.sh  -c 8.0 -i $HOME/.dotnet
+
+sudo mkdir /usr/share/dotnet/
+sudo cp -r $HOME/.dotnet/* /usr/share/dotnet/
+```
+
+Then add the following line to `.zshrc` and run `source .zshrc` (or `.bashrc` if using bash):
+
+```sh
+export PATH=$HOME/.dotnet:$HOME/.dotnet/tools:$PATH
+```
+
+The purpose of copying the .NET distribution into `/usr/share/dotnet` is to make standard dotnet packages available to dotnet.   If you are uncomfortable modifying a system directory, you can add the following line to your `.zshrc` or `.bashrc` instead:
+
+```sh
+export DOTNET_ROOT=$HOME/.dotnet
+```
+
+### [Step 4] Install Z3
 
 ```sh
 cd ~
 git clone https://github.com/Z3Prover/z3.git
 cd z3
-python scripts/mk_make.py --java 
+python scripts/mk_make.py --java
 cd build; make
 ```
 
-Then add the following lines to your `.zshrc` (or `.bashrc` if using bash) and run `source ~/.zshrc`:
+Then add the following lines to your `.zshrc` and run `source ~/.zshrc` (or `.bashrc` if using bash):
 
 ```sh
-export PATH=$PATH=$HOME/z3/build/
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH=$HOME/z3/build/
+export PATH=$PATH:$HOME/z3/build/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/z3/build/
 ```
 
 ??? hint "Troubleshoot: Confirm that Z3 is correctly installed on your machine."
@@ -60,13 +84,32 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH=$HOME/z3/build/
 
     If you get `z3` command not found error, most likely, you need to add the path to `z3` in your `PATH`.
 
-### [Step 4] Install UCLID5
+Note:
+
+* Python: Building Z3 requires Python 3, but Python 2 is the default on Amazon Linux 2.  If `python --version` displays version 2, try
+    ```sh
+    sudo alternatives --set python `which python3`
+    ```
+    or
+    ```sh
+    alias python=python3
+    ```
+
+* G++: Building Z3 requires G++ 8 or later with support for C++20, but G++ 7 is the default on Amazon Linux 2.  If `g++ --version` displays version 7, try
+
+    ```sh
+    sudo yum install gcc10 gcc10-c++
+    ```
+
+    to install gcc10-gcc and gcc10-g++ and replace the string `gcc` with `gcc10-` in `config.mk`.
+
+### [Step 5] Install UCLID5
 
 ```sh
 cd ~
 git clone https://github.com/uclid-org/uclid.git
 cd uclid
-sbt update clean compile "set fork:=true" test # should fail some tests that use cvc5 and delphi 
+sbt update clean compile "set fork:=true" test # should fail some tests that use cvc5 and delphi
 sbt universal:packageBin
 unzip target/universal/uclid-0.9.5.zip
 ```
@@ -74,8 +117,11 @@ unzip target/universal/uclid-0.9.5.zip
 Then add the following line to your `.zshrc` (or `.bashrc` if using bash) and run `source ~/.zshrc`:
 
 ```sh
-export PATH=$PATH=$HOME/uclid/uclid-0.9.5/bin/
+export PATH=$PATH:$HOME/uclid/uclid-0.9.5/bin/
 ```
+
+Note:
+* Tests using cvc5 and delphi are likely to fail.  If you just cut and paste the build commands into your shell, this failure may inhibit running the last two commands, so just cut and paste the last two commands into your shell again.
 
 ??? hint "Troubleshoot: Confirm that UCLID5 is correctly installed on your machine."
     ```shell
@@ -84,13 +130,15 @@ export PATH=$PATH=$HOME/uclid/uclid-0.9.5/bin/
 
     If you get `uclid` command not found error, most likely, you need to add the path to `uclid` in your `PATH`.
 
-### [Step 5] Install PVerifier
+### [Step 6] Install PVerifier
+
+The following steps will build P with PVerifier by running the regular P build on the PVerifier branch of the repository.
 
 ```sh
 cd ~
-git clone https://github.com/p-org/P/tree/dev_p3.0/pverifier
+git clone https://github.com/p-org/P
 cd P
-# follow regular P install instructions
+git checkout dev_p3.0/pverifier
 root=$(pwd)
 cd $root/Bld
 ./build.sh


### PR DESCRIPTION
This  pull request corrects some typos in the PVerifier installation instructions on Amazon Linux, and adds instructions like installing .NET 8.0 and installing maven, python 3, and gcc 10 and g++ 10 that are missing when installing on top of a fresh installation of Amazon Linux 2.  

I also removed the comment "follow regular P install instructions" for the P installation instructions, because I misinterpreted this explanation as an instruction to go follow the regular P [build instructions](https://github.com/p-org/P/blob/master/Docs/docs/getstarted/build.md).

I'm not sure what the `!!! success` and `??? hint` tags are, but the don't seem to be formatting as intended (eg, `java -version` is formatted as `shell java version`).