### PR TITLE
Prevent liveness issues due to timers

### DIFF
--- a/Tutorial/Common/Timer/PSrc/Timer.p
+++ b/Tutorial/Common/Timer/PSrc/Timer.p
@@ -13,24 +13,15 @@ event eDelayedTimeOut;
 machine Timer {
   // user/client of the timer
   var client: machine;
-  // Bound the maximum number of delays that are possible
-  var maxDelays: int;
-  var remainingDelays: int;
 
   start state Init {
     entry (_client : machine) {
       client = _client;
-      maxDelays = 50;
-      remainingDelays = maxDelays;
       goto WaitForTimerRequests;
     }
   }
 
   state WaitForTimerRequests {
-    entry {
-      remainingDelays = maxDelays;
-    }
-
     on eStartTimer goto TimerStarted;
 
     ignore eCancelTimer, eDelayedTimeOut;
@@ -38,13 +29,11 @@ machine Timer {
 
   state TimerStarted {
     entry {
-      // Only fire the timer with a chance of 1/maxDelays to avoid livelocks
-      // Also bound the maximum number of times we can delay
-      if(choose(maxDelays) == 0 || remainingDelays == 0) {
+      // Only fire the timer with a chance of 1/10 to avoid livelocks
+      if(choose(10) == 0) {
         send client, eTimeOut;
         goto WaitForTimerRequests;
       } else {
-        remainingDelays = remainingDelays - 1;
         send this, eDelayedTimeOut;
       }
     }

--- a/Tutorial/Common/Timer/PSrc/Timer.p
+++ b/Tutorial/Common/Timer/PSrc/Timer.p
@@ -29,7 +29,8 @@ machine Timer {
 
   state TimerStarted {
     entry {
-      if($) {
+      // Only fire the timer with a chance of 1/10 to avoid livelocks
+      if(choose(10) == 0) {
         send client, eTimeOut;
         goto WaitForTimerRequests;
       } else {
@@ -37,24 +38,9 @@ machine Timer {
       }
     }
 
-    on eDelayedTimeOut goto TimerDelayed;
+    on eDelayedTimeOut goto TimerStarted;
     on eCancelTimer goto WaitForTimerRequests;
     defer eStartTimer;
-  }
-
-  state TimerDelayed {
-    entry {
-      if($) {
-        send client, eTimeOut;
-        goto WaitForTimerRequests;
-      } else {
-        // do nothing, wait for eCancelTimer and ignore any old eDelayedTimeOut
-      }
-    }
-
-    on eCancelTimer goto WaitForTimerRequests;
-    defer eStartTimer;
-    ignore eDelayedTimeOut;
   }
 }
 


### PR DESCRIPTION
Addresses the issue in #876. Namely, a timer can introduce liveness bugs because the current timer can just not fire and thus algorithms relying on a timer to kick in might never finish. Also the timer kicks in too quickly which can lead to livelock problems. This PR fixes the issues as follows: we reduce the chance of the timer kicking in to 1/10 which leads to fewer livelock problems and we make sure the timer cannot end in a state where it cannot kick in.