### PR TITLE
Fix Tier-1 correctness issues from code review (CLI modes, float culture, type-check, error handling)

### DIFF
--- a/Src/PCompiler/CompilerCore/Backend/CompiledFile.cs
+++ b/Src/PCompiler/CompilerCore/Backend/CompiledFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Globalization;
+using System.IO;
 
 namespace Plang.Compiler.Backend
 {
@@ -10,7 +11,8 @@ namespace Plang.Compiler.Backend
         }
 
         public string FileName { get; }
-        public StringWriter Stream { get; } = new StringWriter();
+        // Invariant culture so generated numeric literals don't depend on the host locale.
+        public StringWriter Stream { get; } = new StringWriter(CultureInfo.InvariantCulture);
         public string Contents => Stream.GetStringBuilder().ToString();
     }
 }

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1491,7 +1492,7 @@ namespace Plang.Compiler.Backend.CSharp
 
         public void WriteFloatLiteralExpr(CompilationContext context, StringWriter output, FloatLiteralExpr floatLiteralExpr)
         {
-            context.Write(output, $"((PFloat){floatLiteralExpr.Value})");
+            context.Write(output, $"((PFloat){floatLiteralExpr.Value.ToString(CultureInfo.InvariantCulture)})");
         }
 
         public void WriteFunCallExpr(CompilationContext context, StringWriter output, FunCallExpr funCallExpr)

--- a/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PEx/PExCodeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -1696,7 +1697,7 @@ internal class PExCodeGenerator : ICodeGenerator, IExpressionEmitter<Compilation
 
     public void WriteFloatLiteralExpr(CompilationContext context, StringWriter output, FloatLiteralExpr floatLiteralExpr)
     {
-        var unguarded = $"new {GetPExType(PrimitiveType.Float)}({floatLiteralExpr.Value}f)";
+        var unguarded = $"new {GetPExType(PrimitiveType.Float)}({floatLiteralExpr.Value.ToString(CultureInfo.InvariantCulture)}f)";
         context.Write(output, unguarded);
     }
 

--- a/Src/PCompiler/CompilerCore/Backend/PObserve/TypeManager.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PObserve/TypeManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using Plang.Compiler.TypeChecker.AST;
 using Plang.Compiler.TypeChecker.AST.Expressions;
@@ -157,7 +158,7 @@ namespace Plang.Compiler.Backend.Java
 
                 internal static string ToJavaLiteral(double d)
                 {
-                    return d + "f";
+                    return d.ToString(CultureInfo.InvariantCulture) + "f";
                 }
             }
 

--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -40,7 +40,7 @@ namespace Plang.Compiler
                 Environment.ExitCode = 1;
                 return Environment.ExitCode;
             }
-            catch (IOException e)
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
             {
                 // A missing/locked/unreadable input .p file should be a clean error, not a crash.
                 job.Output.WriteError("[Parser Error:]\n" + e.Message);

--- a/Src/PCompiler/CompilerCore/Compiler.cs
+++ b/Src/PCompiler/CompilerCore/Compiler.cs
@@ -40,6 +40,13 @@ namespace Plang.Compiler
                 Environment.ExitCode = 1;
                 return Environment.ExitCode;
             }
+            catch (IOException e)
+            {
+                // A missing/locked/unreadable input .p file should be a clean error, not a crash.
+                job.Output.WriteError("[Parser Error:]\n" + e.Message);
+                Environment.ExitCode = 1;
+                return Environment.ExitCode;
+            }
 
             job.Output.WriteInfo("Type checking ...");
             // Run type checker and produce AST

--- a/Src/PCompiler/CompilerCore/TypeChecker/MachineChecker.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/MachineChecker.cs
@@ -27,8 +27,10 @@ namespace Plang.Compiler.TypeChecker
         {
             var startState = FindStartState(machine, handler);
             machine.PayloadType = GetStatePayload(startState);
-            gScope.Get(machine.Name, out Interface @interface);
-            @interface.PayloadType = machine.PayloadType;
+            if (gScope.Get(machine.Name, out Interface @interface))
+            {
+                @interface.PayloadType = machine.PayloadType;
+            }
         }
 
         private static void ValidateSpecObservesList(ITranslationErrorHandler handler, Machine machine, ICompilerConfiguration job)

--- a/Src/PCompiler/CompilerCore/TypeChecker/StatementVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/StatementVisitor.cs
@@ -240,7 +240,7 @@ namespace Plang.Compiler.TypeChecker
         public override IPStmt VisitWhileStmt(PParser.WhileStmtContext context)
         {
             var condition = exprVisitor.Visit(context.expr());
-            if (!Equals(condition.Type, PrimitiveType.Bool))
+            if (!PrimitiveType.Bool.IsSameTypeAs(condition.Type))
             {
                 throw handler.TypeMismatch(context.expr(), condition.Type, PrimitiveType.Bool);
             }
@@ -291,7 +291,7 @@ namespace Plang.Compiler.TypeChecker
         public override IPStmt VisitIfStmt(PParser.IfStmtContext context)
         {
             var condition = exprVisitor.Visit(context.expr());
-            if (!Equals(condition.Type, PrimitiveType.Bool))
+            if (!PrimitiveType.Bool.IsSameTypeAs(condition.Type))
             {
                 throw handler.TypeMismatch(context.expr(), condition.Type, PrimitiveType.Bool);
             }

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -14,6 +14,30 @@ namespace Plang.Options
     public sealed class PCheckerOptions
     {
         /// <summary>
+        /// The accepted values for <c>--mode</c>. Both the parser's allowed-values list and
+        /// the exhaustive input domain of <see cref="ParseCheckerMode"/>; the two must stay
+        /// in sync (an allowed-but-unmapped mode would be rejected at runtime).
+        /// </summary>
+        internal static readonly string[] CheckerModes = { "bugfinding", "pex" };
+
+        /// <summary>
+        /// Maps a <c>--mode</c> value to its <see cref="CheckerMode"/>. Throws if the mode is
+        /// not one of <see cref="CheckerModes"/>.
+        /// </summary>
+        internal static CheckerMode ParseCheckerMode(string mode)
+        {
+            switch (mode.ToLowerInvariant())
+            {
+                case "bugfinding":
+                    return CheckerMode.BugFinding;
+                case "pex":
+                    return CheckerMode.PEx;
+                default:
+                    throw new Exception($"Invalid checker mode '{mode}'.");
+            }
+        }
+
+        /// <summary>
         /// The command line parser to use.
         /// </summary>
         private readonly CommandLineArgumentParser Parser;
@@ -31,7 +55,7 @@ namespace Plang.Options
             basicOptions.AddPositionalArgument("path", "Path to the compiled file to check for correctness (*.dll)."+
                                                        " If this option is not passed, the compiler searches for a *.dll file in the current folder").IsRequired = false;
             var modes = basicOptions.AddArgument("mode", "md", "Checker mode to use. Can be bugfinding or pex. If this option is not passed, bugfinding mode is used as default");
-            modes.AllowedValues = new List<string>() { "bugfinding", "pex", "pobserve"};
+            modes.AllowedValues = CheckerModes.ToList();
             basicOptions.AddArgument("testcase", "tc", "Test case to explore");
             // basicOptions.AddArgument("smoke-testing", "tsmoke",
             //     "Smoke test the program by running the checker on all the test cases", typeof(bool));
@@ -181,18 +205,7 @@ namespace Plang.Options
                     checkerConfiguration.AssemblyToBeAnalyzed = (string)option.Value;
                     break;
                 case "mode":
-                    switch ((string)option.Value)
-                    {
-                        case "bugfinding":
-                            checkerConfiguration.Mode = CheckerMode.BugFinding;
-                            break;
-                        case "pex":
-                            checkerConfiguration.Mode = CheckerMode.PEx;
-                            break;
-                        default:
-                            Error.CheckerReportAndExit($"Invalid checker mode '{option.Value}'.");
-                            break;
-                    }
+                    checkerConfiguration.Mode = ParseCheckerMode((string)option.Value);
                     break;
                 case "testcase":
                     checkerConfiguration.TestCaseName = (string)option.Value;

--- a/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCompilerOptions.cs
@@ -11,6 +11,37 @@ namespace Plang.Options
     internal sealed class PCompilerOptions
     {
         /// <summary>
+        /// The accepted values for <c>--mode</c>. This is both the parser's allowed-values
+        /// list and the exhaustive input domain of <see cref="ParseCompilerMode"/>; the two
+        /// must stay in sync (a mode that is allowed but unmapped would crash at runtime).
+        /// </summary>
+        internal static readonly string[] CompilerModes =
+            { "bugfinding", "pchecker", "pex", "pobserve", "verification", "pverifier" };
+
+        /// <summary>
+        /// Maps a <c>--mode</c> value to its target backend. Throws if the mode is not one
+        /// of <see cref="CompilerModes"/>.
+        /// </summary>
+        internal static CompilerOutput ParseCompilerMode(string mode)
+        {
+            switch (mode.ToLowerInvariant())
+            {
+                case "bugfinding":
+                case "pchecker":
+                    return CompilerOutput.PChecker;
+                case "pex":
+                    return CompilerOutput.PEx;
+                case "pobserve":
+                    return CompilerOutput.PObserve;
+                case "verification":
+                case "pverifier":
+                    return CompilerOutput.PVerifier;
+                default:
+                    throw new Exception($"Unexpected mode: '{mode}'");
+            }
+        }
+
+        /// <summary>
         /// The command line parser to use.
         /// </summary>
         private readonly CommandLineArgumentParser Parser;
@@ -38,8 +69,8 @@ namespace Plang.Options
             pfilesGroup.AddArgument("projname", "pn", "Project name for the compiled output");
             pfilesGroup.AddArgument("outdir", "o", "Dump output to directory (absolute or relative path)");
 
-            var modes = Parser.AddArgument("mode", "md", "Compilation mode to use. Can be bugfinding, pex, or pobserve. If this option is not passed, bugfinding mode is used as default");
-            modes.AllowedValues = new List<string>() { "bugfinding", "pex", "pobserve", "verification", "coverage" };
+            var modes = Parser.AddArgument("mode", "md", "Compilation mode to use. Can be bugfinding (alias pchecker), pex, pobserve, or verification (alias pverifier). If this option is not passed, bugfinding mode is used as default");
+            modes.AllowedValues = CompilerModes.ToList();
 
             Parser.AddArgument("pobserve-package", "po", "PObserve package name").IsHidden = true;
 
@@ -147,21 +178,10 @@ namespace Plang.Options
                     compilerConfiguration.Parallelism = (int)option.Value;
                     break;
                 case "mode":
-                    compilerConfiguration.OutputLanguages = new List<CompilerOutput>();
-                    switch (((string)option.Value).ToLowerInvariant())
+                    compilerConfiguration.OutputLanguages = new List<CompilerOutput>
                     {
-                        case "pchecker":
-                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.PChecker);
-                            break;
-                        case "pex":
-                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.PEx);
-                            break;
-                        case "pobserve":
-                            compilerConfiguration.OutputLanguages.Add(CompilerOutput.PObserve);
-                            break;
-                        default:
-                            throw new Exception($"Unexpected mode: '{option.Value}'");
-                    }
+                        ParseCompilerMode((string)option.Value)
+                    };
                     break;
                 case "pobserve-package":
                     compilerConfiguration.PObservePackageName = (string)option.Value;

--- a/Src/PCompiler/PCommandLine/PCommandLine.csproj
+++ b/Src/PCompiler/PCommandLine/PCommandLine.csproj
@@ -22,6 +22,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="UnitTests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\PChecker\CheckerCore\CheckerCore.csproj" />
     <ProjectReference Include="..\CompilerCore\CompilerCore.csproj" />
     <None Include="../../../Icon/icon.png" Pack="true" PackagePath="" />

--- a/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
+++ b/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
@@ -67,6 +67,15 @@ namespace Plang.Parser
             {
                 Error.ReportAndExit($"<Error parsing project file>:\n {ex.Message}");
             }
+            catch (System.Xml.XmlException xe)
+            {
+                // Malformed .pproj XML is a user error, not an internal compiler bug.
+                Error.ReportAndExit($"<Error parsing project file>:\n malformed XML: {xe.Message}");
+            }
+            catch (IOException ioe)
+            {
+                Error.ReportAndExit($"<Error parsing project file>:\n {ioe.Message}");
+            }
             catch (Exception other)
             {
                 Error.ReportAndExit($"<Internal Error>:\n {other.Message}\n <Please report to the P team or create a issue on GitHub, Thanks!>");
@@ -94,6 +103,15 @@ namespace Plang.Parser
             catch (CommandlineParsingError ex)
             {
                 Error.ReportAndExit($"<Error parsing project file>:\n {ex.Message}");
+            }
+            catch (System.Xml.XmlException xe)
+            {
+                // Malformed .pproj XML is a user error, not an internal compiler bug.
+                Error.ReportAndExit($"<Error parsing project file>:\n malformed XML: {xe.Message}");
+            }
+            catch (IOException ioe)
+            {
+                Error.ReportAndExit($"<Error parsing project file>:\n {ioe.Message}");
             }
             catch (Exception other)
             {
@@ -188,8 +206,9 @@ namespace Plang.Parser
         private DirectoryInfo GetOutputDirectory(FileInfo fullPathName)
         {
             var projectXml = XElement.Load(fullPathName.FullName);
-            if (projectXml.Elements("OutputDir").Any())
-                return Directory.CreateDirectory(projectXml.Element("OutputDir")?.Value);
+            var outputDir = projectXml.Element("OutputDir")?.Value;
+            if (!string.IsNullOrWhiteSpace(outputDir))
+                return Directory.CreateDirectory(outputDir);
             return new DirectoryInfo(Directory.GetCurrentDirectory());
         }
 
@@ -236,7 +255,7 @@ namespace Plang.Parser
                             break;
                         default:
                             throw new CommandlineParsingError(
-                                $"Expected PChecker, PObserve, PVerifier, or Symbolic as target, received {projectXml.Element("Target")?.Value}");
+                                $"Expected PChecker, PEx, PObserve, or PVerifier as target, received {projectXml.Element("Target")?.Value}");
                     }
                 }
             }

--- a/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
+++ b/Src/PCompiler/PCommandLine/Parser/ParsePProjectFile.cs
@@ -220,8 +220,9 @@ namespace Plang.Parser
         private string GetOutputDirectoryName(FileInfo fullPathName)
         {
             var projectXml = XElement.Load(fullPathName.FullName);
-            if (projectXml.Elements("OutputDir").Any())
-                return projectXml.Element("OutputDir")?.Value;
+            var outputDir = projectXml.Element("OutputDir")?.Value;
+            if (!string.IsNullOrWhiteSpace(outputDir))
+                return outputDir;
             return Directory.GetCurrentDirectory();
         }
 

--- a/Tst/UnitTests/CompilerModeTests.cs
+++ b/Tst/UnitTests/CompilerModeTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using Plang.Compiler;
+using Plang.Options;
+using PChecker;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Guards the CLI <c>--mode</c> handling. The bug these protect against: an `--mode`
+    /// value that the parser accepts (in AllowedValues) but the handler doesn't map, which
+    /// makes a documented mode crash at runtime (regression introduced in the P 3.0 rename).
+    /// </summary>
+    [TestFixture]
+    public class CompilerModeTests
+    {
+        [Test]
+        public void EveryAllowedCompilerModeMapsWithoutThrowing()
+        {
+            foreach (var mode in PCompilerOptions.CompilerModes)
+            {
+                Assert.DoesNotThrow(() => PCompilerOptions.ParseCompilerMode(mode),
+                    $"--mode {mode} is in AllowedValues but is not handled.");
+            }
+        }
+
+        [Test]
+        public void CompilerModeMappings()
+        {
+            Assert.AreEqual(CompilerOutput.PChecker, PCompilerOptions.ParseCompilerMode("bugfinding"));
+            Assert.AreEqual(CompilerOutput.PChecker, PCompilerOptions.ParseCompilerMode("pchecker"));
+            Assert.AreEqual(CompilerOutput.PEx, PCompilerOptions.ParseCompilerMode("pex"));
+            Assert.AreEqual(CompilerOutput.PObserve, PCompilerOptions.ParseCompilerMode("pobserve"));
+            Assert.AreEqual(CompilerOutput.PVerifier, PCompilerOptions.ParseCompilerMode("verification"));
+            Assert.AreEqual(CompilerOutput.PVerifier, PCompilerOptions.ParseCompilerMode("pverifier"));
+        }
+
+        [Test]
+        public void CompilerModeIsCaseInsensitive()
+        {
+            Assert.AreEqual(CompilerOutput.PChecker, PCompilerOptions.ParseCompilerMode("BugFinding"));
+        }
+
+        [Test]
+        public void UnknownCompilerModeThrows()
+        {
+            Assert.Throws<System.Exception>(() => PCompilerOptions.ParseCompilerMode("nonsense"));
+        }
+
+        [Test]
+        public void EveryAllowedCheckerModeMapsWithoutThrowing()
+        {
+            foreach (var mode in PCheckerOptions.CheckerModes)
+            {
+                Assert.DoesNotThrow(() => PCheckerOptions.ParseCheckerMode(mode),
+                    $"checker --mode {mode} is in AllowedValues but is not handled.");
+            }
+        }
+
+        [Test]
+        public void CheckerModeMappings()
+        {
+            Assert.AreEqual(CheckerMode.BugFinding, PCheckerOptions.ParseCheckerMode("bugfinding"));
+            Assert.AreEqual(CheckerMode.PEx, PCheckerOptions.ParseCheckerMode("pex"));
+        }
+    }
+}


### PR DESCRIPTION
First of three PRs addressing the multi-agent code review. This one is the **Tier-1 correctness fixes** + the tests that guard them.

## Fixes

**1. CLI `--mode` crash (regression from the P 3.0 rename, #903, ~9 months old).** The parser's allowed-values and the handler `switch` had drifted: `p compile --mode bugfinding` (the *documented default*), `--mode verification`, and `--mode coverage` validated then threw `"Unexpected mode"`, while `pchecker` was unreachable; on the checker side `--mode pobserve` was allowed but unmapped. Now:
- `bugfinding`/`pchecker` → `PChecker`, `pex` → `PEx`, `pobserve` → `PObserve`, `verification`/`pverifier` → `PVerifier`; dropped the unbacked `coverage` and the checker's `pobserve`.
- Mapping extracted into `internal ParseCompilerMode`/`ParseCheckerMode` + shared `CompilerModes`/`CheckerModes` lists used for *both* the allowed-values and the handler, so they can't silently drift again.

**2. Invariant-culture float emission** (locale-dependent miscompile). PChecker (`:1494`), PEx (`:1699`), PObserve (`TypeManager.ToJavaLiteral`) emitted `double` literals via current-culture formatting → comma-decimal locales produced uncompilable C#/Java. All three now use `InvariantCulture`, and `CompiledFile.Stream` is backed by `StringWriter(InvariantCulture)`. **Byte-identical on dot-decimal locales.**

**3. Type checker:** `while`/`if` condition used object `Equals` instead of `IsSameTypeAs` (`StatementVisitor.cs:243,294`), wrongly rejecting a `bool` aliased via `type T = bool;`. `MachineChecker.InitializeContructorType` ignored a `Scope.Get` result → null-deref guard added.

**4. Error handling:** `Compiler.Compile` catches `IOException` (missing/locked `.p` → clean error, not a raw crash); `ParsePProjectFile` reports malformed-XML / IO as user errors instead of "Internal Error / report to P team", guards an empty `<OutputDir>`, and fixes a stale "Symbolic" target message.

## Tests
- New `CompilerModeTests` (6) — asserts **every** allowed `--mode` maps without throwing (the exact invariant that broke) plus the specific mappings. These fail on pre-fix code.
- Restored `InternalsVisibleTo("UnitTests")` on `PCommandLine`.

## Verification
- Build clean (the one remaining `CS0162` in `TransformASTPass` is pre-existing — removed in the follow-up cleanup PR).
- Focused `CompilerModeTests` pass; full `UnitTests` suite run in progress (will confirm no codegen regression; the float change is byte-identical on this dot-decimal host).

Follow-ups: **PR 2** (remove dead while-recursion code + Tier-3 minor cleanups), **PR 3** (AST-exhaustiveness + golden tests, `Scope.Lookup` dedup, PObserve monitor-illegal throws).


---
_Generated by [Claude Code](https://claude.ai/code/session_012yYFn7Lc59CuqXdPcdSREX)_