### PR TITLE
Updating PEx Maven Publishing Github action

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,33 +1,109 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
-name: Maven Publish
+name: Publish to Maven Central
 
 on:
-  push:
-    branches: [ "maven-publish-**" ]
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.4.1). Leave empty to use current P version from pom.xml'
+        required: false
+        type: string
 
 jobs:
-  Maven-Publish-Ubuntu:
+  publish:
     runs-on: ubuntu-latest
+    
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-      - name: Publish to the Maven Central Repository
-        working-directory: Src/PRuntimes/PSymRuntime
-        run: mvn --batch-mode deploy -P release -Dmaven.test.skip
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Cache Maven dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+        
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        
+    - name: Extract version from release
+      id: get_version
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          VERSION=${{ github.event.release.tag_name }}
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+        else
+          VERSION=${{ github.event.inputs.version }}
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Publishing version: $VERSION"
+        
+    - name: Update PEx version
+      run: |
+        cd Src/PEx
+        # Update the revision property in pom.xml
+        sed -i "s/<revision>.*<\/revision>/<revision>${{ steps.get_version.outputs.VERSION }}<\/revision>/" pom.xml
+        echo "Updated PEx version to ${{ steps.get_version.outputs.VERSION }}"
+        
+    - name: Create Maven settings.xml
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml << 'EOF'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 
+                                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>central</id>
+              <username>${{ secrets.MAVEN_USERNAME }}</username>
+              <password>${{ secrets.MAVEN_PASSWORD }}</password>
+            </server>
+            <server>
+              <id>gpg.passphrase</id>
+              <passphrase>${{ secrets.GPG_PASSPHRASE }}</passphrase>
+            </server>
+          </servers>
+        </settings>
+        EOF
+        
+    - name: Publish to Maven Central
+      run: |
+        cd Src/PEx
+        mvn clean deploy -P release -DskipTests
+      env:
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        
+    - name: Create deployment summary
+      run: |
+        echo "## 🚀 Maven Central Deployment" >> $GITHUB_STEP_SUMMARY
+        echo "Successfully published **PEx ${{ steps.get_version.outputs.VERSION }}** to Maven Central!" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### 📦 Artifact Details" >> $GITHUB_STEP_SUMMARY
+        echo "- **Group ID:** io.github.p-org" >> $GITHUB_STEP_SUMMARY
+        echo "- **Artifact ID:** pex" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version:** ${{ steps.get_version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### 📋 Maven Dependency" >> $GITHUB_STEP_SUMMARY
+        echo '```xml' >> $GITHUB_STEP_SUMMARY
+        echo '<dependency>' >> $GITHUB_STEP_SUMMARY
+        echo '    <groupId>io.github.p-org</groupId>' >> $GITHUB_STEP_SUMMARY
+        echo '    <artifactId>pex</artifactId>' >> $GITHUB_STEP_SUMMARY
+        echo "    <version>${{ steps.get_version.outputs.VERSION }}</version>" >> $GITHUB_STEP_SUMMARY
+        echo '</dependency>' >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "🔗 [View on Maven Central](https://central.sonatype.com/artifact/io.github.p-org/pex/${{ steps.get_version.outputs.VERSION }})" >> $GITHUB_STEP_SUMMARY

--- a/Src/PCompiler/CompilerCore/Backend/PEx/Constants.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/Constants.cs
@@ -63,7 +63,7 @@ xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/x
         <dependency>
             <groupId>io.github.p-org</groupId>
             <artifactId>pex</artifactId>
-            <version>[0.3.0,)</version>
+            <version>[0.4.0,)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->

--- a/Src/PEx/pom.xml
+++ b/Src/PEx/pom.xml
@@ -119,14 +119,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.4.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <tokenAuth>true</tokenAuth>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>
@@ -246,7 +247,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -263,17 +264,9 @@
     </profiles>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>
-                https://s01.oss.sonatype.org/content/repositories/snapshots
-            </url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>
-                https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+            <id>central</id>
+            <url>https://central.sonatype.com/api/v1/publisher/deployments/upload/</url>
         </repository>
     </distributionManagement>
 
@@ -283,7 +276,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <log4j2.configurationFile>${project.basedir}/src/main/resources/log4j2.xml</log4j2.configurationFile>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>0.3.0</revision>
+        <revision>0.4.0</revision>
     </properties>
 
 </project>


### PR DESCRIPTION
- Tested by manually triggering Github maven publish action to publish PEx v0.4.1 and verified the PEx maven version on maven central page: https://central.sonatype.com/artifact/io.github.p-org/pex
- Haven't tested the automated publish to maven when P is publishing because we will need to publish a new version of P to test it.