### PR TITLE
Docs: multi-error compilation user/contributor docs + stale comment refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,79 @@ p compile --mode pex
 
 # Run model checking with PEx backend
 p check --mode pex
+
+# Multi-error compilation — report ALL type errors in one pass
+# instead of aborting on the first. Default is strict (one error,
+# exit 1). Errors are sorted by source location.
+P_COMPILER_COLLECT_ERRORS=1 p compile
 ```
+
+## Multi-Error Type Checking (Compiler)
+
+The C# compiler under `Src/PCompiler/CompilerCore/` supports a **collecting
+mode** that gathers diagnostics through `IDiagnosticCollector` instead of
+throwing on the first error. Opt in via the `P_COMPILER_COLLECT_ERRORS=1`
+environment variable. Default (strict) mode is bit-for-bit identical to
+pre-3.0 behavior for valid programs and same exit code on invalid programs.
+
+### Architecture
+
+- **`IDiagnosticCollector` / `DefaultDiagnosticCollector`** — strict mode
+  rethrows immediately; collecting mode appends to a list, returns, and the
+  collector is flushed at end of compilation via
+  `Compiler.FlushCollectedDiagnostics`.
+- **`ErrorType` (singleton sentinel) / `ErrorExpr`** — substituted for
+  failed-to-type-check expressions in collecting mode. `ErrorType` claims
+  compatibility with every other type so downstream compatibility checks
+  cascade-suppress (one root-cause error doesn't generate a chain of
+  "incompatible operand" diagnostics).
+- **`PLanguageType.IsSameTypeAs`** has a symmetric short-circuit when either
+  side is `ErrorType`.
+- **`TypeCheckingUtils.CheckAssignable`** is the cascade-aware compatibility
+  check helper; visitors should route compatibility checks through this
+  helper rather than calling `IsAssignableFrom` directly.
+- **`Analyzer.TolerantStep`** is the per-pass-item analog: it wraps each
+  iteration in `try { body() } catch (TranslationException) when (collecting)`
+  so one bad machine/function doesn't clobber siblings' diagnostics.
+
+### When adding a new throw site in a visitor
+
+Follow the convention in `ExprVisitor.cs`'s class doc:
+
+1. **Visit children first** — so their internal errors surface even if the
+   parent lookup fails.
+2. **Short-circuit on `ErrorType`** — `if (subExpr.Type is ErrorType) return new ErrorExpr(context);`
+   at the top of each method after visiting children.
+3. **Convert each `throw handler.X(...)` to**:
+   ```csharp
+   handler.Diagnostics.Report(handler.X(...));
+   return new ErrorExpr(context);  // or new NoStmt(context) for statements
+   ```
+4. **Route compatibility checks through `CheckAssignable`** — it auto-suppresses
+   when either side is `ErrorType`.
+
+For statements that can't be reconstructed (missing variable/interface/function/state/event), return `new NoStmt(context)` instead of an `ErrorExpr`-bearing statement.
+
+### When adding a new analyzer pass
+
+If it iterates per-machine, per-function, or per-item:
+
+```csharp
+foreach (var thing in scope.Things)
+{
+    TolerantStep(handler, () => DoStuffWith(thing));
+}
+```
+
+This way, one bad item doesn't abort the pass for siblings in collecting mode. The `when (ContinueOnError)` filter on `TolerantStep`'s catch preserves strict-mode bit-for-bit. Place the new pass behind the existing `if (handler.Diagnostics.HasErrors) return globalScope;` gate in `Analyzer.cs` if it assumes a fully-typed AST (most "analysis" passes — propagations, capability checks, module-system passes).
+
+### Test fixtures
+
+- **`Tst/UnitTests/TypeChecker/DiagnosticCollectorTest.cs`** — collector contract + env-var parsing
+- **`Tst/UnitTests/TypeChecker/Phase1DormancyTest.cs`** — iterates every Correct/StaticError dir; asserts both modes succeed on Correct/ and that collecting count ≥ strict count on StaticError/
+- **`Tst/UnitTests/TypeChecker/MultiErrorAcceptanceTest.cs`** — `[TestCaseSource]` with pinned strict/collecting counts on curated multi-error files under `Tst/RegressionTests/Feature3Exprs/StaticError/`
+
+When adding a new pinned test, add a row to `MultiErrorAcceptanceTest.PinnedCases()` with the file path, expected strict count, expected collecting count, and a one-paragraph description of which cascade rule or recovery path it exercises.
 
 ### Working with PeasyAI
 

--- a/ChangeList.md
+++ b/ChangeList.md
@@ -1,6 +1,20 @@
 P 3.0 Changes
 
-=== First PL === 
+=== Multi-Error Type Checker (#957, #963, #965) ===
+- Opt-in via `P_COMPILER_COLLECT_ERRORS=1` environment variable.
+- When enabled, `p compile` reports all type errors in one pass instead of
+  aborting on the first error. Errors are sorted by source location.
+- Cascade-suppression rules (ErrorType/ErrorExpr sentinels +
+  `TypeCheckingUtils.CheckAssignable`) prevent one root-cause error from
+  generating downstream "incompatible operand" noise.
+- Cross-machine `<state>` lookup (in `x is <state>` test expressions) now
+  resolves against the instance's specific machine; same-named states in
+  unrelated machines no longer bind silently (#963).
+- Default behavior (env var unset) is unchanged — strict mode still
+  aborts on the first error, bit-for-bit identical to pre-3.0 behavior
+  for valid programs and same exit code on invalid programs.
+
+=== First PL ===
 - branch: `dev_p3.0/cleanup_targets`
 - Targets have been renamed to `PChecker`, `PObserve`, and `Stately`; `PVerifier` and `PExhaustive` to be added later.
 - Removed `Symbolic` and other engines around it.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ Validate that production systems conform to their formal P specifications.
 
 👉 [Learn about PObserve](https://p-org.github.io/P/advanced/pobserve/pobserve/)
 
+### Multi-Error Compilation
+
+Set `P_COMPILER_COLLECT_ERRORS=1` to make `p compile` report ALL type errors
+in one pass instead of aborting on the first. Errors are sorted by source
+location with cascade-suppression so root causes surface without downstream
+noise.
+
+```bash
+$ P_COMPILER_COLLECT_ERRORS=1 p compile
+[Error:] [bad.p:6:4] got type: bool, expected: int
+[Error:] [bad.p:8:13] could not find variable 'undeclaredVar'
+[Error:] [bad.p:9:16] incompatible binary operands int and string
+```
+
+Particularly useful with AI fix loops (PeasyAI, Cursor) and large refactors —
+fix N errors per LLM round-trip instead of N round-trips per N errors.
+
 ## The P Framework
 
 | Component | Description |

--- a/Src/PCompiler/CompilerCore/IDiagnosticCollector.cs
+++ b/Src/PCompiler/CompilerCore/IDiagnosticCollector.cs
@@ -12,16 +12,32 @@ namespace Plang.Compiler
     ///     the historical "fail on first error" behavior. The compiler unwinds
     ///     to the top-level catch in <c>Compiler.cs</c>.
     ///   - Collecting (<see cref="ContinueOnError"/> == true):
-    ///     <see cref="Report"/> appends the diagnostic and returns. Callers are
-    ///     responsible for substituting a recovery value (e.g.
-    ///     <c>ErrorType.Instance</c> or <c>new ErrorExpr(ctx)</c>) so downstream
-    ///     visitors can continue without NREs. The compiler flushes the full
-    ///     list after type-checking completes and exits with a non-zero code
-    ///     if any errors were collected.
+    ///     <see cref="Report"/> appends the diagnostic and returns. Callers
+    ///     substitute a recovery value (e.g. <see cref="Plang.Compiler.TypeChecker.Types.ErrorType"/>.Instance or
+    ///     <c>new ErrorExpr(ctx)</c>) so downstream visitors continue without
+    ///     NREs. The compiler flushes the full list (sorted by source location)
+    ///     after type-checking completes and exits with a non-zero code if any
+    ///     errors were collected.
     ///
-    /// Phase 1 wiring only — no visitor currently calls <see cref="Report"/>.
-    /// Existing <c>throw handler.X(...)</c> sites remain unchanged. Phase 2
-    /// will convert them to <c>handler.Diagnostics.Report(handler.X(...))</c>.
+    /// Lifecycle:
+    /// <list type="bullet">
+    ///   <item><c>CompilerConfiguration.ReadContinueOnErrorEnvVar</c> seeds
+    ///     <see cref="ContinueOnError"/> from the
+    ///     <c>P_COMPILER_COLLECT_ERRORS</c> environment variable.</item>
+    ///   <item>Visitors (<c>ExprVisitor</c>, <c>StatementVisitor</c>) report
+    ///     through <c>handler.Diagnostics.Report(handler.X(...))</c>.</item>
+    ///   <item><c>Analyzer.TolerantStep</c> wraps each gathering-pass iteration
+    ///     so a TranslationException on one machine/function doesn't clobber
+    ///     siblings' diagnostics.</item>
+    ///   <item><c>Compiler.FlushCollectedDiagnostics</c> sorts by
+    ///     <c>(file, line, column)</c> and emits each diagnostic with
+    ///     <c>[Error:]</c> prefix to stderr.</item>
+    /// </list>
+    ///
+    /// The contract is exercised by
+    /// <c>Tst/UnitTests/TypeChecker/DiagnosticCollectorTest.cs</c>,
+    /// <c>Tst/UnitTests/TypeChecker/Phase1DormancyTest.cs</c>, and
+    /// <c>Tst/UnitTests/TypeChecker/MultiErrorAcceptanceTest.cs</c>.
     /// </summary>
     public interface IDiagnosticCollector
     {

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/ErrorExpr.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/ErrorExpr.cs
@@ -13,11 +13,11 @@ namespace Plang.Compiler.TypeChecker.AST.Expressions
     /// transformer's post-typecheck passes are constrained to <c>IExprTerm</c>,
     /// so an <see cref="ErrorExpr"/> that accidentally leaks past type-checking
     /// will trip a clear cast failure rather than silently corrupting downstream
-    /// code generation. The <see cref="Compiler"/> top-level guards this by
-    /// skipping IR transformation when the diagnostic collector
-    /// <c>HasErrors</c>.
+    /// code generation. <c>Compiler.Compile</c> guards this by skipping IR
+    /// transformation when <c>handler.Diagnostics.HasErrors</c>.
     ///
-    /// Phase 1 introduces this class; no visitor produces it yet.
+    /// Produced by <c>ExprVisitor</c>/<c>StatementVisitor</c> whenever a node
+    /// fails type-checking in collecting mode.
     /// </summary>
     public sealed class ErrorExpr : IPExpr
     {

--- a/Src/PCompiler/CompilerCore/TypeChecker/Types/ErrorType.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Types/ErrorType.cs
@@ -13,7 +13,7 @@ namespace Plang.Compiler.TypeChecker.Types
     /// cascading errors: e.g. <c>undeclaredVar + 1</c> should produce one
     /// "undeclared" diagnostic, not also an "incompatible operand types" one.
     ///
-    /// Cascade suppression has two pieces:
+    /// Cascade suppression has three pieces working together:
     ///   - This class overrides <see cref="IsAssignableFrom"/> to return true
     ///     for any other type. That covers the asymmetric case where the
     ///     sentinel is on the LHS of an assignability check.
@@ -22,18 +22,18 @@ namespace Plang.Compiler.TypeChecker.Types
     ///     equality checks regardless of operand order, since not every
     ///     existing type's <c>IsAssignableFrom</c> override knows about the
     ///     sentinel.
-    ///   - Phase 2 will additionally add a <c>CheckAssignable</c> helper in
-    ///     <c>TypeCheckingUtils</c> that visitors use in place of inline
-    ///     <c>IsAssignableFrom</c> calls, to cover the remaining asymmetric
-    ///     sites where <c>ErrorType</c> appears on the RHS.
+    ///   - <c>TypeCheckingUtils.CheckAssignable</c> is the cascade-aware
+    ///     helper visitors use in place of inline <c>IsAssignableFrom</c>
+    ///     calls; it auto-suppresses when either side is <see cref="ErrorType"/>.
     ///
-    /// Phase 1 introduces the sentinel; no visitor produces it yet. Phase 2
-    /// converts the ~111 throw sites in ExprVisitor/StatementVisitor to record-
-    /// and-continue, where this type does its job.
+    /// Produced by <c>ExprVisitor</c>/<c>StatementVisitor</c> whenever a node
+    /// fails type-checking in collecting mode (see
+    /// <see cref="IDiagnosticCollector"/>).
     ///
     /// Invariant: <see cref="ErrorType"/> instances must never reach the IR
-    /// transformer or backend code generators. <see cref="Compiler"/> guards
-    /// this by skipping post-typecheck stages when <c>HasErrors</c>.
+    /// transformer or backend code generators. <c>Compiler.Compile</c> guards
+    /// this by skipping post-typecheck stages when
+    /// <c>handler.Diagnostics.HasErrors</c>.
     /// </summary>
     public sealed class ErrorType : PLanguageType
     {

--- a/Src/PeasyAI/src/ui/mcp/tools/compilation.py
+++ b/Src/PeasyAI/src/ui/mcp/tools/compilation.py
@@ -36,7 +36,7 @@ def register_compilation_tools(mcp, get_services, with_metadata):
 
     @mcp.tool(
         name="peasy-ai-compile",
-        description="Compile a P project and return compilation results. The project directory must contain a .pproj file. On failure, the response includes parsed errors with file, line, and message details. Use peasy-ai-fix-compile-error or peasy-ai-fix-all to resolve compilation errors."
+        description="Compile a P project and return compilation results. The project directory must contain a .pproj file. On failure, the response includes parsed errors with file, line, and message details. Use peasy-ai-fix-compile-error or peasy-ai-fix-all to resolve compilation errors. Tip: set P_COMPILER_COLLECT_ERRORS=1 in the project environment to receive ALL type errors in a single response (compiler 3.0+) — lets fix-all converge in fewer iterations."
     )
     def p_compile(params: PCompileParams) -> Dict[str, Any]:
         logger.info(f"[TOOL] peasy-ai-compile: {params.path}")

--- a/Src/PeasyAI/src/ui/mcp/tools/fixing.py
+++ b/Src/PeasyAI/src/ui/mcp/tools/fixing.py
@@ -410,7 +410,7 @@ If you receive needs_guidance, ask the user the questions and call again with us
 
     @mcp.tool(
         name="peasy-ai-fix-all",
-        description="Iteratively compile, detect errors, and fix them in a loop until the project compiles successfully or max_iterations is reached. This is the recommended way to fix multiple compilation errors at once — it automatically re-compiles after each fix to catch cascading issues. Use this instead of calling peasy-ai-fix-compile-error repeatedly."
+        description="Iteratively compile, detect errors, and fix them in a loop until the project compiles successfully or max_iterations is reached. This is the recommended way to fix multiple compilation errors at once — it automatically re-compiles after each fix to catch cascading issues. Use this instead of calling peasy-ai-fix-compile-error repeatedly. Tip: with P compiler 3.0+, set P_COMPILER_COLLECT_ERRORS=1 to get all type errors per compile in one batch — the loop converges in N/k iterations instead of N, where k is the average errors-per-iteration."
     )
     def fix_iteratively(params: FixIterativelyParams) -> Dict[str, Any]:
         logger.info(f"[TOOL] peasy-ai-fix-all: {params.project_path}")


### PR DESCRIPTION
## Summary

Final multi-agent audit on master found the multi-error compilation feature (#957, #963, #965) shipped without:
- Any user-facing mention of the `P_COMPILER_COLLECT_ERRORS` env var
- Any contributor guidance for new throw sites
- Updated XML doc comments (several still say "Phase 1 wiring only" / "Phase 2 will...")

This PR closes those gaps. **Pure docs** — no compiler behavior change.

## Changes

| File | Change |
|---|---|
| `README.md` | New "Multi-Error Compilation" section under "What's New" with a worked example |
| `ChangeList.md` | Entry under "P 3.0 Changes" describing the env var + behavior contract |
| `CLAUDE.md` | New "Multi-Error Type Checking (Compiler)" section with architecture, contributor convention, and test-fixture layout |
| `Src/PCompiler/CompilerCore/IDiagnosticCollector.cs` | Stale "Phase 1 wiring only" XML doc → Lifecycle list with cross-references |
| `Src/PCompiler/CompilerCore/TypeChecker/Types/ErrorType.cs` | "Phase 2 will..." forward reference → describes the now-landed three-piece cascade-suppression |
| `Src/PCompiler/CompilerCore/TypeChecker/AST/Expressions/ErrorExpr.cs` | "Phase 1 introduces this class; no visitor produces it yet" struck |
| `Src/PeasyAI/src/ui/mcp/tools/compilation.py` | `peasy-ai-compile` description tips users about the env var |
| `Src/PeasyAI/src/ui/mcp/tools/fixing.py` | `peasy-ai-fix-all` description explains the iteration-convergence speedup |

## Test plan

- [ ] CI green (this PR doesn't touch code so existing tests are sufficient)
- [ ] Markdown renders correctly on GitHub

## Follow-up

A separate PR will propagate `P_COMPILER_COLLECT_ERRORS=1` in PeasyAI's `subprocess.run` calls. The MCP tool descriptions added here pre-document the integration so adopters know what to look for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)