### PR TITLE
Fix build: restore missing ASTExt using in IExpressionEmitter (master broken)

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/IExpressionEmitter.cs
+++ b/Src/PCompiler/CompilerCore/Backend/IExpressionEmitter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Plang.Compiler.Backend.ASTExt;
 using Plang.Compiler.TypeChecker.AST;
 using Plang.Compiler.TypeChecker.AST.Expressions;
 


### PR DESCRIPTION
## Summary

**Master currently does not compile.** `Src/PCompiler/CompilerCore/Backend/IExpressionEmitter.cs` references `CloneExpr` (namespace `Plang.Compiler.Backend.ASTExt`) in its dispatch `switch`, but the `using Plang.Compiler.Backend.ASTExt;` import is absent on master after #954 merged:

```
IExpressionEmitter.cs(27,68): error CS0246: The type or namespace name 'CloneExpr' could not be found
```

The import **was present** in the #954 PR branch (verified: commit `b7908aa`). It appears to have been dropped during/after the merge — most likely by a "remove unused usings" pass that didn't recognize `CloneExpr`'s use in the `case CloneExpr e:` label / the rename from `ExpressionGenerator.cs`.

This PR restores the single missing `using` line. Nothing else changes.

## Verification (local, .NET 8)
- Before: `dotnet build CompilerCore` → `CS0246` (and cascading `CS0535` "does not implement WriteCloneExpr" on all three backends).
- After: **Build succeeded, 0 errors.**

Recommend merging promptly to unbreak `master` / CI. (The in-flight statement-emitter PR is rebased on top of this and will also build once this lands.)


---
_Generated by [Claude Code](https://claude.ai/code/session_012yYFn7Lc59CuqXdPcdSREX)_