### PR TITLE
Docs update AWS Pi-Week Talk Amazon S3 strong consistency link

### DIFF
--- a/Docs/docs/casestudies.md
+++ b/Docs/docs/casestudies.md
@@ -19,7 +19,7 @@ P was used for creating formal models of all the core distributed protocols invo
 S3's strong consistency and checking that the system model satisfies the desired
 correctness guarantees. Details about P and how it is being used by the S3 team can be
 found in the [AWS Pi-Week Talk](https://pages.awscloud.com/pi-week-2021.html):
-[**Use of Automated Reasoning for S3 Strong Consistency Launch**](https://www.twitch.tv/videos/962963706?t=0h15m15s).
+[**Amazon S3 Strong Consistency**](https://youtu.be/B0yXz6EeCaA?list=PL2yQDdvlhXf8vAnQB10dCPIeWUKdHUgOP).
 
 ### [AWS] Amazon IoT Devices: OTA Protocol
 


### PR DESCRIPTION
From #915, we now that Twitch link to Amazon S3 strong consistency talk is broken so we need to update to a valid link. [*AWS Pi Week 2021: Amazon S3 Strong Consistency | AWS Events*](https://www.youtube.com/watch?v=B0yXz6EeCaA&list=PL2yQDdvlhXf8vAnQB10dCPIeWUKdHUgOP&index=15) seems to be a good candidate for this, thus this change.