### PR TITLE
Pin README CI badges to the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 [![NuGet](https://img.shields.io/nuget/v/p.svg)](https://www.nuget.org/packages/P/)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/p-org/P/master/LICENSE.txt)
-![GitHub Action (CI on Windows)](https://github.com/p-org/P/workflows/CI%20on%20Windows/badge.svg)
-![GitHub Action (CI on Ubuntu)](https://github.com/p-org/P/workflows/CI%20on%20Ubuntu/badge.svg)
-![GitHub Action (CI on MacOS)](https://github.com/p-org/P/workflows/CI%20on%20MacOS/badge.svg)
-[![Tutorials](https://github.com/p-org/P/actions/workflows/tutorials.yml/badge.svg)](https://github.com/p-org/P/actions/workflows/tutorials.yml)
+![GitHub Action (CI on Windows)](https://github.com/p-org/P/workflows/CI%20on%20Windows/badge.svg?branch=master)
+![GitHub Action (CI on Ubuntu)](https://github.com/p-org/P/workflows/CI%20on%20Ubuntu/badge.svg?branch=master)
+![GitHub Action (CI on MacOS)](https://github.com/p-org/P/workflows/CI%20on%20MacOS/badge.svg?branch=master)
+[![Tutorials](https://github.com/p-org/P/actions/workflows/tutorials.yml/badge.svg?branch=master)](https://github.com/p-org/P/actions/workflows/tutorials.yml?query=branch%3Amaster)
 
 ---
 


### PR DESCRIPTION
## Summary

The README CI badges had **no branch filter**, so each badge showed the status of the most recent run of that workflow on *any* branch — including failed runs on feature/PR branches and the superseded PR merge-ref `actions/checkout` failures. That made the repo look "red" on the home page even when **master** was green.

Adds `?branch=master` to all four CI badges (Windows / Ubuntu / macOS / Tutorials) so they report **default-branch** status, and points the Tutorials badge link at the master-filtered runs.

## Verification
I queried the master-pinned badge endpoints — all five workflows (ubuntuci, windowsci, macosci, pex, tutorials) report **passing** on master. So the home page will now reflect that instead of stray non-master run statuses.

Docs/markdown-only change; no code impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_012yYFn7Lc59CuqXdPcdSREX)_