### PR TITLE
Extract shared FindLocalPProject helper for CLI options

### DIFF
--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -94,7 +94,7 @@ namespace Plang.Options
             {
                 var result = Parser.ParseArguments(args);
                 // if there are no --pproj or --pfiles arguments, then search for a pproj file locally and load it
-                FindLocalPProject(result);
+                ProjectFileLocator.FindLocalPProject(result);
 
                 // load pproj file first
                 UpdateConfigurationWithPProjectFile(configuration, result);
@@ -131,32 +131,6 @@ namespace Plang.Options
 
             return configuration;
         }
-
-        private static void FindLocalPProject(List<CommandLineArgument> result)
-        {
-            // CommandLineOutput.WriteInfo(".. Searching for a P project file *.pproj locally in the current folder");
-            var filtered =
-                from file in Directory.GetFiles(Directory.GetCurrentDirectory(), "*.pproj")
-                let info = new FileInfo(file)
-                where (((info.Attributes & FileAttributes.Hidden) ==0)& ((info.Attributes & FileAttributes.System)==0))
-                select file;
-            var files = filtered.ToArray();
-            if (files.Length == 0)
-            {
-                // CommandLineOutput.WriteInfo(
-                //     $".. No P project file *.pproj found in the current folder: {Directory.GetCurrentDirectory()}");
-            }
-            else
-            {
-                var commandlineArg = new CommandLineArgument();
-                commandlineArg.Value = files.First();
-                commandlineArg.LongName = "pproj";
-                commandlineArg.ShortName = "pp";
-                // CommandLineOutput.WriteInfo($".. Found P project file: {commandlineArg.Value}");
-                result.Add(commandlineArg);
-            }
-        }
-
 
         /// <summary>
         /// Updates the checker configuration with the specified P project file.

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -65,7 +65,7 @@ namespace Plang.Options
             {
                 var result = Parser.ParseArguments(args);
                 // if there are no --pproj or --pfiles arguments, then search for a pproj file locally and load it
-                FindLocalPProject(result);
+                ProjectFileLocator.FindLocalPProject(result);
 
                 // load pproj file first
                 UpdateConfigurationWithPProjectFile(compilerConfiguration, result);
@@ -98,37 +98,6 @@ namespace Plang.Options
             }
 
             return compilerConfiguration;
-        }
-
-        private static void FindLocalPProject(List<CommandLineArgument> result)
-        {
-            foreach (var arg in result)
-            {
-                if (arg.LongName.Equals("pproj") || arg.LongName.Equals("pfiles"))
-                    return;
-            }
-
-            CommandLineOutput.WriteInfo(".. Searching for a P project file *.pproj locally in the current folder");
-            var filtered =
-                from file in Directory.GetFiles(Directory.GetCurrentDirectory(), "*.pproj")
-                let info = new FileInfo(file)
-                where (((info.Attributes & FileAttributes.Hidden) ==0)& ((info.Attributes & FileAttributes.System)==0))
-                select file;
-            var files = filtered.ToArray();
-            if (files.Length == 0)
-            {
-                CommandLineOutput.WriteInfo(
-                    $".. No P project file *.pproj found in the current folder: {Directory.GetCurrentDirectory()}");
-            }
-            else
-            {
-                var commandlineArg = new CommandLineArgument();
-                commandlineArg.Value = files.First();
-                commandlineArg.LongName = "pproj";
-                commandlineArg.ShortName = "pp";
-                CommandLineOutput.WriteInfo($".. Found P project file: {commandlineArg.Value}");
-                result.Add(commandlineArg);
-            }
         }
 
         /// <summary>

--- a/Src/PCompiler/PCommandLine/Options/ProjectFileLocator.cs
+++ b/Src/PCompiler/PCommandLine/Options/ProjectFileLocator.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PChecker.IO.Debugging;
+using Plang.Parser;
+
+namespace Plang.Options
+{
+    /// <summary>
+    /// Shared helpers for locating P project files (*.pproj) on disk.
+    /// Used by both <c>p compile</c> and <c>p check</c> argument parsers so the
+    /// two stay in sync.
+    /// </summary>
+    internal static class ProjectFileLocator
+    {
+        /// <summary>
+        /// If neither <c>pproj</c> nor <c>pfiles</c> has been supplied, searches
+        /// the current directory for a single <c>*.pproj</c> file and, if one is
+        /// found, appends it to <paramref name="result"/> as a <c>pproj</c> argument.
+        /// </summary>
+        public static void FindLocalPProject(List<CommandLineArgument> result)
+        {
+            foreach (var arg in result)
+            {
+                if (arg.LongName.Equals("pproj") || arg.LongName.Equals("pfiles"))
+                {
+                    return;
+                }
+            }
+
+            CommandLineOutput.WriteInfo(".. Searching for a P project file *.pproj locally in the current folder");
+            var filtered =
+                from file in Directory.GetFiles(Directory.GetCurrentDirectory(), "*.pproj")
+                let info = new FileInfo(file)
+                where ((info.Attributes & FileAttributes.Hidden) == 0) & ((info.Attributes & FileAttributes.System) == 0)
+                select file;
+            var files = filtered.ToArray();
+            if (files.Length == 0)
+            {
+                CommandLineOutput.WriteInfo(
+                    $".. No P project file *.pproj found in the current folder: {Directory.GetCurrentDirectory()}");
+                return;
+            }
+
+            var commandlineArg = new CommandLineArgument
+            {
+                Value = files.First(),
+                LongName = "pproj",
+                ShortName = "pp",
+            };
+            CommandLineOutput.WriteInfo($".. Found P project file: {commandlineArg.Value}");
+            result.Add(commandlineArg);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`PCheckerOptions` and `PCompilerOptions` each carried their own ~25-line `FindLocalPProject` method that scanned the current directory for a `*.pproj` file. The two copies had silently drifted:

- **`PCompilerOptions`** guarded against double-resolution when the user already passed `--pproj` or `--pfiles`; **`PCheckerOptions` did not**, so `p check --pproj foo.pproj` would still trigger a CWD scan and could append a second `pproj` argument.
- **`PCompilerOptions`** emitted "Searching for…", "No P project file found…", "Found P project file…" via `CommandLineOutput`; the same calls in `PCheckerOptions` had been commented out, suppressing diagnostics on the check path.

This PR moves the canonical implementation (with the guard and the logging) to a new `ProjectFileLocator` helper in `Plang.Options`, and has both option parsers call it.

## Changes

- New `Src/PCompiler/PCommandLine/Options/ProjectFileLocator.cs` containing the consolidated `FindLocalPProject(List<CommandLineArgument>)`.
- `PCheckerOptions` and `PCompilerOptions` now delegate to it; the private duplicate methods are removed.

Net: +60 / −59 lines, but the duplication and the divergence are gone.

## Behavior change

- `p compile`: no observable change (this side already had the guard and the logging).
- `p check`: now (a) skips the CWD scan when `--pproj` / `--pfiles` is supplied, and (b) prints the same "Searching…/Found…/No project file…" diagnostics that `p compile` prints.

## Test plan

- [ ] CI build passes (.NET is not available in the dev environment used to author this; the change is mechanical so CI is the source of truth).
- [ ] `p compile` in a directory with a single `*.pproj` behaves identically to before.
- [ ] `p check --pproj foo.pproj` no longer scans the CWD.
- [ ] `p check` (no args) in a directory with a single `*.pproj` now logs the same diagnostics as `p compile`.

Context: first item from the compiler redundancy review on `claude/compiler-redundancy-review-R6XaR`. Further items will be opened as separate PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_012yYFn7Lc59CuqXdPcdSREX)_