### PR TITLE
Unify statement emission behind IStatementEmitter (PChecker, PEx, PObserve)

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/IExpressionEmitter.cs
+++ b/Src/PCompiler/CompilerCore/Backend/IExpressionEmitter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Plang.Compiler.Backend.ASTExt;
 using Plang.Compiler.TypeChecker.AST;
 using Plang.Compiler.TypeChecker.AST.Expressions;
 

--- a/Src/PCompiler/CompilerCore/Backend/IStatementEmitter.cs
+++ b/Src/PCompiler/CompilerCore/Backend/IStatementEmitter.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using Plang.Compiler.TypeChecker.AST;
+using Plang.Compiler.TypeChecker.AST.Statements;
+
+namespace Plang.Compiler.Backend
+{
+    /// <summary>
+    /// Uniform contract for emitting P statements, implemented by the imperative
+    /// code-generator backends (PChecker, PEx, PObserve). Each backend supplies one
+    /// method per general <see cref="IPStmt"/> node; the single dispatch over the node
+    /// kinds lives in <see cref="StatementEmitterExtensions.WriteStmt{TContext,TFrame}"/>.
+    ///
+    /// Two backend differences are absorbed by the shape of the contract:
+    ///   * <typeparamref name="TFrame"/> carries whatever per-emission state a backend
+    ///     threads through statement emission (PChecker: the enclosing <c>Function</c>;
+    ///     PEx: the function plus its <c>ControlFlowContext</c>; PObserve: nothing).
+    ///   * the <c>bool</c> result reports whether the statement terminated control flow
+    ///     ("exited"). PEx uses this to elide fall-through returns; the others always
+    ///     return <c>false</c> and ignore it.
+    ///
+    /// Backends whose IR lowering means a node never reaches them (e.g. PEx eliminates
+    /// <see cref="ForeachStmt"/>/<see cref="NoStmt"/>/<see cref="ReceiveStmt"/>) implement
+    /// that method as an explicit throw. PEx's own <c>ReceiveSplitStmt</c> is a
+    /// PEx-internal node and is handled in PEx outside this contract.
+    ///
+    /// As with <see cref="IExpressionEmitter{TContext}"/>, an interface is used rather
+    /// than a base class so a backend with its own class hierarchy (PObserve's
+    /// <c>JavaSourceGenerator</c>) can participate, and adding a statement node forces
+    /// every backend to handle it (or throw) or fail to compile.
+    /// </summary>
+    internal interface IStatementEmitter<TContext, TFrame>
+        where TContext : CompilationContextBase
+    {
+        bool WriteAddStmt(TContext context, StringWriter output, TFrame frame, AddStmt stmt);
+        bool WriteAnnounceStmt(TContext context, StringWriter output, TFrame frame, AnnounceStmt stmt);
+        bool WriteAssertStmt(TContext context, StringWriter output, TFrame frame, AssertStmt stmt);
+        bool WriteAssignStmt(TContext context, StringWriter output, TFrame frame, AssignStmt stmt);
+        bool WriteBreakStmt(TContext context, StringWriter output, TFrame frame, BreakStmt stmt);
+        bool WriteCompoundStmt(TContext context, StringWriter output, TFrame frame, CompoundStmt stmt);
+        bool WriteContinueStmt(TContext context, StringWriter output, TFrame frame, ContinueStmt stmt);
+        bool WriteCtorStmt(TContext context, StringWriter output, TFrame frame, CtorStmt stmt);
+        bool WriteForeachStmt(TContext context, StringWriter output, TFrame frame, ForeachStmt stmt);
+        bool WriteFunCallStmt(TContext context, StringWriter output, TFrame frame, FunCallStmt stmt);
+        bool WriteGotoStmt(TContext context, StringWriter output, TFrame frame, GotoStmt stmt);
+        bool WriteIfStmt(TContext context, StringWriter output, TFrame frame, IfStmt stmt);
+        bool WriteInsertStmt(TContext context, StringWriter output, TFrame frame, InsertStmt stmt);
+        bool WriteMoveAssignStmt(TContext context, StringWriter output, TFrame frame, MoveAssignStmt stmt);
+        bool WriteNoStmt(TContext context, StringWriter output, TFrame frame, NoStmt stmt);
+        bool WritePrintStmt(TContext context, StringWriter output, TFrame frame, PrintStmt stmt);
+        bool WriteRaiseStmt(TContext context, StringWriter output, TFrame frame, RaiseStmt stmt);
+        bool WriteReceiveStmt(TContext context, StringWriter output, TFrame frame, ReceiveStmt stmt);
+        bool WriteRemoveStmt(TContext context, StringWriter output, TFrame frame, RemoveStmt stmt);
+        bool WriteReturnStmt(TContext context, StringWriter output, TFrame frame, ReturnStmt stmt);
+        bool WriteSendStmt(TContext context, StringWriter output, TFrame frame, SendStmt stmt);
+        bool WriteWhileStmt(TContext context, StringWriter output, TFrame frame, WhileStmt stmt);
+    }
+
+    internal static class StatementEmitterExtensions
+    {
+        /// <summary>
+        /// The single dispatch over general <see cref="IPStmt"/> node kinds. Returns the
+        /// backend's per-node result (whether control flow exited). Backends call this
+        /// (via <c>this</c>) to emit nested statements.
+        /// </summary>
+        public static bool WriteStmt<TContext, TFrame>(
+            this IStatementEmitter<TContext, TFrame> emitter,
+            TContext context, StringWriter output, TFrame frame, IPStmt stmt)
+            where TContext : CompilationContextBase
+        {
+            switch (stmt)
+            {
+                case AddStmt s: return emitter.WriteAddStmt(context, output, frame, s);
+                case AnnounceStmt s: return emitter.WriteAnnounceStmt(context, output, frame, s);
+                case AssertStmt s: return emitter.WriteAssertStmt(context, output, frame, s);
+                case AssignStmt s: return emitter.WriteAssignStmt(context, output, frame, s);
+                case BreakStmt s: return emitter.WriteBreakStmt(context, output, frame, s);
+                case CompoundStmt s: return emitter.WriteCompoundStmt(context, output, frame, s);
+                case ContinueStmt s: return emitter.WriteContinueStmt(context, output, frame, s);
+                case CtorStmt s: return emitter.WriteCtorStmt(context, output, frame, s);
+                case ForeachStmt s: return emitter.WriteForeachStmt(context, output, frame, s);
+                case FunCallStmt s: return emitter.WriteFunCallStmt(context, output, frame, s);
+                case GotoStmt s: return emitter.WriteGotoStmt(context, output, frame, s);
+                case IfStmt s: return emitter.WriteIfStmt(context, output, frame, s);
+                case InsertStmt s: return emitter.WriteInsertStmt(context, output, frame, s);
+                case MoveAssignStmt s: return emitter.WriteMoveAssignStmt(context, output, frame, s);
+                case NoStmt s: return emitter.WriteNoStmt(context, output, frame, s);
+                case PrintStmt s: return emitter.WritePrintStmt(context, output, frame, s);
+                case RaiseStmt s: return emitter.WriteRaiseStmt(context, output, frame, s);
+                case ReceiveStmt s: return emitter.WriteReceiveStmt(context, output, frame, s);
+                case RemoveStmt s: return emitter.WriteRemoveStmt(context, output, frame, s);
+                case ReturnStmt s: return emitter.WriteReturnStmt(context, output, frame, s);
+                case SendStmt s: return emitter.WriteSendStmt(context, output, frame, s);
+                case WhileStmt s: return emitter.WriteWhileStmt(context, output, frame, s);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(stmt), $"type was {stmt?.GetType().FullName}");
+            }
+        }
+    }
+}

--- a/Src/PCompiler/CompilerCore/Backend/IStatementEmitter.cs
+++ b/Src/PCompiler/CompilerCore/Backend/IStatementEmitter.cs
@@ -36,6 +36,7 @@ namespace Plang.Compiler.Backend
         bool WriteAnnounceStmt(TContext context, StringWriter output, TFrame frame, AnnounceStmt stmt);
         bool WriteAssertStmt(TContext context, StringWriter output, TFrame frame, AssertStmt stmt);
         bool WriteAssignStmt(TContext context, StringWriter output, TFrame frame, AssignStmt stmt);
+        bool WriteAssumeStmt(TContext context, StringWriter output, TFrame frame, AssumeStmt stmt);
         bool WriteBreakStmt(TContext context, StringWriter output, TFrame frame, BreakStmt stmt);
         bool WriteCompoundStmt(TContext context, StringWriter output, TFrame frame, CompoundStmt stmt);
         bool WriteContinueStmt(TContext context, StringWriter output, TFrame frame, ContinueStmt stmt);
@@ -53,6 +54,7 @@ namespace Plang.Compiler.Backend
         bool WriteRemoveStmt(TContext context, StringWriter output, TFrame frame, RemoveStmt stmt);
         bool WriteReturnStmt(TContext context, StringWriter output, TFrame frame, ReturnStmt stmt);
         bool WriteSendStmt(TContext context, StringWriter output, TFrame frame, SendStmt stmt);
+        bool WriteSwapAssignStmt(TContext context, StringWriter output, TFrame frame, SwapAssignStmt stmt);
         bool WriteWhileStmt(TContext context, StringWriter output, TFrame frame, WhileStmt stmt);
     }
 
@@ -74,6 +76,7 @@ namespace Plang.Compiler.Backend
                 case AnnounceStmt s: return emitter.WriteAnnounceStmt(context, output, frame, s);
                 case AssertStmt s: return emitter.WriteAssertStmt(context, output, frame, s);
                 case AssignStmt s: return emitter.WriteAssignStmt(context, output, frame, s);
+                case AssumeStmt s: return emitter.WriteAssumeStmt(context, output, frame, s);
                 case BreakStmt s: return emitter.WriteBreakStmt(context, output, frame, s);
                 case CompoundStmt s: return emitter.WriteCompoundStmt(context, output, frame, s);
                 case ContinueStmt s: return emitter.WriteContinueStmt(context, output, frame, s);
@@ -91,6 +94,7 @@ namespace Plang.Compiler.Backend
                 case RemoveStmt s: return emitter.WriteRemoveStmt(context, output, frame, s);
                 case ReturnStmt s: return emitter.WriteReturnStmt(context, output, frame, s);
                 case SendStmt s: return emitter.WriteSendStmt(context, output, frame, s);
+                case SwapAssignStmt s: return emitter.WriteSwapAssignStmt(context, output, frame, s);
                 case WhileStmt s: return emitter.WriteWhileStmt(context, output, frame, s);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(stmt), $"type was {stmt?.GetType().FullName}");

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -15,7 +15,8 @@ using Plang.Compiler.TypeChecker.Types;
 
 namespace Plang.Compiler.Backend.CSharp
 {
-    internal class PCheckerCodeGenerator : ICodeGenerator, IExpressionEmitter<CompilationContext>
+    internal class PCheckerCodeGenerator : ICodeGenerator, IExpressionEmitter<CompilationContext>,
+        IStatementEmitter<CompilationContext, Function>
     {
 
         /// <summary>
@@ -833,358 +834,395 @@ namespace Plang.Compiler.Backend.CSharp
 
             foreach (var bodyStatement in function.Body.Statements)
             {
-                WriteStmt(context: context, output: output, function: function, stmt: bodyStatement);
+                this.WriteStmt(context, output, function, bodyStatement);
             }
 
             context.WriteLine(output, "}");
         }
 
-        private void WriteStmt(CompilationContext context, StringWriter output, Function function, IPStmt stmt)
+        // PChecker emits statements without tracking control-flow exit, so every handler
+        // returns false. The (context, output, function) state is threaded via the
+        // IStatementEmitter frame (here the enclosing Function).
+        public bool WriteAnnounceStmt(CompilationContext context, StringWriter output, Function function, AnnounceStmt announceStmt)
         {
-            switch (stmt)
+            context.Write(output, "currentMachine.Announce((Event)");
+            this.WriteExpr(context, output, announceStmt.Event);
+            if (announceStmt.Payload != null)
             {
-                case AnnounceStmt announceStmt:
-                    context.Write(output, "currentMachine.Announce((Event)");
-                    this.WriteExpr(context, output, announceStmt.Event);
-                    if (announceStmt.Payload != null)
-                    {
-                        context.Write(output, ", ");
-                        this.WriteExpr(context, output, announceStmt.Payload);
-                    }
+                context.Write(output, ", ");
+                this.WriteExpr(context, output, announceStmt.Payload);
+            }
 
-                    context.WriteLine(output, ");");
-                    break;
+            context.WriteLine(output, ");");
+            return false;
+        }
 
-                case AssertStmt assertStmt:
-                    context.Write(output, "currentMachine.Assert(");
-                    this.WriteExpr(context, output, assertStmt.Assertion);
-                    context.Write(output, ",");
-                    context.Write(output, "\"Assertion Failed: \" + ");
-                    this.WriteExpr(context, output, assertStmt.Message);
-                    context.WriteLine(output, ");");
-                    //last statement
-                    if (FunctionValidator.SurelyReturns(assertStmt))
-                    {
-                        context.WriteLine(output, "throw new PUnreachableCodeException();");
-                    }
+        public bool WriteAssertStmt(CompilationContext context, StringWriter output, Function function, AssertStmt assertStmt)
+        {
+            context.Write(output, "currentMachine.Assert(");
+            this.WriteExpr(context, output, assertStmt.Assertion);
+            context.Write(output, ",");
+            context.Write(output, "\"Assertion Failed: \" + ");
+            this.WriteExpr(context, output, assertStmt.Message);
+            context.WriteLine(output, ");");
+            //last statement
+            if (FunctionValidator.SurelyReturns(assertStmt))
+            {
+                context.WriteLine(output, "throw new PUnreachableCodeException();");
+            }
 
-                    break;
+            return false;
+        }
 
-                case AssignStmt assignStmt:
-                    var needCtorAdapter = !assignStmt.Value.Type.IsSameTypeAs(assignStmt.Location.Type)
-                                          && !PrimitiveType.Null.IsSameTypeAs(assignStmt.Value.Type)
-                                          && !PrimitiveType.Any.IsSameTypeAs(assignStmt.Location.Type);
-                    WriteLValue(context, output, assignStmt.Location);
-                    context.Write(output, $" = ({GetCSharpType(assignStmt.Location.Type, true)})(");
-                    if (needCtorAdapter)
-                    {
-                        context.Write(output, $"new {GetCSharpType(assignStmt.Location.Type)}(");
-                    }
+        public bool WriteAssignStmt(CompilationContext context, StringWriter output, Function function, AssignStmt assignStmt)
+        {
+            var needCtorAdapter = !assignStmt.Value.Type.IsSameTypeAs(assignStmt.Location.Type)
+                                  && !PrimitiveType.Null.IsSameTypeAs(assignStmt.Value.Type)
+                                  && !PrimitiveType.Any.IsSameTypeAs(assignStmt.Location.Type);
+            WriteLValue(context, output, assignStmt.Location);
+            context.Write(output, $" = ({GetCSharpType(assignStmt.Location.Type, true)})(");
+            if (needCtorAdapter)
+            {
+                context.Write(output, $"new {GetCSharpType(assignStmt.Location.Type)}(");
+            }
 
-                    this.WriteExpr(context, output, assignStmt.Value);
-                    if (needCtorAdapter)
-                    {
-                        if (assignStmt.Location.Type.Canonicalize() is SequenceType seqType)
-                        {
-                            context.Write(output, $".Cast<{GetCSharpType(seqType.ElementType)}>()");
-                        }
-
-                        context.Write(output, ")");
-                    }
-
-                    context.WriteLine(output, ");");
-                    break;
-
-                case CompoundStmt compoundStmt:
-                    context.WriteLine(output, "{");
-                    foreach (var subStmt in compoundStmt.Statements)
-                    {
-                        WriteStmt(context, output, function, subStmt);
-                    }
-
-                    context.WriteLine(output, "}");
-                    break;
-
-                case CtorStmt ctorStmt:
-                    context.Write(output,
-                        $"currentMachine.CreateInterface<{context.Names.GetNameForDecl(ctorStmt.Interface)}>(");
-                    context.Write(output, "currentMachine");
-                    if (ctorStmt.Arguments.Any())
-                    {
-                        context.Write(output, ", ");
-                        if (ctorStmt.Arguments.Count > 1)
-                        {
-                            //create tuple from rvaluelist
-                            context.Write(output, "new PTuple(");
-                            var septor = "";
-                            foreach (var ctorExprArgument in ctorStmt.Arguments)
-                            {
-                                context.Write(output, septor);
-                                this.WriteExpr(context, output, ctorExprArgument);
-                                septor = ",";
-                            }
-
-                            context.Write(output, ")");
-                        }
-                        else
-                        {
-                            this.WriteExpr(context, output, ctorStmt.Arguments.First());
-                        }
-                    }
-
-                    context.WriteLine(output, ");");
-                    break;
-
-                case FunCallStmt funCallStmt:
-                    var isStatic = funCallStmt.Function.Owner == null;
-                    var awaitMethod = funCallStmt.Function.CanReceive ? "await " : "";
-                    var globalFunctionClass = isStatic ? $"{context.GlobalFunctionClassName}." : "";
-                    context.Write(output,
-                        $"{awaitMethod}{globalFunctionClass}{context.Names.GetNameForDecl(funCallStmt.Function)}(");
-                    var separator = "";
-
-                    foreach (var param in funCallStmt.ArgsList)
-                    {
-                        context.Write(output, separator);
-                        this.WriteExpr(context, output, param);
-                        separator = ", ";
-                    }
-
-                    if (isStatic)
-                    {
-                        context.Write(output, separator + "currentMachine");
-                    }
-
-                    context.WriteLine(output, ");");
-                    break;
-
-                case GotoStmt gotoStmt:
-                    //last statement
-                    context.Write(output, $"currentMachine.RaiseGotoStateEvent<{context.Names.GetNameForDecl(gotoStmt.State)}>(");
-                    if (gotoStmt.Payload != null)
-                    {
-                        this.WriteExpr(context, output, gotoStmt.Payload);
-                    }
-
-                    context.WriteLine(output, ");");
-                    context.WriteLine(output, "return;");
-                    break;
-
-                case IfStmt ifStmt:
-                    context.Write(output, "if (");
-                    this.WriteExpr(context, output, ifStmt.Condition);
-                    context.WriteLine(output, ")");
-                    WriteStmt(context, output, function, ifStmt.ThenBranch);
-                    if (ifStmt.ElseBranch != null && ifStmt.ElseBranch.Statements.Any())
-                    {
-                        context.WriteLine(output, "else");
-                        WriteStmt(context, output, function, ifStmt.ElseBranch);
-                    }
-
-                    break;
-
-                case AddStmt addStmt:
-                    context.Write(output, "((PSet)");
-                    this.WriteExpr(context, output, addStmt.Variable);
-                    context.Write(output, ").Add(");
-                    this.WriteExpr(context, output, addStmt.Value);
-                    context.WriteLine(output, ");");
-                    break;
-
-                case InsertStmt insertStmt:
-                    var isMap = PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Map);
-                    var castOp = isMap ? "(PMap)" : "(PSeq)";
-                    context.Write(output, $"({castOp}");
-                    this.WriteExpr(context, output, insertStmt.Variable);
-                    if (isMap)
-                    {
-                        context.Write(output, ").Add(");
-                    }
-                    else
-                    {
-                        context.Write(output, ").Insert(");
-                    }
-
-                    this.WriteExpr(context, output, insertStmt.Index);
-                    context.Write(output, ", ");
-                    this.WriteExpr(context, output, insertStmt.Value);
-                    context.WriteLine(output, ");");
-                    break;
-
-                case MoveAssignStmt moveAssignStmt:
-                    var upCast = "";
-                    if (!moveAssignStmt.FromVariable.Type.IsSameTypeAs(moveAssignStmt.ToLocation.Type))
-                    {
-                        upCast = $"({GetCSharpType(moveAssignStmt.ToLocation.Type)})";
-                        if (PLanguageType.TypeIsOfKind(moveAssignStmt.FromVariable.Type, TypeKind.Enum))
-                        {
-                            upCast = $"{upCast}(long)";
-                        }
-                    }
-
-                    WriteLValue(context, output, moveAssignStmt.ToLocation);
-                    context.WriteLine(output,
-                        $" = {upCast}{context.Names.GetNameForDecl(moveAssignStmt.FromVariable)};");
-                    break;
-
-                case NoStmt _:
-                    break;
-
-                case PrintStmt printStmt:
-                    context.Write(output, "currentMachine.LogLine(\"\" + ");
-                    this.WriteExpr(context, output, printStmt.Message);
-                    context.WriteLine(output, ");");
-                    break;
-
-                case RaiseStmt raiseStmt:
-                    //last statement
-                    if (raiseStmt.Payload.Any())
-                    {
-                        this.WriteExpr(context, output, raiseStmt.Event);
-                        context.Write(output, ".Payload = ");
-                        this.WriteExpr(context, output, raiseStmt.Payload.First());
-                        context.WriteLine(output, ";");
-                    }
-                    context.Write(output, "currentMachine.RaiseEvent(");
-                    this.WriteExpr(context, output, raiseStmt.Event);
-                    context.WriteLine(output, ");");
-                    context.WriteLine(output, "return;");
-                    break;
-
-                case ReceiveStmt receiveStmt:
-                    var eventName = context.Names.GetTemporaryName("recvEvent");
-                    var eventTypeNames = receiveStmt.Cases.Keys.Select(evt => context.Names.GetNameForDecl(evt))
-                        .ToHashSet();
-                    eventTypeNames.Add("PHalt"); // halt as a special case for receive
-                    var recvArgs = string.Join(", ", eventTypeNames.Select(name => $"typeof({name})"));
-                    context.WriteLine(output, $"var {eventName} = await currentMachine.ReceiveEventAsync({recvArgs});");
-                    context.WriteLine(output, $"switch ({eventName}) {{");
-                    // add halt as a special case if doesnt exist
-                    if (receiveStmt.Cases.All(kv => kv.Key.Name != "PHalt"))
-                    {
-                        context.WriteLine(output,"case PHalt _hv: { currentMachine.RaiseEvent(_hv); break;} ");
-
-                    }
-
-                    foreach (var (key, value) in receiveStmt.Cases)
-                    {
-                        var caseName = context.Names.GetTemporaryName("evt");
-                        context.WriteLine(output, $"case {context.Names.GetNameForDecl(key)} {caseName}: {{");
-                        if (value.Signature.Parameters.FirstOrDefault() is { } caseArg)
-                        {
-                            context.WriteLine(output,
-                                $"{GetCSharpType(caseArg.Type)} {context.Names.GetNameForDecl(caseArg)} = ({GetCSharpType(caseArg.Type)})({caseName}.Payload);");
-                        }
-
-                        foreach (var local in value.LocalVariables)
-                        {
-                            var type = local.Type;
-                            context.WriteLine(output,
-                                $"{GetCSharpType(type, true)} {context.Names.GetNameForDecl(local)} = {GetDefaultValue(type)};");
-                        }
-
-                        foreach (var caseStmt in value.Body.Statements)
-                        {
-                            WriteStmt(context, output, function, caseStmt);
-                        }
-
-                        context.WriteLine(output, "} break;");
-                    }
-
-                    context.WriteLine(output, "}");
-                    break;
-
-                case RemoveStmt removeStmt:
+            this.WriteExpr(context, output, assignStmt.Value);
+            if (needCtorAdapter)
+            {
+                if (assignStmt.Location.Type.Canonicalize() is SequenceType seqType)
                 {
-                    var castOperation = PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Map)
-                        ? "(PMap)"
-                        : PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Sequence)
-                            ? "(PSeq)"
-                            : "(PSet)";
-                    context.Write(output, $"({castOperation}");
-                    switch (removeStmt.Variable.Type.Canonicalize())
-                    {
-                        case MapType _:
-                            this.WriteExpr(context, output, removeStmt.Variable);
-                            context.Write(output, ").Remove(");
-                            this.WriteExpr(context, output, removeStmt.Value);
-                            context.WriteLine(output, ");");
-                            break;
-
-                        case SequenceType _:
-                            this.WriteExpr(context, output, removeStmt.Variable);
-                            context.Write(output, ").RemoveAt(");
-                            this.WriteExpr(context, output, removeStmt.Value);
-                            context.WriteLine(output, ");");
-                            break;
-
-                        case SetType _:
-                            this.WriteExpr(context, output, removeStmt.Variable);
-                            context.Write(output, ").Remove(");
-                            this.WriteExpr(context, output, removeStmt.Value);
-                            context.WriteLine(output, ");");
-                            break;
-
-                        default:
-                            throw new ArgumentOutOfRangeException(
-                                $"Remove cannot be applied to type {removeStmt.Variable.Type.OriginalRepresentation}");
-                    }
-                    break;
+                    context.Write(output, $".Cast<{GetCSharpType(seqType.ElementType)}>()");
                 }
 
-                case ReturnStmt returnStmt:
-                    context.Write(output, "return ");
-                    if (returnStmt.ReturnValue != null)
+                context.Write(output, ")");
+            }
+
+            context.WriteLine(output, ");");
+            return false;
+        }
+
+        public bool WriteCompoundStmt(CompilationContext context, StringWriter output, Function function, CompoundStmt compoundStmt)
+        {
+            context.WriteLine(output, "{");
+            foreach (var subStmt in compoundStmt.Statements)
+            {
+                this.WriteStmt(context, output, function, subStmt);
+            }
+
+            context.WriteLine(output, "}");
+            return false;
+        }
+
+        public bool WriteCtorStmt(CompilationContext context, StringWriter output, Function function, CtorStmt ctorStmt)
+        {
+            context.Write(output,
+                $"currentMachine.CreateInterface<{context.Names.GetNameForDecl(ctorStmt.Interface)}>(");
+            context.Write(output, "currentMachine");
+            if (ctorStmt.Arguments.Any())
+            {
+                context.Write(output, ", ");
+                if (ctorStmt.Arguments.Count > 1)
+                {
+                    //create tuple from rvaluelist
+                    context.Write(output, "new PTuple(");
+                    var septor = "";
+                    foreach (var ctorExprArgument in ctorStmt.Arguments)
                     {
-                        this.WriteExpr(context, output, returnStmt.ReturnValue);
+                        context.Write(output, septor);
+                        this.WriteExpr(context, output, ctorExprArgument);
+                        septor = ",";
                     }
-                    context.WriteLine(output, ";");
-                    break;
 
-                case BreakStmt breakStmt:
-                    context.WriteLine(output, "break;");
-                    break;
+                    context.Write(output, ")");
+                }
+                else
+                {
+                    this.WriteExpr(context, output, ctorStmt.Arguments.First());
+                }
+            }
 
-                case ContinueStmt continueStmt:
-                    context.WriteLine(output, "continue;");
-                    break;
+            context.WriteLine(output, ");");
+            return false;
+        }
 
-                case SendStmt sendStmt:
-                    if (sendStmt.Arguments.Any())
-                    {
-                        this.WriteExpr(context, output, sendStmt.Evt);
-                        context.Write(output, ".Payload = ");
-                        this.WriteExpr(context, output, sendStmt.Arguments.First());
-                        context.WriteLine(output, ";");
-                    }
-                    context.Write(output, "currentMachine.SendEvent(");
-                    this.WriteExpr(context, output, sendStmt.MachineExpr);
-                    context.Write(output, ", (Event)");
-                    this.WriteExpr(context, output, sendStmt.Evt);
+        public bool WriteFunCallStmt(CompilationContext context, StringWriter output, Function function, FunCallStmt funCallStmt)
+        {
+            var isStatic = funCallStmt.Function.Owner == null;
+            var awaitMethod = funCallStmt.Function.CanReceive ? "await " : "";
+            var globalFunctionClass = isStatic ? $"{context.GlobalFunctionClassName}." : "";
+            context.Write(output,
+                $"{awaitMethod}{globalFunctionClass}{context.Names.GetNameForDecl(funCallStmt.Function)}(");
+            var separator = "";
 
+            foreach (var param in funCallStmt.ArgsList)
+            {
+                context.Write(output, separator);
+                this.WriteExpr(context, output, param);
+                separator = ", ";
+            }
+
+            if (isStatic)
+            {
+                context.Write(output, separator + "currentMachine");
+            }
+
+            context.WriteLine(output, ");");
+            return false;
+        }
+
+        public bool WriteGotoStmt(CompilationContext context, StringWriter output, Function function, GotoStmt gotoStmt)
+        {
+            //last statement
+            context.Write(output, $"currentMachine.RaiseGotoStateEvent<{context.Names.GetNameForDecl(gotoStmt.State)}>(");
+            if (gotoStmt.Payload != null)
+            {
+                this.WriteExpr(context, output, gotoStmt.Payload);
+            }
+
+            context.WriteLine(output, ");");
+            context.WriteLine(output, "return;");
+            return false;
+        }
+
+        public bool WriteIfStmt(CompilationContext context, StringWriter output, Function function, IfStmt ifStmt)
+        {
+            context.Write(output, "if (");
+            this.WriteExpr(context, output, ifStmt.Condition);
+            context.WriteLine(output, ")");
+            this.WriteStmt(context, output, function, ifStmt.ThenBranch);
+            if (ifStmt.ElseBranch != null && ifStmt.ElseBranch.Statements.Any())
+            {
+                context.WriteLine(output, "else");
+                this.WriteStmt(context, output, function, ifStmt.ElseBranch);
+            }
+
+            return false;
+        }
+
+        public bool WriteAddStmt(CompilationContext context, StringWriter output, Function function, AddStmt addStmt)
+        {
+            context.Write(output, "((PSet)");
+            this.WriteExpr(context, output, addStmt.Variable);
+            context.Write(output, ").Add(");
+            this.WriteExpr(context, output, addStmt.Value);
+            context.WriteLine(output, ");");
+            return false;
+        }
+
+        public bool WriteInsertStmt(CompilationContext context, StringWriter output, Function function, InsertStmt insertStmt)
+        {
+            var isMap = PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Map);
+            var castOp = isMap ? "(PMap)" : "(PSeq)";
+            context.Write(output, $"({castOp}");
+            this.WriteExpr(context, output, insertStmt.Variable);
+            if (isMap)
+            {
+                context.Write(output, ").Add(");
+            }
+            else
+            {
+                context.Write(output, ").Insert(");
+            }
+
+            this.WriteExpr(context, output, insertStmt.Index);
+            context.Write(output, ", ");
+            this.WriteExpr(context, output, insertStmt.Value);
+            context.WriteLine(output, ");");
+            return false;
+        }
+
+        public bool WriteMoveAssignStmt(CompilationContext context, StringWriter output, Function function, MoveAssignStmt moveAssignStmt)
+        {
+            var upCast = "";
+            if (!moveAssignStmt.FromVariable.Type.IsSameTypeAs(moveAssignStmt.ToLocation.Type))
+            {
+                upCast = $"({GetCSharpType(moveAssignStmt.ToLocation.Type)})";
+                if (PLanguageType.TypeIsOfKind(moveAssignStmt.FromVariable.Type, TypeKind.Enum))
+                {
+                    upCast = $"{upCast}(long)";
+                }
+            }
+
+            WriteLValue(context, output, moveAssignStmt.ToLocation);
+            context.WriteLine(output,
+                $" = {upCast}{context.Names.GetNameForDecl(moveAssignStmt.FromVariable)};");
+            return false;
+        }
+
+        public bool WriteNoStmt(CompilationContext context, StringWriter output, Function function, NoStmt noStmt)
+        {
+            return false;
+        }
+
+        public bool WritePrintStmt(CompilationContext context, StringWriter output, Function function, PrintStmt printStmt)
+        {
+            context.Write(output, "currentMachine.LogLine(\"\" + ");
+            this.WriteExpr(context, output, printStmt.Message);
+            context.WriteLine(output, ");");
+            return false;
+        }
+
+        public bool WriteRaiseStmt(CompilationContext context, StringWriter output, Function function, RaiseStmt raiseStmt)
+        {
+            //last statement
+            if (raiseStmt.Payload.Any())
+            {
+                this.WriteExpr(context, output, raiseStmt.Event);
+                context.Write(output, ".Payload = ");
+                this.WriteExpr(context, output, raiseStmt.Payload.First());
+                context.WriteLine(output, ";");
+            }
+            context.Write(output, "currentMachine.RaiseEvent(");
+            this.WriteExpr(context, output, raiseStmt.Event);
+            context.WriteLine(output, ");");
+            context.WriteLine(output, "return;");
+            return false;
+        }
+
+        public bool WriteReceiveStmt(CompilationContext context, StringWriter output, Function function, ReceiveStmt receiveStmt)
+        {
+            var eventName = context.Names.GetTemporaryName("recvEvent");
+            var eventTypeNames = receiveStmt.Cases.Keys.Select(evt => context.Names.GetNameForDecl(evt))
+                .ToHashSet();
+            eventTypeNames.Add("PHalt"); // halt as a special case for receive
+            var recvArgs = string.Join(", ", eventTypeNames.Select(name => $"typeof({name})"));
+            context.WriteLine(output, $"var {eventName} = await currentMachine.ReceiveEventAsync({recvArgs});");
+            context.WriteLine(output, $"switch ({eventName}) {{");
+            // add halt as a special case if doesnt exist
+            if (receiveStmt.Cases.All(kv => kv.Key.Name != "PHalt"))
+            {
+                context.WriteLine(output,"case PHalt _hv: { currentMachine.RaiseEvent(_hv); break;} ");
+
+            }
+
+            foreach (var (key, value) in receiveStmt.Cases)
+            {
+                var caseName = context.Names.GetTemporaryName("evt");
+                context.WriteLine(output, $"case {context.Names.GetNameForDecl(key)} {caseName}: {{");
+                if (value.Signature.Parameters.FirstOrDefault() is { } caseArg)
+                {
+                    context.WriteLine(output,
+                        $"{GetCSharpType(caseArg.Type)} {context.Names.GetNameForDecl(caseArg)} = ({GetCSharpType(caseArg.Type)})({caseName}.Payload);");
+                }
+
+                foreach (var local in value.LocalVariables)
+                {
+                    var type = local.Type;
+                    context.WriteLine(output,
+                        $"{GetCSharpType(type, true)} {context.Names.GetNameForDecl(local)} = {GetDefaultValue(type)};");
+                }
+
+                foreach (var caseStmt in value.Body.Statements)
+                {
+                    this.WriteStmt(context, output, function, caseStmt);
+                }
+
+                context.WriteLine(output, "} break;");
+            }
+
+            context.WriteLine(output, "}");
+            return false;
+        }
+
+        public bool WriteRemoveStmt(CompilationContext context, StringWriter output, Function function, RemoveStmt removeStmt)
+        {
+            var castOperation = PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Map)
+                ? "(PMap)"
+                : PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Sequence)
+                    ? "(PSeq)"
+                    : "(PSet)";
+            context.Write(output, $"({castOperation}");
+            switch (removeStmt.Variable.Type.Canonicalize())
+            {
+                case MapType _:
+                    this.WriteExpr(context, output, removeStmt.Variable);
+                    context.Write(output, ").Remove(");
+                    this.WriteExpr(context, output, removeStmt.Value);
                     context.WriteLine(output, ");");
                     break;
 
-                case ForeachStmt foreachStmt:
-                    var tempVarName = $"__temp_{context.Names.GetNameForDecl(foreachStmt.Item)}";
-                    context.Write(output, $"foreach (var {tempVarName} in ");
-                    this.WriteExpr(context, output, foreachStmt.IterCollection);
-                    context.WriteLine(output, ") {");
-                    context.WriteLine(output, $"{context.Names.GetNameForDecl(foreachStmt.Item)} = ({GetCSharpType(foreachStmt.Item.Type)}) {tempVarName};");
-                    WriteStmt(context, output, function, foreachStmt.Body);
-                    context.WriteLine(output, "}");
+                case SequenceType _:
+                    this.WriteExpr(context, output, removeStmt.Variable);
+                    context.Write(output, ").RemoveAt(");
+                    this.WriteExpr(context, output, removeStmt.Value);
+                    context.WriteLine(output, ");");
                     break;
 
-                case WhileStmt whileStmt:
-                    context.Write(output, "while (");
-                    this.WriteExpr(context, output, whileStmt.Condition);
-                    context.WriteLine(output, ")");
-                    WriteStmt(context, output, function, whileStmt.Body);
+                case SetType _:
+                    this.WriteExpr(context, output, removeStmt.Variable);
+                    context.Write(output, ").Remove(");
+                    this.WriteExpr(context, output, removeStmt.Value);
+                    context.WriteLine(output, ");");
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(stmt));
+                    throw new ArgumentOutOfRangeException(
+                        $"Remove cannot be applied to type {removeStmt.Variable.Type.OriginalRepresentation}");
             }
+
+            return false;
+        }
+
+        public bool WriteReturnStmt(CompilationContext context, StringWriter output, Function function, ReturnStmt returnStmt)
+        {
+            context.Write(output, "return ");
+            if (returnStmt.ReturnValue != null)
+            {
+                this.WriteExpr(context, output, returnStmt.ReturnValue);
+            }
+            context.WriteLine(output, ";");
+            return false;
+        }
+
+        public bool WriteBreakStmt(CompilationContext context, StringWriter output, Function function, BreakStmt breakStmt)
+        {
+            context.WriteLine(output, "break;");
+            return false;
+        }
+
+        public bool WriteContinueStmt(CompilationContext context, StringWriter output, Function function, ContinueStmt continueStmt)
+        {
+            context.WriteLine(output, "continue;");
+            return false;
+        }
+
+        public bool WriteSendStmt(CompilationContext context, StringWriter output, Function function, SendStmt sendStmt)
+        {
+            if (sendStmt.Arguments.Any())
+            {
+                this.WriteExpr(context, output, sendStmt.Evt);
+                context.Write(output, ".Payload = ");
+                this.WriteExpr(context, output, sendStmt.Arguments.First());
+                context.WriteLine(output, ";");
+            }
+            context.Write(output, "currentMachine.SendEvent(");
+            this.WriteExpr(context, output, sendStmt.MachineExpr);
+            context.Write(output, ", (Event)");
+            this.WriteExpr(context, output, sendStmt.Evt);
+
+            context.WriteLine(output, ");");
+            return false;
+        }
+
+        public bool WriteForeachStmt(CompilationContext context, StringWriter output, Function function, ForeachStmt foreachStmt)
+        {
+            var tempVarName = $"__temp_{context.Names.GetNameForDecl(foreachStmt.Item)}";
+            context.Write(output, $"foreach (var {tempVarName} in ");
+            this.WriteExpr(context, output, foreachStmt.IterCollection);
+            context.WriteLine(output, ") {");
+            context.WriteLine(output, $"{context.Names.GetNameForDecl(foreachStmt.Item)} = ({GetCSharpType(foreachStmt.Item.Type)}) {tempVarName};");
+            this.WriteStmt(context, output, function, foreachStmt.Body);
+            context.WriteLine(output, "}");
+            return false;
+        }
+
+        public bool WriteWhileStmt(CompilationContext context, StringWriter output, Function function, WhileStmt whileStmt)
+        {
+            context.Write(output, "while (");
+            this.WriteExpr(context, output, whileStmt.Condition);
+            context.WriteLine(output, ")");
+            this.WriteStmt(context, output, function, whileStmt.Body);
+            return false;
         }
 
         private void WriteLValue(CompilationContext context, StringWriter output, IPExpr lvalue)

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -1225,6 +1225,15 @@ namespace Plang.Compiler.Backend.CSharp
             return false;
         }
 
+        // assume and swap-assign do not reach the PChecker backend; match the prior
+        // switch default (which threw) so the behavior is unchanged.
+        public bool WriteAssumeStmt(CompilationContext context, StringWriter output, Function function, AssumeStmt stmt) =>
+            throw new ArgumentOutOfRangeException(nameof(stmt));
+
+        public bool WriteSwapAssignStmt(CompilationContext context, StringWriter output, Function function, SwapAssignStmt stmt) =>
+            throw new ArgumentOutOfRangeException(nameof(stmt));
+
+
         private void WriteLValue(CompilationContext context, StringWriter output, IPExpr lvalue)
         {
 #pragma warning disable CCN0002 // Non exhaustive patterns in switch block

--- a/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
@@ -902,7 +902,7 @@ internal class PExCodeGenerator : ICodeGenerator, IExpressionEmitter<Compilation
     {
         var function = frame.Function;
         var flowContext = frame.FlowContext;
-        if (!(whileStmt.Condition is BoolLiteralExpr) && ((BoolLiteralExpr)whileStmt.Condition).Value)
+        if (!(whileStmt.Condition is BoolLiteralExpr ble) || !ble.Value)
             throw new ArgumentOutOfRangeException(
                 "While statement condition should always be transformed to constant 'true' during IR simplification.");
 
@@ -1090,6 +1090,8 @@ internal class PExCodeGenerator : ICodeGenerator, IExpressionEmitter<Compilation
     public bool WriteForeachStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, ForeachStmt stmt) => throw UnsupportedStmt(stmt, frame);
     public bool WriteNoStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, NoStmt stmt) => throw UnsupportedStmt(stmt, frame);
     public bool WriteReceiveStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, ReceiveStmt stmt) => throw UnsupportedStmt(stmt, frame);
+    public bool WriteAssumeStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, AssumeStmt stmt) => throw UnsupportedStmt(stmt, frame);
+    public bool WriteSwapAssignStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, SwapAssignStmt stmt) => throw UnsupportedStmt(stmt, frame);
 
     private static NotImplementedException UnsupportedStmt(IPStmt stmt, PExStmtFrame frame) =>
         new NotImplementedException(

--- a/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
@@ -15,7 +15,22 @@ using Plang.Compiler.TypeChecker.Types;
 
 namespace Plang.Compiler.Backend.PEx;
 
-internal class PExCodeGenerator : ICodeGenerator, IExpressionEmitter<CompilationContext>
+// Per-statement state PEx threads through emission: the enclosing function and the
+// current control-flow context. Carried as the IStatementEmitter frame.
+internal readonly struct PExStmtFrame
+{
+    public readonly Function Function;
+    public readonly PExCodeGenerator.ControlFlowContext FlowContext;
+
+    public PExStmtFrame(Function function, PExCodeGenerator.ControlFlowContext flowContext)
+    {
+        Function = function;
+        FlowContext = flowContext;
+    }
+}
+
+internal class PExCodeGenerator : ICodeGenerator, IExpressionEmitter<CompilationContext>,
+    IStatementEmitter<CompilationContext, PExStmtFrame>
 {
     public IEnumerable<CompiledFile> GenerateCode(ICompilerConfiguration job, Scope globalScope)
     {
@@ -684,349 +699,401 @@ internal class PExCodeGenerator : ICodeGenerator, IExpressionEmitter<Compilation
         }
     }
 
+    // Thin wrapper keeping PEx's existing call shape (function + flow context + bool
+    // "exited" result). It handles the cases that are not part of the shared statement
+    // contract — call-in-assignment lowering and PEx's own ReceiveSplitStmt — and otherwise
+    // routes to the shared IStatementEmitter dispatch with a frame carrying (function, flow).
     private bool WriteStmt(Function function, CompilationContext context, StringWriter output,
         ControlFlowContext flowContext, IPStmt stmt)
     {
-        var exited = false;
-
         if (TryGetCallInAssignment(stmt) is { } callExpr)
         {
             WriteFunCallStmt(context, output, callExpr.Function, callExpr.Arguments, (stmt as AssignStmt)?.Location);
             return false;
         }
 
-        switch (stmt)
+        if (stmt is ReceiveSplitStmt splitStmt)
         {
-            case AssignStmt assignStmt:
-                Debug.Assert(assignStmt.Value != null);
-                Debug.Assert(assignStmt.Location != null);
-                CheckIsSupportedAssignment(assignStmt.Value.Type, assignStmt.Location.Type);
+            return WriteReceiveSplitStmt(context, output, splitStmt);
+        }
 
-                WriteWithLValueMutationContext(
-                    context,
-                    output,
-                    assignStmt.Location,
-                    false,
-                    locationTemp =>
-                    {
-                        var expr = UnnestCloneExpr(assignStmt.Value);
-                        if (expr is NullLiteralExpr)
-                        {
-                            context.WriteLine(output, $"{locationTemp} = {GetDefaultValue(assignStmt.Location.Type)};");
-                        }
-                        else
-                        {
-                            context.Write(output, $"{locationTemp} = ({GetPExType(assignStmt.Location.Type)}) ");
-                            this.WriteExpr(context, output, expr);
-                            context.WriteLine(output, ";");
-                        }
-                    }
-                );
+        return this.WriteStmt(context, output, new PExStmtFrame(function, flowContext), stmt);
+    }
 
-                break;
+    private bool WriteReceiveSplitStmt(CompilationContext context, StringWriter output, ReceiveSplitStmt splitStmt)
+    {
+        var continuation = splitStmt.Cont;
+        context.WriteLine(output,
+            $"PContinuation {context.GetContinuationName(continuation)} = getContinuation(\"{context.GetContinuationName(continuation)}\");");
+        foreach (var local in continuation.LocalParameters)
+            context.WriteLine(output,
+                $"{context.GetContinuationName(continuation)}.setVar(\"{continuation.StoreForLocal[local].Name}\", {CompilationContext.GetVar(local.Name)});");
+        context.WriteLine(output,
+            $"{CompilationContext.CurrentMachine}.blockUntil(\"{context.GetContinuationName(continuation)}\");");
+        context.Write(output, "return;");
+        return true;
+    }
 
-            case MoveAssignStmt moveStmt:
-                CheckIsSupportedAssignment(moveStmt.FromVariable.Type, moveStmt.ToLocation.Type);
+    public bool WriteAssignStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, AssignStmt assignStmt)
+    {
+        Debug.Assert(assignStmt.Value != null);
+        Debug.Assert(assignStmt.Location != null);
+        CheckIsSupportedAssignment(assignStmt.Value.Type, assignStmt.Location.Type);
 
-                WriteWithLValueMutationContext(
-                    context,
-                    output,
-                    moveStmt.ToLocation,
-                    false,
-                    locationTemp =>
-                    {
-                        context.Write(output, $"{locationTemp} = ({GetPExType(moveStmt.ToLocation.Type)}) ");
-                        this.WriteExpr(context, output,
-                            new VariableAccessExpr(moveStmt.FromVariable.SourceLocation, moveStmt.FromVariable));
-                        context.WriteLine(output, ";");
-                    }
-                );
-
-                break;
-
-            case AssertStmt assertStmt:
-                context.Write(output, "Assert.fromModel((");
-                this.WriteExpr(context, output, assertStmt.Assertion);
-                context.Write(output, ").getValue(), ");
-                this.WriteExpr(context, output, assertStmt.Message);
-                context.Write(output, ");");
-                break;
-
-            case ReturnStmt returnStmt:
-                if (!(returnStmt.ReturnValue is null))
+        WriteWithLValueMutationContext(
+            context,
+            output,
+            assignStmt.Location,
+            false,
+            locationTemp =>
+            {
+                var expr = UnnestCloneExpr(assignStmt.Value);
+                if (expr is NullLiteralExpr)
                 {
-                    context.Write(output, $"{CompilationContext.ReturnValue} = ");
-                    context.Write(output, $"({GetPExType(context.ReturnType)}) ");
-                    this.WriteExpr(context, output, returnStmt.ReturnValue);
+                    context.WriteLine(output, $"{locationTemp} = {GetDefaultValue(assignStmt.Location.Type)};");
+                }
+                else
+                {
+                    context.Write(output, $"{locationTemp} = ({GetPExType(assignStmt.Location.Type)}) ");
+                    this.WriteExpr(context, output, expr);
                     context.WriteLine(output, ";");
-                    context.Write(output, $"return {CompilationContext.ReturnValue};");
                 }
-                else
-                {
-                    context.Write(output, "return;");
-                }
+            }
+        );
 
-                exited = true;
-                break;
+        return false;
+    }
 
-            case GotoStmt gotoStmt:
-                context.Write(output,
-                    $"{CompilationContext.CurrentMachine}.gotoState({context.GetNameForDecl(gotoStmt.State)}");
-                if (gotoStmt.Payload == null)
-                {
-                    context.Write(output, ", null");
-                }
-                else
-                {
-                    context.Write(output, ", ");
-                    this.WriteExpr(context, output, gotoStmt.Payload);
-                }
+    public bool WriteMoveAssignStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, MoveAssignStmt moveStmt)
+    {
+        CheckIsSupportedAssignment(moveStmt.FromVariable.Type, moveStmt.ToLocation.Type);
 
-                context.WriteLine(output, ");");
-
-                if (function.Signature.ReturnType == null || function.Signature.ReturnType.IsSameTypeAs(PrimitiveType.Null))
-                    context.WriteLine(output, "return;");
-                else
-                    context.WriteLine(output, "return null;");
-                exited = true;
-                break;
-
-            case RaiseStmt raiseStmt:
-                // TODO: Add type checking for the payload!
-                context.WriteLine(output, "// NOTE (TODO): We currently perform no typechecking on the payload!");
-
-                context.Write(output, $"{CompilationContext.CurrentMachine}.raiseEvent(");
-                this.WriteExpr(context, output, raiseStmt.Event);
-                if (raiseStmt.Payload.Count > 0)
-                {
-                    // TODO: Determine how multi-payload raise statements are supposed to work
-                    Debug.Assert(raiseStmt.Payload.Count == 1);
-                    context.Write(output, ", ");
-                    this.WriteExpr(context, output, raiseStmt.Payload[0]);
-                }
-
-                context.WriteLine(output, ");");
-
-                if (function.Signature.ReturnType == null || function.Signature.ReturnType.IsSameTypeAs(PrimitiveType.Null))
-                    context.WriteLine(output, "return;");
-                else
-                    context.WriteLine(output, "return null;");
-                exited = true;
-                break;
-
-            case PrintStmt printStmt:
-                context.Write(output, $"{CompilationContext.SchedulerVar}.getLogger().logModel(");
-                this.WriteExpr(context, output, printStmt.Message);
-                context.WriteLine(output, ".toString());");
-                break;
-
-            case BreakStmt _:
-                context.WriteLine(output, "break;");
-                break;
-
-            case ContinueStmt _:
-                context.WriteLine(output, "continue;");
-                break;
-
-            case CompoundStmt compoundStmt:
-                foreach (var subStmt in compoundStmt.Statements)
-                {
-                    exited |= WriteStmt(function, context, output, flowContext, subStmt);
-                    context.WriteLine(output);
-
-                    if (exited) break;
-                }
-
-                break;
-
-            case WhileStmt whileStmt:
-                if (!(whileStmt.Condition is BoolLiteralExpr) && ((BoolLiteralExpr)whileStmt.Condition).Value)
-                    throw new ArgumentOutOfRangeException(
-                        "While statement condition should always be transformed to constant 'true' during IR simplification.");
-
-                var loopContext = flowContext.FreshLoopContext(context);
-
-                /* Loop body */
-                context.WriteLine(output, "while (true) {");
-                exited = WriteStmt(function, context, output, loopContext, whileStmt.Body);
-                context.WriteLine(output, "}");
-
-                break;
-
-            case IfStmt ifStmt:
-                /* Prologue */
-
-                var condTemp = context.FreshTempVar();
-                Debug.Assert(ifStmt.Condition.Type.IsSameTypeAs(PrimitiveType.Bool));
-                context.Write(output, $"{GetPExType(PrimitiveType.Bool)} {condTemp} = ");
-                this.WriteExpr(context, output, ifStmt.Condition);
+        WriteWithLValueMutationContext(
+            context,
+            output,
+            moveStmt.ToLocation,
+            false,
+            locationTemp =>
+            {
+                context.Write(output, $"{locationTemp} = ({GetPExType(moveStmt.ToLocation.Type)}) ");
+                this.WriteExpr(context, output,
+                    new VariableAccessExpr(moveStmt.FromVariable.SourceLocation, moveStmt.FromVariable));
                 context.WriteLine(output, ";");
-
-                var thenContext = flowContext.FreshBranchSubContext(context);
-                var elseContext = flowContext.FreshBranchSubContext(context);
-
-                /* Body */
-
-                context.WriteLine(output, $"if ({condTemp}.getValue()) {{");
-                context.WriteLine(output, "// 'then' branch");
-                exited = WriteStmt(function, context, output, thenContext, ifStmt.ThenBranch);
-                context.WriteLine(output, "}");
-
-                if (!(ifStmt.ElseBranch is null))
-                {
-                    context.WriteLine(output, "else {");
-                    context.WriteLine(output, "// 'else' branch");
-                    exited &= WriteStmt(function, context, output, elseContext, ifStmt.ElseBranch);
-                    context.WriteLine(output, "}");
-                }
-
-                break;
-
-            case FunCallStmt funCallStmt:
-                WriteFunCallStmt(context, output, funCallStmt.Function, funCallStmt.ArgsList);
-                break;
-
-            case CtorStmt ctorStmt:
-                WriteCtorExpr(context, output, ctorStmt.Interface, ctorStmt.Arguments);
-                context.WriteLine(output, ";");
-                break;
-
-            case SendStmt sendStmt:
-                context.Write(output, $"{CompilationContext.CurrentMachine}.sendEvent(");
-                this.WriteExpr(context, output, sendStmt.MachineExpr);
-                context.Write(output, ", ");
-                this.WriteExpr(context, output, sendStmt.Evt);
-                context.Write(output, ", ");
-                if (sendStmt.Arguments.Count == 0)
-                    context.Write(output, "null");
-                else if (sendStmt.Arguments.Count == 1)
-                    this.WriteExpr(context, output, sendStmt.Arguments[0]);
-                else
-                    throw new NotImplementedException(
-                        "Send statements with more than one payload argument are not supported");
-                context.WriteLine(output, ");");
-                break;
-
-            case InsertStmt insertStmt:
-            {
-                var isMap = PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Map);
-                var isSet = PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Set);
-                PLanguageType keyType = null;
-                PLanguageType elementType;
-                if (isMap)
-                {
-                    keyType = ((MapType)insertStmt.Variable.Type.Canonicalize()).KeyType;
-                    elementType = ((MapType)insertStmt.Variable.Type.Canonicalize()).ValueType;
-                }
-                else if (isSet)
-                {
-                    elementType = ((SetType)insertStmt.Variable.Type.Canonicalize()).ElementType;
-                }
-                else
-                {
-                    elementType = ((SequenceType)insertStmt.Variable.Type.Canonicalize()).ElementType;
-                }
-
-                WriteWithLValueMutationContext(
-                    context,
-                    output,
-                    insertStmt.Variable,
-                    true,
-                    structureTemp =>
-                    {
-                        context.Write(output, $"{structureTemp} = ");
-                        context.Write(output, $"(({GetPExType(insertStmt.Variable.Type)}) ");
-                        this.WriteExpr(context, output, insertStmt.Variable);
-                        context.Write(output, ").add(");
-
-                        this.WriteExpr(context, output, insertStmt.Index);
-                        context.Write(output, ", ");
-                        this.WriteExpr(context, output, insertStmt.Value);
-
-                        context.WriteLine(output, ");");
-                    }
-                );
-
-                break;
             }
+        );
 
-            case AddStmt addStmt:
-            {
-                WriteWithLValueMutationContext(
-                    context,
-                    output,
-                    addStmt.Variable,
-                    true,
-                    structureTemp =>
-                    {
-                        context.Write(output, $"{structureTemp} = ");
-                        context.Write(output, $"(({GetPExType(addStmt.Variable.Type)}) ");
-                        this.WriteExpr(context, output, addStmt.Variable);
-                        context.Write(output, ").add(");
-                        this.WriteExpr(context, output, addStmt.Value);
-                        context.WriteLine(output, ");");
-                    }
-                );
+        return false;
+    }
 
-                break;
-            }
+    public bool WriteAssertStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, AssertStmt assertStmt)
+    {
+        context.Write(output, "Assert.fromModel((");
+        this.WriteExpr(context, output, assertStmt.Assertion);
+        context.Write(output, ").getValue(), ");
+        this.WriteExpr(context, output, assertStmt.Message);
+        context.Write(output, ");");
+        return false;
+    }
 
-            case RemoveStmt removeStmt:
-            {
-                var isMap = PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Map);
-                var isSet = PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Set);
+    public bool WriteReturnStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, ReturnStmt returnStmt)
+    {
+        if (!(returnStmt.ReturnValue is null))
+        {
+            context.Write(output, $"{CompilationContext.ReturnValue} = ");
+            context.Write(output, $"({GetPExType(context.ReturnType)}) ");
+            this.WriteExpr(context, output, returnStmt.ReturnValue);
+            context.WriteLine(output, ";");
+            context.Write(output, $"return {CompilationContext.ReturnValue};");
+        }
+        else
+        {
+            context.Write(output, "return;");
+        }
 
-                WriteWithLValueMutationContext(
-                    context,
-                    output,
-                    removeStmt.Variable,
-                    true,
-                    structureTemp =>
-                    {
-                        context.Write(output, $"{structureTemp} = ");
-                        context.Write(output, $"(({GetPExType(removeStmt.Variable.Type)}) ");
-                        this.WriteExpr(context, output, removeStmt.Variable);
+        return true;
+    }
 
-                        if (isMap || isSet)
-                            context.Write(output, ").remove(");
-                        else
-                            context.Write(output, ").removeAt(");
+    public bool WriteGotoStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, GotoStmt gotoStmt)
+    {
+        var function = frame.Function;
+        context.Write(output,
+            $"{CompilationContext.CurrentMachine}.gotoState({context.GetNameForDecl(gotoStmt.State)}");
+        if (gotoStmt.Payload == null)
+        {
+            context.Write(output, ", null");
+        }
+        else
+        {
+            context.Write(output, ", ");
+            this.WriteExpr(context, output, gotoStmt.Payload);
+        }
 
-                        this.WriteExpr(context, output, removeStmt.Value);
-                        context.WriteLine(output, ");");
-                    }
-                );
-                break;
-            }
-            case AnnounceStmt announceStmt:
-                context.Write(output, $"{CompilationContext.SchedulerVar}.announce(");
-                this.WriteExpr(context, output, announceStmt.Event);
-                context.Write(output, ", ");
-                if (announceStmt.Payload == null)
-                    context.Write(output, "null");
-                else
-                    this.WriteExpr(context, output, announceStmt.Payload);
-                context.WriteLine(output, ");");
-                break;
-            case ReceiveSplitStmt splitStmt:
-                var continuation = splitStmt.Cont;
-                context.WriteLine(output,
-                    $"PContinuation {context.GetContinuationName(continuation)} = getContinuation(\"{context.GetContinuationName(continuation)}\");");
-                foreach (var local in continuation.LocalParameters)
-                    context.WriteLine(output,
-                        $"{context.GetContinuationName(continuation)}.setVar(\"{continuation.StoreForLocal[local].Name}\", {CompilationContext.GetVar(local.Name)});");
-                context.WriteLine(output,
-                    $"{CompilationContext.CurrentMachine}.blockUntil(\"{context.GetContinuationName(continuation)}\");");
-                context.Write(output, "return;");
-                exited = true;
-                break;
-            default:
-                throw new NotImplementedException(
-                    $"Statement type '{stmt.GetType().Name}' is not supported, found in {function.Name}");
+        context.WriteLine(output, ");");
+
+        if (function.Signature.ReturnType == null || function.Signature.ReturnType.IsSameTypeAs(PrimitiveType.Null))
+            context.WriteLine(output, "return;");
+        else
+            context.WriteLine(output, "return null;");
+        return true;
+    }
+
+    public bool WriteRaiseStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, RaiseStmt raiseStmt)
+    {
+        var function = frame.Function;
+        // TODO: Add type checking for the payload!
+        context.WriteLine(output, "// NOTE (TODO): We currently perform no typechecking on the payload!");
+
+        context.Write(output, $"{CompilationContext.CurrentMachine}.raiseEvent(");
+        this.WriteExpr(context, output, raiseStmt.Event);
+        if (raiseStmt.Payload.Count > 0)
+        {
+            // TODO: Determine how multi-payload raise statements are supposed to work
+            Debug.Assert(raiseStmt.Payload.Count == 1);
+            context.Write(output, ", ");
+            this.WriteExpr(context, output, raiseStmt.Payload[0]);
+        }
+
+        context.WriteLine(output, ");");
+
+        if (function.Signature.ReturnType == null || function.Signature.ReturnType.IsSameTypeAs(PrimitiveType.Null))
+            context.WriteLine(output, "return;");
+        else
+            context.WriteLine(output, "return null;");
+        return true;
+    }
+
+    public bool WritePrintStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, PrintStmt printStmt)
+    {
+        context.Write(output, $"{CompilationContext.SchedulerVar}.getLogger().logModel(");
+        this.WriteExpr(context, output, printStmt.Message);
+        context.WriteLine(output, ".toString());");
+        return false;
+    }
+
+    public bool WriteBreakStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, BreakStmt stmt)
+    {
+        context.WriteLine(output, "break;");
+        return false;
+    }
+
+    public bool WriteContinueStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, ContinueStmt stmt)
+    {
+        context.WriteLine(output, "continue;");
+        return false;
+    }
+
+    public bool WriteCompoundStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, CompoundStmt compoundStmt)
+    {
+        var function = frame.Function;
+        var flowContext = frame.FlowContext;
+        var exited = false;
+        foreach (var subStmt in compoundStmt.Statements)
+        {
+            exited |= WriteStmt(function, context, output, flowContext, subStmt);
+            context.WriteLine(output);
+
+            if (exited) break;
         }
 
         return exited;
     }
+
+    public bool WriteWhileStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, WhileStmt whileStmt)
+    {
+        var function = frame.Function;
+        var flowContext = frame.FlowContext;
+        if (!(whileStmt.Condition is BoolLiteralExpr) && ((BoolLiteralExpr)whileStmt.Condition).Value)
+            throw new ArgumentOutOfRangeException(
+                "While statement condition should always be transformed to constant 'true' during IR simplification.");
+
+        var loopContext = flowContext.FreshLoopContext(context);
+
+        /* Loop body */
+        context.WriteLine(output, "while (true) {");
+        var exited = WriteStmt(function, context, output, loopContext, whileStmt.Body);
+        context.WriteLine(output, "}");
+
+        return exited;
+    }
+
+    public bool WriteIfStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, IfStmt ifStmt)
+    {
+        var function = frame.Function;
+        var flowContext = frame.FlowContext;
+        /* Prologue */
+
+        var condTemp = context.FreshTempVar();
+        Debug.Assert(ifStmt.Condition.Type.IsSameTypeAs(PrimitiveType.Bool));
+        context.Write(output, $"{GetPExType(PrimitiveType.Bool)} {condTemp} = ");
+        this.WriteExpr(context, output, ifStmt.Condition);
+        context.WriteLine(output, ";");
+
+        var thenContext = flowContext.FreshBranchSubContext(context);
+        var elseContext = flowContext.FreshBranchSubContext(context);
+
+        /* Body */
+
+        context.WriteLine(output, $"if ({condTemp}.getValue()) {{");
+        context.WriteLine(output, "// 'then' branch");
+        var exited = WriteStmt(function, context, output, thenContext, ifStmt.ThenBranch);
+        context.WriteLine(output, "}");
+
+        if (!(ifStmt.ElseBranch is null))
+        {
+            context.WriteLine(output, "else {");
+            context.WriteLine(output, "// 'else' branch");
+            exited &= WriteStmt(function, context, output, elseContext, ifStmt.ElseBranch);
+            context.WriteLine(output, "}");
+        }
+
+        return exited;
+    }
+
+    public bool WriteFunCallStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, FunCallStmt funCallStmt)
+    {
+        WriteFunCallStmt(context, output, funCallStmt.Function, funCallStmt.ArgsList);
+        return false;
+    }
+
+    public bool WriteCtorStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, CtorStmt ctorStmt)
+    {
+        WriteCtorExpr(context, output, ctorStmt.Interface, ctorStmt.Arguments);
+        context.WriteLine(output, ";");
+        return false;
+    }
+
+    public bool WriteSendStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, SendStmt sendStmt)
+    {
+        context.Write(output, $"{CompilationContext.CurrentMachine}.sendEvent(");
+        this.WriteExpr(context, output, sendStmt.MachineExpr);
+        context.Write(output, ", ");
+        this.WriteExpr(context, output, sendStmt.Evt);
+        context.Write(output, ", ");
+        if (sendStmt.Arguments.Count == 0)
+            context.Write(output, "null");
+        else if (sendStmt.Arguments.Count == 1)
+            this.WriteExpr(context, output, sendStmt.Arguments[0]);
+        else
+            throw new NotImplementedException(
+                "Send statements with more than one payload argument are not supported");
+        context.WriteLine(output, ");");
+        return false;
+    }
+
+    public bool WriteInsertStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, InsertStmt insertStmt)
+    {
+        var isMap = PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Map);
+        var isSet = PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Set);
+        PLanguageType keyType = null;
+        PLanguageType elementType;
+        if (isMap)
+        {
+            keyType = ((MapType)insertStmt.Variable.Type.Canonicalize()).KeyType;
+            elementType = ((MapType)insertStmt.Variable.Type.Canonicalize()).ValueType;
+        }
+        else if (isSet)
+        {
+            elementType = ((SetType)insertStmt.Variable.Type.Canonicalize()).ElementType;
+        }
+        else
+        {
+            elementType = ((SequenceType)insertStmt.Variable.Type.Canonicalize()).ElementType;
+        }
+
+        WriteWithLValueMutationContext(
+            context,
+            output,
+            insertStmt.Variable,
+            true,
+            structureTemp =>
+            {
+                context.Write(output, $"{structureTemp} = ");
+                context.Write(output, $"(({GetPExType(insertStmt.Variable.Type)}) ");
+                this.WriteExpr(context, output, insertStmt.Variable);
+                context.Write(output, ").add(");
+
+                this.WriteExpr(context, output, insertStmt.Index);
+                context.Write(output, ", ");
+                this.WriteExpr(context, output, insertStmt.Value);
+
+                context.WriteLine(output, ");");
+            }
+        );
+
+        return false;
+    }
+
+    public bool WriteAddStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, AddStmt addStmt)
+    {
+        WriteWithLValueMutationContext(
+            context,
+            output,
+            addStmt.Variable,
+            true,
+            structureTemp =>
+            {
+                context.Write(output, $"{structureTemp} = ");
+                context.Write(output, $"(({GetPExType(addStmt.Variable.Type)}) ");
+                this.WriteExpr(context, output, addStmt.Variable);
+                context.Write(output, ").add(");
+                this.WriteExpr(context, output, addStmt.Value);
+                context.WriteLine(output, ");");
+            }
+        );
+
+        return false;
+    }
+
+    public bool WriteRemoveStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, RemoveStmt removeStmt)
+    {
+        var isMap = PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Map);
+        var isSet = PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Set);
+
+        WriteWithLValueMutationContext(
+            context,
+            output,
+            removeStmt.Variable,
+            true,
+            structureTemp =>
+            {
+                context.Write(output, $"{structureTemp} = ");
+                context.Write(output, $"(({GetPExType(removeStmt.Variable.Type)}) ");
+                this.WriteExpr(context, output, removeStmt.Variable);
+
+                if (isMap || isSet)
+                    context.Write(output, ").remove(");
+                else
+                    context.Write(output, ").removeAt(");
+
+                this.WriteExpr(context, output, removeStmt.Value);
+                context.WriteLine(output, ");");
+            }
+        );
+        return false;
+    }
+
+    public bool WriteAnnounceStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, AnnounceStmt announceStmt)
+    {
+        context.Write(output, $"{CompilationContext.SchedulerVar}.announce(");
+        this.WriteExpr(context, output, announceStmt.Event);
+        context.Write(output, ", ");
+        if (announceStmt.Payload == null)
+            context.Write(output, "null");
+        else
+            this.WriteExpr(context, output, announceStmt.Payload);
+        context.WriteLine(output, ");");
+        return false;
+    }
+
+    // The following statement kinds never reach PEx: its IR lowering replaces foreach with
+    // while, drops no-ops, and splits receives into ReceiveSplitStmt (handled above).
+    public bool WriteForeachStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, ForeachStmt stmt) => throw UnsupportedStmt(stmt, frame);
+    public bool WriteNoStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, NoStmt stmt) => throw UnsupportedStmt(stmt, frame);
+    public bool WriteReceiveStmt(CompilationContext context, StringWriter output, PExStmtFrame frame, ReceiveStmt stmt) => throw UnsupportedStmt(stmt, frame);
+
+    private static NotImplementedException UnsupportedStmt(IPStmt stmt, PExStmtFrame frame) =>
+        new NotImplementedException(
+            $"Statement type '{stmt.GetType().Name}' is not supported, found in {frame.Function.Name}");
 
     private void WriteContinuation(CompilationContext context, StringWriter output, Continuation continuation)
     {

--- a/Src/PCompiler/CompilerCore/Backend/PObserve/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PObserve/MachineGenerator.cs
@@ -592,6 +592,8 @@ namespace Plang.Compiler.Backend.Java {
         public bool WriteReceiveStmt(CompilationContext context, StringWriter output, object frame, ReceiveStmt stmt) => WriteUnsupportedStmt(stmt);
         public bool WriteSendStmt(CompilationContext context, StringWriter output, object frame, SendStmt stmt) => WriteUnsupportedStmt(stmt);
         public bool WriteAnnounceStmt(CompilationContext context, StringWriter output, object frame, AnnounceStmt stmt) => WriteUnsupportedStmt(stmt);
+        public bool WriteAssumeStmt(CompilationContext context, StringWriter output, object frame, AssumeStmt stmt) => WriteUnsupportedStmt(stmt);
+        public bool WriteSwapAssignStmt(CompilationContext context, StringWriter output, object frame, SwapAssignStmt stmt) => WriteUnsupportedStmt(stmt);
 
         private bool WriteUnsupportedStmt(IPStmt stmt)
         {

--- a/Src/PCompiler/CompilerCore/Backend/PObserve/MachineGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PObserve/MachineGenerator.cs
@@ -12,7 +12,8 @@ using Plang.Compiler.TypeChecker.Types;
 
 namespace Plang.Compiler.Backend.Java {
 
-    internal class MachineGenerator : JavaSourceGenerator, IExpressionEmitter<CompilationContext>
+    internal class MachineGenerator : JavaSourceGenerator, IExpressionEmitter<CompilationContext>,
+        IStatementEmitter<CompilationContext, object>
     {
 
         private Machine _currentMachine; // Some generated code is machine-dependent, so stash the current machine here.
@@ -376,195 +377,226 @@ namespace Plang.Compiler.Backend.Java {
             WriteLine($".withExit(this::{fname})");
         }
 
+        // 1-arg convenience wrapper used throughout this generator; routes to the shared
+        // IStatementEmitter dispatch. PObserve threads no per-statement state, so TFrame is
+        // unused (object/null) and every handler returns false.
         private void WriteStmt(IPStmt stmt)
         {
-            TypeManager.JType t;
+            this.WriteStmt(Context, Source.Stream, null, stmt);
+        }
 
-            switch (stmt)
+        public bool WriteAddStmt(CompilationContext context, StringWriter output, object frame, AddStmt addStmt)
+        {
+            var t = Types.JavaTypeFor(addStmt.Variable.Type);
+            WriteExpr(addStmt.Variable);
+            Write($".{t.MutatorMethodName}(");
+            // If mutating a sequence, cast the value to int so that it calls the
+            // expected set method
+            if (PLanguageType.TypeIsOfKind(addStmt.Variable.Type, TypeKind.Sequence))
             {
-                case AddStmt addStmt:
-                    t = Types.JavaTypeFor(addStmt.Variable.Type);
-                    WriteExpr(addStmt.Variable);
-                    Write($".{t.MutatorMethodName}(");
-                    // If mutating a sequence, cast the value to int so that it calls the
-                    // expected set method
-                    if (PLanguageType.TypeIsOfKind(addStmt.Variable.Type, TypeKind.Sequence))
-                    {
-                        Write("(int)");
-                    }
-                    WriteExpr(addStmt.Value);
-                    WriteLine(");");
-                    break;
-
-                case AssertStmt assertStmt:
-                    Write($"{Constants.TryAssertMethodName}(");
-                    WriteExpr(assertStmt.Assertion);
-                    Write(", ");
-                    WriteExpr(assertStmt.Message);
-                    WriteLine(");");
-                    break;
-
-                case AssignStmt assignStmt:
-                    WriteAssignStatement(assignStmt);
-                    break;
-
-                case BreakStmt _:
-                    WriteLine("break;");
-                    break;
-
-                case CompoundStmt compoundStmt:
-                    WriteLine("{");
-                    foreach (var s in compoundStmt.Statements)
-                    {
-                        WriteStmt(s);
-                    }
-                    WriteLine("}");
-                    break;
-
-                case ContinueStmt _:
-                    WriteLine("continue;");
-                    break;
-
-                case CtorStmt _:
-                    goto default;
-
-                case FunCallStmt funCallStmt:
-                    WriteFunctionCallExpr(funCallStmt.Function, funCallStmt.ArgsList);
-                    WriteLine(";");
-                    break;
-
-                case GotoStmt gotoStmt:
-                    Write($"gotoState({Names.IdentForState(gotoStmt.State)}");
-                    if (gotoStmt.Payload != null)
-                    {
-                        Write(", ");
-                        WriteExpr(gotoStmt.Payload);
-                    }
-                    WriteLine(");");
-                    WriteLine("return;");
-                    break;
-
-                case IfStmt ifStmt:
-                    Write("if (");
-                    WriteExpr(ifStmt.Condition);
-                    Write(") ");
-
-                    if (ifStmt.ThenBranch.Statements.Count == 0)
-                    {
-                        WriteLine("{");
-                        WriteLine("}");
-                    }
-                    else
-                    {
-                        WriteStmt(ifStmt.ThenBranch);
-                    }
-
-                    if (ifStmt.ElseBranch != null && ifStmt.ElseBranch.Statements.Count > 0)
-                    {
-                        WriteLine("else");
-                        WriteStmt(ifStmt.ElseBranch);
-                    }
-                    break;
-
-
-                case InsertStmt insertStmt:
-                    t = Types.JavaTypeFor(insertStmt.Variable.Type);
-                    WriteExpr(insertStmt.Variable);
-                    if (PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Sequence))
-                    {
-                        Write($".{t.InsertMethodName}((int)(");
-                    }
-                    else
-                    {
-                        Write($".{t.InsertMethodName}((");
-                    }
-                    WriteExpr(insertStmt.Index);
-                    Write("), ");
-                    WriteExpr(insertStmt.Value);
-                    WriteLine(");");
-                    break;
-
-                case MoveAssignStmt moveAssignStmt:
-                    WriteMoveAssignStatement(moveAssignStmt);
-                    break;
-
-                case NoStmt _:
-                    break;
-
-                case PrintStmt printStmt:
-                    Write("logger.info(");
-                    WriteExpr(printStmt.Message);
-                    WriteLine(");");
-                    break;
-
-                case RaiseStmt raiseStmt:
-                    Write($"{Constants.TryRaiseEventMethodName}(new ");
-                    WriteExpr(raiseStmt.Event);
-                    Write("(");
-                    foreach (var (sep, expr) in raiseStmt.Payload.WithPrefixSep(", "))
-                    {
-                        Write(sep);
-                        WriteExpr(expr);
-                    }
-                    Write(")");
-                    WriteLine(");");
-                    break;
-
-                case ReceiveStmt _:
-                    goto default;
-
-                case RemoveStmt removeStmt:
-                    t = Types.JavaTypeFor(removeStmt.Variable.Type);
-                    WriteExpr(removeStmt.Variable);
-                    Write($".{t.RemoveMethodName}(");
-                    // If removing from a sequence, cast the value to int so that it calls the
-                    // expected remove-by-index method
-                    if (PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Sequence))
-                    {
-                        Write("(int)");
-                    }
-                    WriteExpr(removeStmt.Value);
-                    WriteLine(");");
-                    break;
-
-                case ReturnStmt returnStmt:
-                    Write("return ");
-                    if (returnStmt.ReturnValue != null)
-                    {
-                        WriteExpr(returnStmt.ReturnValue);
-                    }
-                    WriteLine(";");
-                    break;
-
-                case SendStmt _:
-                    goto default;
-
-                case ForeachStmt foreachStmt:
-                {
-                    var varname = Names.GetNameForDecl(foreachStmt.Item);
-                    t = Types.JavaTypeFor(foreachStmt.Item.Type);
-
-                    Write($"for ({t.TypeName} {varname} : ");
-                    WriteExpr(foreachStmt.IterCollection);
-                    Write(") ");
-                    WriteStmt(foreachStmt.Body);
-                    break;
-                }
-                case WhileStmt whileStmt:
-                    Write("while (");
-                    WriteExpr(whileStmt.Condition);
-                    Write(") ");
-                    WriteStmt(whileStmt.Body);
-                    break;
-
-                case AnnounceStmt _:
-                    goto default;
-
-                default:
-                    WriteLine($"// TODO: {stmt}");
-                    return;
-                //throw new NotImplementedException(stmt.GetType().ToString());
+                Write("(int)");
             }
+            WriteExpr(addStmt.Value);
+            WriteLine(");");
+            return false;
+        }
+
+        public bool WriteAssertStmt(CompilationContext context, StringWriter output, object frame, AssertStmt assertStmt)
+        {
+            Write($"{Constants.TryAssertMethodName}(");
+            WriteExpr(assertStmt.Assertion);
+            Write(", ");
+            WriteExpr(assertStmt.Message);
+            WriteLine(");");
+            return false;
+        }
+
+        public bool WriteAssignStmt(CompilationContext context, StringWriter output, object frame, AssignStmt assignStmt)
+        {
+            WriteAssignStatement(assignStmt);
+            return false;
+        }
+
+        public bool WriteBreakStmt(CompilationContext context, StringWriter output, object frame, BreakStmt breakStmt)
+        {
+            WriteLine("break;");
+            return false;
+        }
+
+        public bool WriteCompoundStmt(CompilationContext context, StringWriter output, object frame, CompoundStmt compoundStmt)
+        {
+            WriteLine("{");
+            foreach (var s in compoundStmt.Statements)
+            {
+                WriteStmt(s);
+            }
+            WriteLine("}");
+            return false;
+        }
+
+        public bool WriteContinueStmt(CompilationContext context, StringWriter output, object frame, ContinueStmt continueStmt)
+        {
+            WriteLine("continue;");
+            return false;
+        }
+
+        public bool WriteFunCallStmt(CompilationContext context, StringWriter output, object frame, FunCallStmt funCallStmt)
+        {
+            WriteFunctionCallExpr(funCallStmt.Function, funCallStmt.ArgsList);
+            WriteLine(";");
+            return false;
+        }
+
+        public bool WriteGotoStmt(CompilationContext context, StringWriter output, object frame, GotoStmt gotoStmt)
+        {
+            Write($"gotoState({Names.IdentForState(gotoStmt.State)}");
+            if (gotoStmt.Payload != null)
+            {
+                Write(", ");
+                WriteExpr(gotoStmt.Payload);
+            }
+            WriteLine(");");
+            WriteLine("return;");
+            return false;
+        }
+
+        public bool WriteIfStmt(CompilationContext context, StringWriter output, object frame, IfStmt ifStmt)
+        {
+            Write("if (");
+            WriteExpr(ifStmt.Condition);
+            Write(") ");
+
+            if (ifStmt.ThenBranch.Statements.Count == 0)
+            {
+                WriteLine("{");
+                WriteLine("}");
+            }
+            else
+            {
+                WriteStmt(ifStmt.ThenBranch);
+            }
+
+            if (ifStmt.ElseBranch != null && ifStmt.ElseBranch.Statements.Count > 0)
+            {
+                WriteLine("else");
+                WriteStmt(ifStmt.ElseBranch);
+            }
+            return false;
+        }
+
+        public bool WriteInsertStmt(CompilationContext context, StringWriter output, object frame, InsertStmt insertStmt)
+        {
+            var t = Types.JavaTypeFor(insertStmt.Variable.Type);
+            WriteExpr(insertStmt.Variable);
+            if (PLanguageType.TypeIsOfKind(insertStmt.Variable.Type, TypeKind.Sequence))
+            {
+                Write($".{t.InsertMethodName}((int)(");
+            }
+            else
+            {
+                Write($".{t.InsertMethodName}((");
+            }
+            WriteExpr(insertStmt.Index);
+            Write("), ");
+            WriteExpr(insertStmt.Value);
+            WriteLine(");");
+            return false;
+        }
+
+        public bool WriteMoveAssignStmt(CompilationContext context, StringWriter output, object frame, MoveAssignStmt moveAssignStmt)
+        {
+            WriteMoveAssignStatement(moveAssignStmt);
+            return false;
+        }
+
+        public bool WriteNoStmt(CompilationContext context, StringWriter output, object frame, NoStmt noStmt)
+        {
+            return false;
+        }
+
+        public bool WritePrintStmt(CompilationContext context, StringWriter output, object frame, PrintStmt printStmt)
+        {
+            Write("logger.info(");
+            WriteExpr(printStmt.Message);
+            WriteLine(");");
+            return false;
+        }
+
+        public bool WriteRaiseStmt(CompilationContext context, StringWriter output, object frame, RaiseStmt raiseStmt)
+        {
+            Write($"{Constants.TryRaiseEventMethodName}(new ");
+            WriteExpr(raiseStmt.Event);
+            Write("(");
+            foreach (var (sep, expr) in raiseStmt.Payload.WithPrefixSep(", "))
+            {
+                Write(sep);
+                WriteExpr(expr);
+            }
+            Write(")");
+            WriteLine(");");
+            return false;
+        }
+
+        public bool WriteRemoveStmt(CompilationContext context, StringWriter output, object frame, RemoveStmt removeStmt)
+        {
+            var t = Types.JavaTypeFor(removeStmt.Variable.Type);
+            WriteExpr(removeStmt.Variable);
+            Write($".{t.RemoveMethodName}(");
+            // If removing from a sequence, cast the value to int so that it calls the
+            // expected remove-by-index method
+            if (PLanguageType.TypeIsOfKind(removeStmt.Variable.Type, TypeKind.Sequence))
+            {
+                Write("(int)");
+            }
+            WriteExpr(removeStmt.Value);
+            WriteLine(");");
+            return false;
+        }
+
+        public bool WriteReturnStmt(CompilationContext context, StringWriter output, object frame, ReturnStmt returnStmt)
+        {
+            Write("return ");
+            if (returnStmt.ReturnValue != null)
+            {
+                WriteExpr(returnStmt.ReturnValue);
+            }
+            WriteLine(";");
+            return false;
+        }
+
+        public bool WriteForeachStmt(CompilationContext context, StringWriter output, object frame, ForeachStmt foreachStmt)
+        {
+            var varname = Names.GetNameForDecl(foreachStmt.Item);
+            var t = Types.JavaTypeFor(foreachStmt.Item.Type);
+
+            Write($"for ({t.TypeName} {varname} : ");
+            WriteExpr(foreachStmt.IterCollection);
+            Write(") ");
+            WriteStmt(foreachStmt.Body);
+            return false;
+        }
+
+        public bool WriteWhileStmt(CompilationContext context, StringWriter output, object frame, WhileStmt whileStmt)
+        {
+            Write("while (");
+            WriteExpr(whileStmt.Condition);
+            Write(") ");
+            WriteStmt(whileStmt.Body);
+            return false;
+        }
+
+        // The following statement kinds cannot appear in P specification monitors (the only
+        // thing PObserve generates code for); preserve the prior behavior of emitting a TODO
+        // marker rather than failing.
+        public bool WriteCtorStmt(CompilationContext context, StringWriter output, object frame, CtorStmt stmt) => WriteUnsupportedStmt(stmt);
+        public bool WriteReceiveStmt(CompilationContext context, StringWriter output, object frame, ReceiveStmt stmt) => WriteUnsupportedStmt(stmt);
+        public bool WriteSendStmt(CompilationContext context, StringWriter output, object frame, SendStmt stmt) => WriteUnsupportedStmt(stmt);
+        public bool WriteAnnounceStmt(CompilationContext context, StringWriter output, object frame, AnnounceStmt stmt) => WriteUnsupportedStmt(stmt);
+
+        private bool WriteUnsupportedStmt(IPStmt stmt)
+        {
+            WriteLine($"// TODO: {stmt}");
+            return false;
         }
 
         private void WriteAssignStatement(AssignStmt assignStmt)


### PR DESCRIPTION
## Summary

Mirrors the `IExpressionEmitter` design (#954) for **statements**: all three imperative backends (PChecker, PEx, PObserve) share one dispatch over `IPStmt`, so adding a statement node forces every backend to handle it (or explicitly throw) or fail to compile.

Adds **`IStatementEmitter<TContext, TFrame>`** + a static dispatch extension over the **22 general `IPStmt` nodes**. Two backend differences are absorbed by the contract's shape:

| | PChecker | PEx | PObserve |
|---|---|---|---|
| **`TFrame`** (per-stmt state) | `Function` | `PExStmtFrame(Function, ControlFlowContext)` | `object` (unused) |
| **`bool` result** ("exited") | `false` (ignored) | real value (its former `\|=`/`&=`) | `false` (ignored) |

- **PEx** keeps a thin 5-arg `WriteStmt` wrapper for call-in-assignment lowering and its own `ReceiveSplitStmt` (a PEx-internal node, not part of the shared contract), delegating the 22 general nodes to the shared dispatch.
- Nodes a backend's IR never produces are explicit throws — **PEx**: `Foreach`/`No`/`Receive`.
- **PObserve** preserves its prior `// TODO:` marker for statements illegal in monitors (`Ctor`/`Receive`/`Send`/`Announce`) rather than changing output.

> **Stacked on #955** (the one-line master build fix) — that base will retarget to `master` once #955 merges. The statement commit itself is a single, self-contained change.

## Verification (local, .NET 8)
- Builds clean (only the unrelated pre-existing `TransformASTPass.cs:796` CS0162 warning).
- **Generated output is byte-for-byte identical to master for all three backends** across Tutorials 1–6 (`diff -rq`, ignoring PObserve's per-run timestamp header) — including the risky PEx control-flow (`bool`-exited) conversion.
- Full `UnitTests` suite: **396 passed, 0 failed**.


---
_Generated by [Claude Code](https://claude.ai/code/session_012yYFn7Lc59CuqXdPcdSREX)_