### PR TITLE
Replace BinOp/UnOp switch statements with lookup dictionaries

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -1691,61 +1691,39 @@ namespace Plang.Compiler.Backend.CSharp
             }
         }
 
-        private static string UnOpToStr(UnaryOpType operation)
-        {
-            switch (operation)
+        // C# operator strings for unary/binary ops. Eq/Neq are handled at the call site
+        // (they need null-safe equality); Then/Iff are not legal in code generation.
+        private static readonly IReadOnlyDictionary<UnaryOpType, string> UnOpStrings =
+            new Dictionary<UnaryOpType, string>
             {
-                case UnaryOpType.Negate:
-                    return "-";
+                [UnaryOpType.Negate] = "-",
+                [UnaryOpType.Not] = "!",
+            };
 
-                case UnaryOpType.Not:
-                    return "!";
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
-            }
-        }
-
-        private static string BinOpToStr(BinOpType binOpType)
-        {
-            switch (binOpType)
+        private static readonly IReadOnlyDictionary<BinOpType, string> BinOpStrings =
+            new Dictionary<BinOpType, string>
             {
-                case BinOpType.Add:
-                    return "+";
+                [BinOpType.Add] = "+",
+                [BinOpType.Sub] = "-",
+                [BinOpType.Mul] = "*",
+                [BinOpType.Div] = "/",
+                [BinOpType.Mod] = "%",
+                [BinOpType.Lt] = "<",
+                [BinOpType.Le] = "<=",
+                [BinOpType.Gt] = ">",
+                [BinOpType.Ge] = ">=",
+                [BinOpType.And] = "&&",
+                [BinOpType.Or] = "||",
+            };
 
-                case BinOpType.Sub:
-                    return "-";
+        private static string UnOpToStr(UnaryOpType operation) =>
+            UnOpStrings.TryGetValue(operation, out var s)
+                ? s
+                : throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
 
-                case BinOpType.Mul:
-                    return "*";
-
-                case BinOpType.Div:
-                    return "/";
-
-                case BinOpType.Mod:
-                    return "%";
-
-                case BinOpType.Lt:
-                    return "<";
-
-                case BinOpType.Le:
-                    return "<=";
-
-                case BinOpType.Gt:
-                    return ">";
-
-                case BinOpType.Ge:
-                    return ">=";
-
-                case BinOpType.And:
-                    return "&&";
-
-                case BinOpType.Or:
-                    return "||";
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(binOpType), binOpType, null);
-            }
-        }
+        private static string BinOpToStr(BinOpType binOpType) =>
+            BinOpStrings.TryGetValue(binOpType, out var s)
+                ? s
+                : throw new ArgumentOutOfRangeException(nameof(binOpType), binOpType, null);
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
@@ -1864,49 +1864,40 @@ internal class PExCodeGenerator : ICodeGenerator
         context.Write(output, ")");
     }
 
-    private string BinOpToStr(BinOpType binOpType)
-    {
-        switch (binOpType)
+    // PEx method names for unary/binary ops. Eq/Neq are handled at the call site
+    // (they go through PValue.equals); Then/Iff are not legal in code generation.
+    private static readonly IReadOnlyDictionary<BinOpType, string> BinOpStrings =
+        new Dictionary<BinOpType, string>
         {
-            case BinOpType.Add:
-                return "add";
-            case BinOpType.Sub:
-                return "sub";
-            case BinOpType.Mul:
-                return "mul";
-            case BinOpType.Div:
-                return "div";
-            case BinOpType.Mod:
-                return "mod";
-            case BinOpType.Lt:
-                return "lt";
-            case BinOpType.Le:
-                return "le";
-            case BinOpType.Gt:
-                return "gt";
-            case BinOpType.Ge:
-                return "ge";
-            case BinOpType.And:
-                return "and";
-            case BinOpType.Or:
-                return "or";
-            default:
-                throw new ArgumentOutOfRangeException(nameof(binOpType), binOpType, null);
-        }
-    }
+            [BinOpType.Add] = "add",
+            [BinOpType.Sub] = "sub",
+            [BinOpType.Mul] = "mul",
+            [BinOpType.Div] = "div",
+            [BinOpType.Mod] = "mod",
+            [BinOpType.Lt] = "lt",
+            [BinOpType.Le] = "le",
+            [BinOpType.Gt] = "gt",
+            [BinOpType.Ge] = "ge",
+            [BinOpType.And] = "and",
+            [BinOpType.Or] = "or",
+        };
 
-    private static string UnOpToStr(UnaryOpType operation)
-    {
-        switch (operation)
+    private static readonly IReadOnlyDictionary<UnaryOpType, string> UnOpStrings =
+        new Dictionary<UnaryOpType, string>
         {
-            case UnaryOpType.Negate:
-                return "negate";
-            case UnaryOpType.Not:
-                return "not";
-            default:
-                throw new ArgumentOutOfRangeException(nameof(operation));
-        }
-    }
+            [UnaryOpType.Negate] = "negate",
+            [UnaryOpType.Not] = "not",
+        };
+
+    private string BinOpToStr(BinOpType binOpType) =>
+        BinOpStrings.TryGetValue(binOpType, out var s)
+            ? s
+            : throw new ArgumentOutOfRangeException(nameof(binOpType), binOpType, null);
+
+    private static string UnOpToStr(UnaryOpType operation) =>
+        UnOpStrings.TryGetValue(operation, out var s)
+            ? s
+            : throw new ArgumentOutOfRangeException(nameof(operation));
 
     private string GetForeignType(PLanguageType type)
     {


### PR DESCRIPTION
## Summary

The `PCheckerCodeGenerator` and `PExCodeGenerator` each contained two near-identical switch statements mapping `BinOpType`/`UnaryOpType` to a target-language string. The structure was identical across both backends; only the output strings differed (C# operators like `+`, `<=`, `&&` vs PEx method names like `add`, `le`, `and`).

This PR replaces each switch with a `static readonly Dictionary` and reduces the public methods to a single-expression `TryGetValue` + throw. The operator tables are now declarative and visible at a glance, with no loss of behavior.

## Changes

- `Backend/PChecker/PCheckerCodeGenerator.cs:1694-1749` — two switches collapse to two dictionaries + two thin wrappers.
- `Backend/PEx/PExCodeGenerator.cs:1867-1909` — same treatment.

Net diff: **−31 lines** (94 deletions, 63 insertions).

## Behavior preservation

- Same return string for every defined operator (`Add..Or` for binary, `Negate`/`Not` for unary).
- Same `ArgumentOutOfRangeException` thrown for unrecognized values (i.e., `Eq`/`Neq`/`Then`/`Iff` still throw — those are handled at the call site or not legal at codegen).
- No public API change: the methods retain their previous names, signatures, and `private static` access.

## Test plan

- [ ] CI build passes (.NET is not available in the dev environment used to author this).
- [ ] Tutorial tests (`Tutorial/*`) compile and check successfully under both `--mode bugfinding` (PChecker) and `--mode pex` (PEx), since these exercise every operator path.

Context: item #6 from the compiler redundancy review on `claude/compiler-redundancy-review-R6XaR`. Follows #946 (FindLocalPProject extraction). Independent of all other items — no cross-PR conflicts expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_012yYFn7Lc59CuqXdPcdSREX)_