### PR TITLE
PeasyAI: default to collecting-mode compilation in subprocess.run

### DIFF
--- a/Src/PeasyAI/src/core/services/compilation.py
+++ b/Src/PeasyAI/src/core/services/compilation.py
@@ -5,6 +5,7 @@ Handles P project compilation and PChecker execution.
 This service is UI-agnostic.
 """
 
+import os
 import subprocess
 import logging
 import traceback
@@ -85,13 +86,20 @@ class CompilationService(BaseService):
                     return_code=-1,
                 )
             
-            # Run P compiler
+            # Run P compiler. Default to collecting-mode (`P_COMPILER_COLLECT_ERRORS=1`)
+            # so a project with N independent type errors produces all N diagnostics
+            # in one compile, letting PeasyAI's fix loop converge in N/k iterations
+            # instead of N. setdefault preserves an explicit user override (set the
+            # env var to "0" or "false" in the parent shell to keep strict mode).
+            env = os.environ.copy()
+            env.setdefault("P_COMPILER_COLLECT_ERRORS", "1")
             result = subprocess.run(
                 ['p', 'compile'],
                 capture_output=True,
                 cwd=project_path,
                 text=True,
                 timeout=300,  # 5 minute timeout
+                env=env,
             )
             
             # Check for success

--- a/Src/PeasyAI/src/core/services/generation.py
+++ b/Src/PeasyAI/src/core/services/generation.py
@@ -1442,12 +1442,17 @@ class GenerationService(BaseService):
                 env = ensure_environment()
                 if env.is_valid and env.p_compiler_path:
                     import subprocess
+                    # Default to collecting-mode compilation (see
+                    # core/services/compilation.py for full rationale).
+                    subprocess_env = os.environ.copy()
+                    subprocess_env.setdefault("P_COMPILER_COLLECT_ERRORS", "1")
                     result = subprocess.run(
                         [env.p_compiler_path, "compile"],
                         cwd=project_path,
                         capture_output=True,
                         text=True,
                         timeout=30,
+                        env=subprocess_env,
                     )
                     if result.returncode == 0:
                         logger.info(f"  Candidate compiles successfully (+{COMPILE_BONUS} bonus)")

--- a/Src/PeasyAI/src/utils/compile_utils.py
+++ b/Src/PeasyAI/src/utils/compile_utils.py
@@ -36,7 +36,16 @@ def try_compile(ppath, captured_streams_output_dir):
     flags = ['-pf', ppath, "-o", str(p.parent)] if p.is_file() else []
 
     final_cmd_arr = ['p', 'compile', *flags]
-    result = subprocess.run(final_cmd_arr, capture_output=True, cwd=ppath if not p.is_file() else None)
+    # Default to collecting-mode compilation (see compilation.py for full rationale).
+    # setdefault preserves an explicit user override.
+    env = os.environ.copy()
+    env.setdefault("P_COMPILER_COLLECT_ERRORS", "1")
+    result = subprocess.run(
+        final_cmd_arr,
+        capture_output=True,
+        cwd=ppath if not p.is_file() else None,
+        env=env,
+    )
 
     out_dir = f"{captured_streams_output_dir}/compile"
     os.makedirs(out_dir, exist_ok=True)


### PR DESCRIPTION
## Summary

PeasyAI's compile path shells out to `p compile` via three `subprocess.run` sites — none of which previously propagated the `P_COMPILER_COLLECT_ERRORS` env var. With P compiler 3.0+'s new multi-error mode (#957/#963/#965), enabling the env var lets PeasyAI's `peasy-ai-fix-all` loop converge in **O(N/k) LLM round trips instead of O(N)** where k is the average errors-per-iteration. This is the motivating use case for the entire multi-error initiative.

## Change

At each of three subprocess.run sites:

```python
env = os.environ.copy()
env.setdefault("P_COMPILER_COLLECT_ERRORS", "1")
result = subprocess.run([...], ..., env=env)
```

`setdefault` (not assignment) preserves the user's explicit override:
- **Unset** → child sees `"1"` (collecting mode, new default)
- **Set to `"0"` / `"false"`** → child sees the user's value (strict mode)
- **Set to anything else** → child sees the user's value

## Sites changed

- `Src/PeasyAI/src/core/services/compilation.py` — canonical compile entry point used by `peasy-ai-compile` MCP tool + `fix_iteratively` loop
- `Src/PeasyAI/src/utils/compile_utils.py` — legacy helper for evaluation pipelines
- `Src/PeasyAI/src/core/services/generation.py:1445` — candidate-scoring compile during code generation

## Not changed

- `Src/PeasyAI/src/utils/checker_utils.py` — invokes `p check`, not `p compile`; env var has no effect there
- `Src/PeasyAI/src/core/compilation/environment.py` — toolchain validation calls (`dotnet --list-sdks` etc.), not P compilation
- The error parser already supports multiple errors via `compilation.get_all_errors` and `error_parser.parse` (both iterate all matches with `re.finditer`). No parser changes needed.

## Follow-up (separate PR)

The multi-agent audit recommended updating `fix_iteratively` to call `get_all_errors` instead of `parse_error` and send all errors to the LLM in one batch. That's a behavioral change to the fix loop. This PR is the prerequisite (env var must propagate first); the batching work is a separate PR.

## Test plan

- [ ] CI green (Python tests under `Src/PeasyAI/tests/`)
- [ ] Manual: run `peasy-ai-fix-all` on a P file with 3 independent errors; observe that the LLM sees all 3 in one round trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)