### PR TITLE
Unified agentic spec inference for P: frozen candidate schema, robust validation backbone, ranking (PLAN.md Phases 0-4)

### DIFF
--- a/Src/PInfer/Scripts/PLAN.md
+++ b/Src/PInfer/Scripts/PLAN.md
@@ -1,0 +1,366 @@
+# Unified P Specification Inference — PInfer core + agentic LLM layer
+
+> **Status:** Design plan v2 (incorporates multi-agent review, 2026-06-30).
+> **Scope decision:** Agentic-first, PInfer optional (plug-in). First milestone = Phases 0–4
+> (inference + judge). Downstream (verifier / monitors / test-gap report) and cross-feeding are
+> deferred to Phases 5–6.
+> **Change log:** v2 corrects the portability contract, freezes a structured candidate schema,
+> makes vacuity/attribution/validation backbone responsibilities, adds a reproducibility +
+> metrics methodology, splits Phase 2, and reconciles §9 acceptance with the milestone scope.
+> See §13 for the v1→v2 finding map.
+
+---
+
+## 1. Motivation
+
+Formulating correctness specifications for industrial P models is a large, manual burden.
+Two efforts attack this from opposite ends:
+
+- **PInfer / Specy** (research system, `experimental/pinfer` branch; OOPSLA'26 paper "Specy:
+  Learning Specifications for Distributed Systems from Event Traces") learns quantified,
+  **event-based** specifications from **execution traces** by statically enumerating a
+  grammar-bounded formula template, dynamically learning payload relations with Daikon, and
+  pruning with Z3 + PChecker. It is **sound within its bounds** but **mirrors the
+  implementation** — it rarely surfaces bugs, and 15/43 of its benchmark specs required manual
+  user guidance.
+
+- **The agentic layer** (`pinfer-agentic-invariants` = PR #974, and `pinfer-peasyai-design`)
+  proposes specs with an LLM from **design intent + source**, has **PChecker verify every one**
+  (the sound oracle), and an LLM **judges** each result over the concrete counterexample. It
+  **can surface bugs** (the intent↔implementation gap) but is **unsound** — every candidate must
+  be checked.
+
+## 2. Core insight (a hypothesis this milestone begins to test, not an assumed fact)
+
+PInfer and the agentic approach are **two proposers over overlapping fragments of the same
+Specy grammar, feeding the same sound oracle (PChecker)**. Everything downstream of proposal —
+prep, repair, validate, prune, rank, judge — can be shared. So the architecture is a **single
+backbone with pluggable proposers**, not two parallel pipelines.
+
+> **Caveat (was overclaimed in v1):** the two proposers do **not** emit identical grammars.
+> PInfer emits grammar-conformant formulas *by construction*, including a first-class
+> trace-order term `index()` (happens-before) and augmented-existential/quorum (SC) constraints.
+> The portable LLM proposers emit free-form P monitors over a **strictly smaller** predicate
+> fragment (`{==,!=,<,<=,>,>=,in}`, no `index()` unless explicitly added). We therefore say
+> "overlapping fragments," and Phase 1 adds an optional grammar-conformance check (§6.6). The
+> complementarity claim (PInfer high-recall / agentic bug-finding) is **asserted but not
+> validated by this milestone** — see §8 for how we begin to measure it and §11 R7 for the risk.
+
+Their strengths are complementary:
+
+| | PInfer (enumerative + Daikon) | Agentic (LLM) |
+|---|---|---|
+| Derives from | implementation **traces** | **intent** (source + design docs) |
+| Soundness | sound within grammar bounds; Z3 + PChecker pruned | unsound; every candidate checked |
+| Finds bugs? | rarely (mirrors implementation) | **can** (intent↔impl gap) |
+| Coverage | exhaustive but grid-bounded | creative but spotty |
+| Event-combo selection | **AST analysis of send/recv/goto** (Specy §4.1) — primary recall driver | LLM guess over event list (no reachability analysis) |
+| Relation vocabulary for H | **Daikon** (data-driven numeric relations) | LLM-guessed over 7 comparison ops |
+| Ordering / happens-before | first-class `index()` term | not expressible in portable fragment |
+| Quorum / cardinality (SC) | `config_event` + existential-n | not expressible in portable fragment |
+| Raw output | thousands of formulas → needs ranking | few, named, explained candidates |
+| Missing | naming, rationale, bug-hunting | recall of true invariants, sound pruning, `index()`, SC, Daikon numerics |
+
+**Cross-feeding is the north star** (Phase 6, deferred):
+1. Agentic candidates get PInfer's **sound Z3 pruning**, not just PChecker falsification.
+2. PInfer's raw formulas get the **LLM ranking + judging + naming** layer.
+3. PInfer's verified invariants **seed the agentic proposer** (few-shot → fewer hallucinated events).
+4. The agentic layer **auto-generates PInfer hints** (UG1 event combos, UG2 custom predicates,
+   UG3 state exposure) — automating the paper's 15/43 manual-guidance cases.
+
+## 3. Dependency & terminology contract (corrects the v1 "portable = no C#" error)
+
+There are **three capability tiers**, not two. "Portable" means *no PInfer enumerator and no Z3*
+— it does **not** mean "no C#": the validation oracle *is* C#.
+
+| Tier | Requires | Provides | Notes |
+|---|---|---|---|
+| **Base** (mandatory) | .NET 8 SDK + the `p` global tool (PCompiler + PChecker); Python 3; an LLM agent runtime + credentials | propose → prep → repair → validate → falsification-prune → rank → judge | `invariant_core.py` shells out to `p compile`/`p check`; `build_env()` probes `dotnet`. This is the whole milestone. |
+| **+Z3 plug-in** | Z3 built with .NET bindings, on `LD_LIBRARY_PATH` | implication-based semantic pruning (`SMTWrapper.CheckImplies`) | Cuts redundant-but-true specs the Base tier keeps. Optional. |
+| **+PInfer enumerator** | Full `experimental/pinfer` toolchain: rebased onto master, Java 22 + Maven, Daikon, vendored `pinfer-dependencies/*.jar`, built C# backend | a 3rd proposer (enumerative + Daikon) whose emitted `.p` monitors merge into the candidate set | Amazon-Linux-tested only. Optional plug-in; detection in §6.5. |
+
+**Base-tier prerequisite (Phase 0):** install .NET 8, run `p install`, confirm `p compile`/`p check`
+work on a tutorial project. No Java/Z3/Daikon needed.
+
+## 4. Target architecture
+
+```
+                        ┌──────────────── PROPOSERS (pluggable) ────────────────┐
+  design intent/docs ─► │ B. Agentic templated (propose_templated.js)           │ [BASE]   ─┐
+  source (PSrc/PTst) ─► │ C. Agentic intent   (intent-lens proposer, NEW)       │ [BASE]    │
+  P model + traces ───► │ A. PInfer enumerative (C#, grid + Daikon)             │ [PLUG-IN] │
+  (seeds, Phase 6)      └────────────────────────┬───────────────────────────────┘          │
+                                                 ▼                                candidates (unified schema §5)
+      ┌──────────────────────── SHARED BACKBONE (invariant_core.py) ─────────────────────────┐
+      │ 1. PREP        deterministic P fixups + AUTO-CANARY generation (prep_candidates.py)    │ [BASE]
+      │ 2. STATIC GATE event/field-name validation vs declarations (reuse PeasyAI validators)  │ [BASE]
+      │ 3. REPAIR      diag → LLM repair → verify  (compile yield ~72%→~100%)                  │ [BASE]
+      │ 4. VALIDATE    PChecker per candidate → HOLDS-BOUNDED / FAILS+cex / VACUOUS /          │ [BASE]
+      │                UNKNOWN-VACUITY / INCONCLUSIVE / COMPILE-ERR  (baseline-diff attribution)│
+      │ 5. PRUNE       Base: dedup(structured key) + falsification;  +Z3: semantic subsumption │ [BASE/+Z3]
+      │ 6. RANK        schema-native scoring kernel (ported from ranking_with_llm.py)          │ [BASE]
+      │ 7. JUDGE       LLM over cex → {verdict, confidence, cex-grounding, development_action}  │ [BASE]
+      └────────────────────────┬──────────────────────────────────────────────────────────────┘
+                               ▼
+              ┌────────── DOWNSTREAM (Phase 5, deferred) ──────────┐
+              │ Verification: TransformToP → PVerifier              │
+              │ Monitoring:   auto-gen runtime monitors             │
+              │ Testing:      test-coverage-gap (φ_L ⇒ φ_U) report  │
+              └─────────────────────────────────────────────────────┘
+```
+
+## 5. Canonical candidate schema (frozen in Phase 1 — the linchpin, corrects C3)
+
+The v1 dedup key `(observes, guard, relation)` referenced fields that do not exist. The schema
+must carry a **structured formula record** alongside the opaque `specCode` so dedup/merge/rank
+are well-defined and every proposer (incl. the PInfer adapter) can populate it.
+
+```jsonc
+Candidate {
+  name: string,                    // unique per run
+  intent: string,                  // NL description
+  category: string,
+  provenance: "templated"|"intent"|"enumerative",   // NEW
+  observes: string[],              // event types the monitor observes
+  // structured formula record (NEW — enables dedup, SC, ranking):
+  formula: {
+    quantifiers: [{var, type, kind: "forall"|"exists"}],   // arity = count
+    guards: string[],              // conjunct predicates (canonicalized)
+    relations: string[],          // conjunct predicates asserted to hold
+    sc: null | {op: "=="|">"|">="|"<="|"count", bound: string},  // quorum/cardinality (M3)
+    config_event: string|null,     // population source for SC (M3)
+    uses_index: bool               // happens-before present (grammar-fragment marker)
+  },
+  specCode: string,                // compilable `spec ... observes ... { }` P monitor
+  canary: string|null,             // auto-generated companion (see §6.1)
+  predicted_bucket: "verified"|"bug"|"spurious"|"vacuous",
+  // filled by the backbone, not the proposer:
+  verdict: Verdict|null,           // see §6.4
+  provenance_run: {model, temperature, prompt_hash, iters, seed}   // reproducibility (M6/M7)
+}
+```
+
+- **Dedup key** = canonicalized `(sorted observes, sorted guards, sorted relations, sc,
+  quantifier-kinds)`. On collision, **cluster and keep a representative** (do not silently drop —
+  record the cluster for metrics). A Python dataclass mirrors this; a **JS↔Python parity test**
+  guards drift between `propose_templated.js`'s `CAND_SCHEMA` and the dataclass (N1).
+- **Freeze gate (Phase 1 exit):** schema, dedup-key function, and judge output schema are pinned
+  and unit-tested before any proposer or backbone stage is built against them.
+
+## 6. Backbone stages in detail (the parts v1 hand-waved)
+
+### 6.1 Vacuity is a backbone responsibility, not a proposer favor (M4)
+v1 only detected VACUOUS when the *LLM* emitted a `_canary`; PInfer and the templated proposer
+emit none, so genuinely-vacuous candidates were reported HOLDS→"verified."
+- **PREP auto-generates a canary per candidate** by negating the asserted relation inside the
+  same guarded branch (guarantees guard-identity), independent of the proposer.
+- A candidate with no derivable canary is classified **UNKNOWN-VACUITY**, never HOLDS.
+- The canary must **trip within the same `--iters` budget**; otherwise we cannot distinguish
+  "guard unreachable" (vacuous) from "guard under-scheduled" (bounded-checking artifact).
+
+### 6.2 Static name gate before model-checking (M9)
+Compile-success + HOLDS ≠ meaningful spec: a hallucinated event widened to a real-but-wrong one,
+or a type-compatible wrong field (`.trial` vs `.attempt`), compiles and HOLDs vacuously.
+- Add a deterministic gate that parses each candidate's `observes` + every payload-field access
+  and validates them against the benchmark's real event/type declarations.
+- **Reuse PeasyAI's `EventDeclarationValidator` and `PayloadFieldValidator`**
+  (`Src/PeasyAI/src/core/validation/validators.py`); promote field-mismatch to a hard reject.
+
+### 6.3 Bug attribution is baseline-differential, not substring matching (M5)
+v1 attributed monitor-vs-SUT failures by grepping the last 160 chars of the trace for
+`_candidates.p`/`liveness`/`hot state` — a monitor-caused **deadlock** ("Deadlock detected")
+matches none of these and gets mislabeled `sut`→INCONCLUSIVE→dropped, discarding real bugs.
+- Run `p check` once on the **unmodified** project; record pre-existing SUT failures.
+- Attribute a candidate failure to the monitor **iff it is absent from that baseline**.
+- Parse structured PChecker output / the failing spec name rather than a truncated message.
+- Regression fixture: a monitor-caught bug whose cex omits the candidate filename.
+
+### 6.4 Bounded verdicts are labeled as such (M6)
+`p check -i N` is bounded exploration, not a proof. The verdict enum is:
+`HOLDS-BOUNDED` (provisional; records `iters`+`seed`) · `HOLDS-PROVEN` (PVerifier only, Phase 5) ·
+`FAILS`(+cex) · `VACUOUS` · `UNKNOWN-VACUITY` · `INCONCLUSIVE` · `COMPILE-ERR`.
+- Nothing may be labeled "verified/sound" on `HOLDS-BOUNDED` alone.
+- **Iteration-sensitivity gate:** rerun the accepted set at 2–3× budget; report any verdict flips.
+
+### 6.5 PInfer plug-in adapter is explicit work, not a one-liner (M2/M14, N4)
+- Detection: probe `p infer --help` exit code **and** presence of Z3 + `daikon.jar` (not just
+  "`p infer` exists").
+- The adapter **consumes PInfer's emitted `spec…observes` monitors** (`TransformToP.WriteSpecMonitor`,
+  confirmed to exist) plus metadata, back-fills `intent`/`category`/`formula`/`provenance`,
+  normalizes naming/`observes` so `SPEC_RE`/`_wire` ingest them. (It does *not* synthesize
+  monitors from formulas — that premise was wrong.)
+- **Also expose PInfer's event-combination list** (`ExploreFunction`/`AddHint` — pure C# AST
+  analysis, no Z3/Daikon/traces) as a lightweight signal to feed the LLM proposers a
+  quantification skeleton — the cheapest high-value fidelity restoration for M2.
+
+### 6.6 Optional grammar-conformance check (M13)
+A Phase-1 checker parses `specCode` → canonical tuple and flags predicates outside the shared
+fragment, so "overlapping fragments" is enforced/observed rather than merely asserted.
+
+## 7. Phased implementation (Base tier unless noted)
+
+### Phase 0 — Consolidate the Base tier
+- Branch off `master`; bring in the agentic scripts from `pinfer-peasyai-design`
+  (`invariant_core.py`, `propose_templated.js`, `prep/diag/check/repair/verify`).
+- Merge scope is **only the two agentic branches** (small); the `experimental/pinfer` rebase is a
+  *plug-in* prerequisite, deferred (N4).
+- Base prereqs installed (§3); PInfer enumerator/Z3 **not** required.
+- **Exit (split):** (a) the deterministic middle (prep/diag/check/verify) runs end-to-end on one
+  tutorial benchmark; (b) a full propose→check→judge runs once with a live LLM (names the agent
+  runtime + credentials in §9). *Does not claim "no C#."*
+
+### Phase 1 — Freeze the shared core + schema (enlarged vs v1)
+- `invariant_core.py` consolidates existing pieces (dedup the 3 `build_env` copies) **and** adds
+  net-new: the `Candidate` dataclass (§5), the dedup-key function, the judge output schema,
+  provenance-run fields.
+- Adopt + **extend** `propose_templated.js`'s `CAND_SCHEMA` with the structured `formula` record,
+  `provenance`, `config_event`, `sc`, `uses_index`.
+- `check_candidates.py`/`diag_compile.py`/`verify_repairs.py` become thin CLIs over the core.
+- **Exit (testable):** schema (de)serialization round-trip test; dedup-key unit test; judge-schema
+  test; JS↔Python schema parity test; `validate_candidates` classification test with mocked
+  `_check_one`/`_wire` covering **every** verdict branch (incl. auto-canary vacuity, UNKNOWN-VACUITY,
+  baseline-diff INCONCLUSIVE). (v1's "test_invariant_core.py green" was hollow — N6.)
+
+### Phase 2a — Intent proposer (net-new, was hidden in v1)
+- Build the intent-lens proposer as a runnable proposer against the frozen schema, reusing the
+  existing `INTENT_LENSES`/`propose_*_prompt()` strings (do **not** duplicate prompt logic).
+- Clarify how it differs from `propose_templated.js` (soft NL lenses vs grammar scaffold) so it
+  isn't a near-duplicate.
+- **Exit:** emits schema-valid candidates on one benchmark.
+
+### Phase 2b — Hybrid merge + PInfer hook
+- `hybrid` merge: dedup by the structured key (§5), cluster-and-keep representatives, union.
+- PInfer plug-in adapter (§6.5) merges enumerative candidates **when the tier is present**;
+  skipped with a logged notice otherwise.
+- **Exit:** one merged, deduped candidate set from ≥2 Base proposers; PInfer candidates ingest
+  correctly on the plug-in box (verified once on FD).
+
+### Phase 3 — Unified pruning (graceful degradation)
+- Base: structured dedup + PChecker falsification.
+- +Z3: implication-based semantic subsumption (`SMTWrapper.CheckImplies`) runs first to cut the set.
+- **Exit (subset/partition claim, corrected — M1):** the +Z3 set ⊆ the Base set (Base keeps
+  redundant-but-true specs Z3 drops); every candidate the Base path *rejects* is also rejected by
+  the +Z3 path; **reduction ratio reported per-path with absolute in/out counts** (not asserted
+  equal). The equality-style comparison is a plug-in-present gate, not part of Base acceptance.
+
+### Phase 4 — Rank + judge
+- **Rank:** port the *scoring kernel* (`compute_score` weighting + 4-metric rubric) from
+  `ranking_with_llm.py` into a schema-native ranker consuming `Candidate`/`Verdict`. **Drop**
+  Strands, the `constants` module, the Bedrock model id, and the `pruned_invariants.txt` input;
+  route the LLM through the wrapper-owns-the-provider seam (M12). Cross-branch port — real work.
+- **Judge:** rewrite `JUDGE_RUBRIC`/`judge_user_prompt` to emit
+  `{verdict, confidence, cex-grounding, development_action}`, action ∈
+  {add-to-tests, debug-bug, drop-spurious, drop-vacuous}. Reconcile `vacuous` ownership
+  (VALIDATE computes it via canary; JUDGE only classifies FAILED candidates). **Remove**
+  `relax-test-coverage-gap` (depends on §10 Phase-5 work).
+- **Exit:** one ranked+judged report on the acceptance benchmarks (§9); judge-contract unit test.
+
+## 8. Reproducibility & evaluation methodology (net-new — M7/M8/M15/M16)
+
+LLM propose/repair/judge and `p check` are non-deterministic; a single-shot table proves nothing.
+
+- **Pinning:** fix model id + temperature (0 where allowed); record `prompt_hash`, model,
+  temperature, and the **PChecker `--seed`** in each candidate's `provenance_run`. Cache raw LLM
+  responses; commit a **golden candidate set** per benchmark so the deterministic
+  `classify()`/prune/rank layer is CI-gatable independent of live LLM calls.
+- **Variance:** run acceptance over **N ≥ 3 seeds**; report the distribution and verdict-set
+  stability (Jaccard across runs), not just one number.
+- **Baseline ablation (M8):** compare the full pipeline against "LLM-propose-once, no
+  prep/repair/validate/prune/rank/judge" on the same benchmarks — isolates the value of the loop.
+- **Metrics table (M8)** with formulas + reported values (gate only where noted):
+  - **false-bug rate** = confirmed-spurious among `bug` verdicts (primary quality metric).
+  - **reduction ratio** = candidates in/out of PRUNE (absolute counts + ratio, per path).
+  - **goal-spec recall** = |recovered| / |authored| (denominators: FD=1, TPC=2).
+  - cost (tokens) + wall-clock — reported, not gated.
+- **Rediscovery oracle (M16):** "recovers the authored spec" = **bounded mutual implication**
+  checked by PChecker (`candidate ∧ ¬authored` and `authored ∧ ¬candidate` both HOLD-BOUNDED under
+  a documented budget), reusing the Verdict pipeline. Fallback: a logged manual candidate→authored
+  mapping, explicitly labeled manual.
+- **Fault-injection benchmark (M15):** since FD and TPC are *correct*, the `bug` branch is never
+  exercised. Add a mutated variant (e.g. break FD's crash-notification path, or TPC's
+  abort-on-any-NO rule) and require JUDGE to label the resulting failure `bug` with a cex-grounded
+  rationale, **and** to *not* label the correct baseline `bug` (false-positive control).
+
+## 9. Interfaces (this milestone)
+- **Base CLI:** `python3 check_candidates.py` (exists) + a top-level `learn_invariants.py`
+  orchestrator over the core (prep/gate/repair/validate/prune/rank/judge). Proposal itself runs
+  inside the **agent runtime** (the `.js` proposers use `agent()`/`parallel()`/`phase()` globals),
+  which needs an LLM provider + credentials (PeasyAI venv + `~/.peasyai/settings.json`, or the
+  agent SDK) — named here so Phase 0(b) is provisionable.
+- Wire points for the two agent surfaces (**PeasyAI MCP `tools/invariants.py`**,
+  **`.claude/skills/learn-invariants`**) stubbed to call the core — full surface build deferred.
+- PInfer C# CLI stays a plug-in, not a dependency.
+
+## 10. Explicit non-goals (deferred to Phases 5–6)
+- **Phase 5 — Downstream:** PVerifier `TransformToP` translation (`HOLDS-PROVEN`), runtime-monitor
+  generation, and the **test-coverage-gap (`φ_L ⇒ φ_U`) report** (moved out of milestone
+  acceptance per C1). `φ_L ⇒ φ_U` needs implication reasoning (Z3 or a caveated LLM approximation)
+  and a defined `φ_L` source — both belong here.
+- **Phase 6 — Cross-feeding:** seeding agentic proposers with PInfer invariants, auto-hint
+  generation, and the enumerative-vs-agentic head-to-head that would *validate* the §2
+  complementarity claim.
+- Building/shipping the full MCP tool + skill surfaces.
+
+## 11. Risks
+1. **Platform:** PInfer enumerator "tested on Amazon Linux only," needs hand-built Z3 + Java 22 +
+   Maven + rebasing `experimental/pinfer` (3 ahead / 42 behind master). Base tier avoids all of
+   this; plug-in tiers own it.
+2. **Soundness contract:** only `HOLDS-PROVEN` (PVerifier) is sound; `HOLDS-BOUNDED` and all LLM
+   proposals/judgments are provisional. Enforced in verdict labels (§6.4) and report copy.
+3. **Bounded checking:** finite `--iters` can miss a counterexample (false HOLDS) *and*
+   under-schedule a guard (false VACUOUS). Mitigated by the iteration-sensitivity gate and the
+   canary-must-trip rule.
+4. **Attribution robustness:** monitor-vs-SUT misattribution silently drops bugs; mitigated by
+   baseline-differential attribution (§6.3) with a regression fixture.
+5. **Vacuity/hallucination:** compile-success + HOLDS ≠ meaningful spec; mitigated by backbone
+   auto-canaries (§6.1) and the static name gate (§6.2).
+6. **Portable recall:** the LLM proposers have no send/recv/goto reachability analysis, so
+   cross-machine causal pairs may be missed; mitigated by feeding PInfer's combo skeleton when the
+   plug-in is present (§6.5), otherwise an accepted recall downgrade.
+7. **Complementarity unvalidated:** §2's central bet is not measured by this milestone (PInfer runs
+   only on the plug-in box); §8 begins measuring it, full head-to-head is Phase 6.
+8. **Non-determinism / reproducibility:** addressed by §8 (pinning, seeds, golden set, variance).
+9. **Schema drift:** JS `CAND_SCHEMA` vs Python dataclass — guarded by the parity test (§5, N1).
+10. **Cost / fan-out:** propose (shapes × lenses × candidates) + repair rounds + per-candidate
+    `p compile`/`p check` + per-failure judge. Mitigations: max-candidates-per-benchmark cap, hard
+    repair-round cap K, shared iters/time budget, cost accounting in the report, and **bisect**
+    (not linear scan) to isolate an offending candidate when batch compile fails.
+
+## 12. Acceptance for the milestone (corrected — C1/M8/M15/M16)
+On `4_FailureDetector` + `2_TwoPhaseCommit` (Base tier), plus one **fault-injected** variant,
+run over **N ≥ 3 seeds** with pinned model/temperature/PChecker-seed and produce a ranked, judged
+report such that:
+- **(a) Recall:** each project's authored spec is recovered, measured by the bounded
+  mutual-implication oracle (§8). Denominators FD=1, TPC=2. Report per-seed distribution.
+  *Note:* TPC's `AtomicityInvariant` needs the SC/cardinality shape (§5, M3) — its recovery is the
+  test that SC support works.
+- **(b) Classification:** every model-checker failure is classified
+  `bug`/`spurious`/`vacuous`/`UNKNOWN-VACUITY` with a cex-grounded rationale; on the fault-injected
+  variant the injected fault is labeled `bug` and the correct baseline is **not**.
+- **(c) Metrics:** the §8 table is emitted — false-bug rate, per-path reduction ratio (absolute
+  counts), recall — alongside the propose-once ablation baseline.
+- **Explicitly NOT required at this milestone:** the test-coverage-gap (`φ_L ⇒ φ_U`) finding
+  (moved to Phase 5), PVerifier proofs, and any PInfer-enumerator/Z3 result (plug-in tiers).
+
+## 13. v1 → v2 finding map
+- **C1** (§9(c) required deferred work) → moved test-gap to §10 Phase 5; §12 excludes it.
+- **C2** (false "no C#") → §3 dependency tiers; labels renamed `[BASE]`/`[+Z3]`/`[PLUG-IN]`.
+- **C3** (dedup key fields missing) → §5 structured `formula` record + freeze gate.
+- **M1** (Phase 3 "identical verdicts") → §7 Phase 3 subset/partition exit.
+- **M2** (causal-combo selection dropped) → §2 table row + §6.5 combo-skeleton + §11 R6.
+- **M3** (quorum/SC missing) → §5 `sc`/`config_event`; §12(a) TPC gate.
+- **M4** (vacuity proposer-dependent) → §6.1 backbone auto-canary + UNKNOWN-VACUITY.
+- **M5** (brittle attribution) → §6.3 baseline-differential.
+- **M6** (bounded HOLDS as sound) → §6.4 `HOLDS-BOUNDED`/`HOLDS-PROVEN` + sensitivity gate.
+- **M7** (non-reproducible) → §8 pinning + N≥3 seeds + golden set.
+- **M8** (no baseline/metrics) → §8 ablation + metrics table; §12(c).
+- **M9** (hallucination survives) → §6.2 static name gate (PeasyAI validators).
+- **M10** (intent proposer missing) → §7 Phase 2a split.
+- **M11** (judge lacks development_action) → §7 Phase 4 judge rewrite + Phase 1 schema freeze.
+- **M12** (ranking near-rewrite) → §7 Phase 4 scoring-kernel port + provider seam.
+- **M13** ("same grammar" false) → §2 "overlapping fragments" + §6.6 conformance check.
+- **M14** (complementarity untested) → §11 R7; §10 Phase 6 head-to-head.
+- **M15** (no bug in benchmarks) → §8 fault-injection; §12(b).
+- **M16** (rediscovery unmeasurable) → §8 bounded mutual-implication oracle.
+- **N1–N6** (schema drift, harness runtime, Daikon numerics caveat, plug-in detection, cost budget,
+  hollow tests) → §5 parity test, §9 runtime, §2 table, §6.5/N4, §11 R10, §7 Phase 1 exit.

--- a/Src/PInfer/Scripts/README_agentic_invariants.md
+++ b/Src/PInfer/Scripts/README_agentic_invariants.md
@@ -1,0 +1,91 @@
+# Agentic invariant mining (propose → check → judge)
+
+A lightweight, agent-driven alternative to brute-force trace mining. Instead of
+enumerating predicates over traces, an LLM agent **proposes** the invariants a
+protocol *should* satisfy by reading the P **source + design-intent comments**,
+those candidates are **model-checked** by PChecker (the sound oracle), and the
+agent then **judges** each result. PChecker — not the agent — is the source of truth.
+
+```
+  ┌─────────────────────────────┐   reads PSrc/*.p + design comments
+  │ ① PROPOSE  (LLM agent)      │   emits intent-level `spec` monitors
+  │   derive from INTENT, not    │   → a candidates .p file
+  │   from the implementation    │
+  └──────────────┬──────────────┘
+                 ▼
+  ┌─────────────────────────────┐   check_candidates.py:
+  │ ② CHECK  (this tool)        │   wire monitors in, generate one test each,
+  │   PChecker on EVERY candidate│   compile, model-check, classify,
+  │   + vacuity canaries         │   extract counterexamples
+  └──────────────┬──────────────┘
+                 ▼  HOLDS / FAILS(+cex) / VACUOUS
+  ┌─────────────────────────────┐   for each FAILS: required property → BUG,
+  │ ③ JUDGE  (LLM agent)        │   else over-strong → SPURIOUS (repair/drop).
+  │   grounded in the cex        │   for each HOLDS: meaningful vs vacuous.
+  └─────────────────────────────┘
+```
+
+## Why this shape
+
+* **Propose from intent, never from the implementation.** If candidates merely
+  paraphrase the code, a bug becomes a "correct" invariant and is never found.
+  Deriving from the protocol's *contract* lets PChecker measure the gap between
+  intent and implementation — and that gap is where bugs live.
+* **No trace pre-filter.** A failing candidate is *information*, not garbage: it
+  is either a real bug (a required property the system violates) or an over-strong
+  candidate. Only a sound check + judgment over the concrete counterexample can
+  tell them apart, so every candidate goes to PChecker.
+* **Vacuity is checked.** "HOLDS" can be a lie if the assertion's guard never
+  fires. A `<Name>_canary` companion (`assert false` in the same guarded branch)
+  reveals it: if the canary never trips, `<Name>` verified nothing.
+
+## Using the checker
+
+```bash
+python3 Src/PInfer/Scripts/check_candidates.py \
+  --project   Tutorial/4_FailureDetector \
+  --candidates /path/to/candidates.p \
+  --main      TestMultipleClients \
+  --assert-in "union { TestMultipleClients }, FailureDetector, FailureInjector" \
+  --iters     3000
+```
+
+* `--candidates` is a `.p` file containing one or more `spec <Name> observes ... { ... }`
+  blocks (the proposer agent's output). A `spec <Name>_canary` block is treated as a
+  vacuity probe for `<Name>`.
+* `--assert-in` is the module expression that appears after `in` in the project's
+  existing test (copy it from `PTst/TestScript.p`).
+* The tool resolves `dotnet`/`DOTNET_ROOT` automatically and cleans up the files it
+  generates (`PSpec/_candidates.p`, `PTst/_candidate_tests.p`) unless `--keep`.
+
+Steps ① and ③ are LLM steps (run them with Claude Code / any agent); this script is
+the deterministic middle. Validated on Two-Phase Commit, where the loop surfaced a
+real read-your-writes consistency violation and correctly separated it from an
+over-strong "all vote SUCCESS ⇒ commit" candidate that fails only due to benign timeouts.
+
+## Compile-repair stage (recovers candidates that don't compile)
+
+LLM-written spec monitors fail to compile ~28% of the time (concentrated in multi-state
+liveness monitors): inline `var` init, `?:` ternary, `not`/`not in`, `{x}` string
+interpolation, duplicate state names, seq-vs-set, invented event names. A two-script
+loop recovers them by feeding the *exact compiler error* back to an LLM:
+
+```bash
+# 1. Diagnose: compile each candidate alone, capture its first compiler error.
+python3 Src/PInfer/Scripts/diag_compile.py --out fails.json \
+    FailureDetector=Tutorial/4_FailureDetector=fd_candidates.p
+# 2. Repair (LLM): an agent per failing spec rewrites it given the error + P syntax rules.
+#    repair_workflow.js is a Workflow; pass `fails.json` as its args; it returns fixed sources.
+# 3. Verify: recompile each fixed spec.
+python3 Src/PInfer/Scripts/verify_repairs.py repairs.json
+```
+
+Iterate steps 2-3: round 1 fixes the shallow errors; round 2 gets the deeper ones the
+first fix exposes (e.g. an invented `eSpec_..._Init` event, a residual seq/set mismatch).
+On the 4-benchmark sweep this recovered **all 23** previously-uncompilable candidates in
+two rounds (15 then 8) — compile yield ~72% → ~100%. The repair agent must read the real
+PSrc/PTst to avoid hallucinating event names, and is told to preserve the property, fixing
+only syntax/encoding. Place repair AFTER deterministic `prep_candidates.py` (which already
+unescapes entities, hoists `var` decls, and rewrites `!in`/`for`) so the LLM only handles
+the genuinely diverse long tail.
+```

--- a/Src/PInfer/Scripts/check_candidates.py
+++ b/Src/PInfer/Scripts/check_candidates.py
@@ -31,10 +31,18 @@ def main():
     ap.add_argument("--assert-in", required=True, help="module expression after 'in' (no trailing ';')")
     ap.add_argument("--iters", type=int, default=3000, help="schedules per candidate")
     ap.add_argument("--keep", action="store_true", help="leave generated files in place")
+    ap.add_argument("--no-auto-canary", action="store_true",
+                    help="don't derive vacuity canaries for canary-less candidates")
+    ap.add_argument("--no-gate", action="store_true",
+                    help="skip the static event/field name gate")
+    ap.add_argument("--no-baseline", action="store_true",
+                    help="skip the baseline run (monitor-vs-SUT attribution degrades)")
     args = ap.parse_args()
 
     src = Path(args.candidates).read_text()
-    verdicts = validate_candidates(args.project, src, args.main, args.assert_in, args.iters, args.keep)
+    verdicts = validate_candidates(args.project, src, args.main, args.assert_in, args.iters, args.keep,
+                                   auto_canary=not args.no_auto_canary,
+                                   gate=not args.no_gate, baseline=not args.no_baseline)
 
     print(f"{'CANDIDATE':<42}{'VERDICT':<17}DETAIL")
     print("-" * 100)

--- a/Src/PInfer/Scripts/check_candidates.py
+++ b/Src/PInfer/Scripts/check_candidates.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+check_candidates.py — CLI over the shared `invariant_core` engine: wire candidate spec
+monitors into a P project, compile, bounded model-check, and classify each as
+HOLDS / FAILS(+counterexample) / VACUOUS / INCONCLUSIVE / COMPILE-ERR.
+
+A `<Name>_canary` companion spec (assert false in the same guarded branch) drives vacuity
+detection; a failure owned by a pre-existing SUT assertion is reported INCONCLUSIVE.
+
+    python3 check_candidates.py --project Tutorial/4_FailureDetector \
+        --candidates fd_candidates.p --main TestMultipleClients \
+        --assert-in "union { TestMultipleClients }, FailureDetector, FailureInjector" --iters 3000
+
+This is the deterministic middle of the agentic loop (propose → check → judge). See
+README_agentic_invariants.md; the engine lives in invariant_core.py.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariant_core import validate_candidates  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", required=True, help="P project dir (contains the .pproj)")
+    ap.add_argument("--candidates", required=True, help=".p file of candidate spec monitors")
+    ap.add_argument("--main", required=True, help="test main machine name")
+    ap.add_argument("--assert-in", required=True, help="module expression after 'in' (no trailing ';')")
+    ap.add_argument("--iters", type=int, default=3000, help="schedules per candidate")
+    ap.add_argument("--keep", action="store_true", help="leave generated files in place")
+    args = ap.parse_args()
+
+    src = Path(args.candidates).read_text()
+    verdicts = validate_candidates(args.project, src, args.main, args.assert_in, args.iters, args.keep)
+
+    print(f"{'CANDIDATE':<42}{'VERDICT':<17}DETAIL")
+    print("-" * 100)
+    for v in verdicts:
+        print(f"{v.name:<42}{v.verdict:<17}{v.detail}")
+    print("\nNext: an agent judges each FAILS as `bug` (required property) or `spurious` "
+          "(over-strong), and each HOLDS-BOUNDED for vacuity/interestingness.")
+    print(json.dumps([{"name": v.name, "verdict": v.verdict, "detail": v.detail} for v in verdicts]))
+
+
+if __name__ == "__main__":
+    main()

--- a/Src/PInfer/Scripts/diag_compile.py
+++ b/Src/PInfer/Scripts/diag_compile.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Diagnose WHY candidate spec monitors fail to compile.
+
+Wires each `spec` block (from a candidates .p file) ALONE into its P project and
+captures the compiler's first error, so the repair stage can fix each given the
+exact diagnostic. Emits a JSON list [{benchmark,dir,name,source,error}].
+
+Usage:
+    python3 diag_compile.py --out fails.json \
+        ClientServer=Tutorial/1_ClientServer=cand_ClientServer.p \
+        FailureDetector=Tutorial/4_FailureDetector=cand_FailureDetector.p
+each positional arg is  <label>=<projectDir>=<candidateFile>.
+"""
+import argparse, json, re, subprocess, sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariant_core import build_env  # noqa: E402  (single source of the dotnet/`p` resolver)
+
+SPEC_RE = re.compile(r'^\s*spec\s+([A-Za-z_]\w*)', re.MULTILINE)
+ERR_RE = re.compile(r'(error:|\[.*Error.*\]|Error:|expecting|mismatched|no viable|cannot|'
+                    r'undeclared|not declared|Expected|duplicates|could not find)', re.IGNORECASE)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="compile_fails.json")
+    ap.add_argument("targets", nargs="+", help="<label>=<projectDir>=<candidateFile> ...")
+    args = ap.parse_args()
+    env = build_env()
+
+    fails = []
+    for t in args.targets:
+        label, d, candfile = t.split("=", 2)
+        src = Path(candfile).read_text()
+        spans = [(m.start(), m.group(1)) for m in SPEC_RE.finditer(src)] + [(len(src), None)]
+        diag = Path(d) / "PSpec" / "_diag.p"
+        for i in range(len(spans) - 1):
+            name, block = spans[i][1], src[spans[i][0]:spans[i + 1][0]].strip()
+            diag.write_text(block)
+            out = subprocess.run(["p", "compile"], cwd=d, env=env, capture_output=True, text=True).stdout
+            if "Compilation succeeded" not in out:
+                errs = [l.strip() for l in out.splitlines() if ERR_RE.search(l)]
+                first = next((l for l in errs if "0 Error" not in l and "Build succeeded" not in l), "")
+                print(f"[{label}] {name}: {first[:150]}")
+                fails.append({"benchmark": label, "dir": d, "name": name, "source": block, "error": first[:300]})
+        diag.unlink(missing_ok=True)
+
+    Path(args.out).write_text(json.dumps(fails, indent=2))
+    print(f"\n{len(fails)} failing specs -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Src/PInfer/Scripts/invariant_core.py
+++ b/Src/PInfer/Scripts/invariant_core.py
@@ -588,6 +588,105 @@ def judge_user_prompt(name: str, benchmark: str, scenario: str, cex: str, spec_s
             "\"development_action\"(debug-bug|drop-spurious)} with reasoning grounded in the cex.")
 
 
+# ───────────────────────── ranking (PLAN.md Phase 4) ─────────────────────────
+# Scoring kernel ported from experimental/pinfer's ranking_with_llm.py (ref [25],
+# "Ranking Formal Specifications using LLMs"), stripped of Strands/Bedrock/constants/
+# pruned_invariants.txt coupling: the LLM scores the four metrics (via the wrapper that
+# owns the provider); this module owns the deterministic combination + verdict gating.
+
+RANK_WEIGHTS = {"quality": 0.8, "distinguishability": 0.2, "visibility": 0.0}
+
+RANK_METRICS = ("generalization", "criticality", "distinguishability", "visibility")
+
+RANK_RUBRIC = (
+    "Score each specification 0.0-1.0 on four metrics:\n"
+    "- generalization: does it express a protocol-level guarantee that holds across "
+    "configurations/scales, or does it overfit trace/test specifics (magic constants, "
+    "specific machine counts)?\n"
+    "- criticality: how severe is a violation for protocol correctness (safety violations "
+    "like double-commit rank highest; bookkeeping invariants lowest)?\n"
+    "- distinguishability: how well does it separate correct from buggy implementations "
+    "(would a plausible bug trip it, or is it satisfied by almost any behavior)?\n"
+    "- visibility: is a violation observable by clients/users of the system, or purely internal?\n"
+    "Focus on specifications enforcing critical protocol properties over implementation details. "
+    "To break a tie, the more important specification must get the higher overall score.")
+
+# Structured output contract for the ranking LLM call (one entry per candidate).
+RANK_OUTPUT_SCHEMA = {
+    "type": "object", "additionalProperties": False, "required": ["scores"],
+    "properties": {"scores": {"type": "array", "items": {
+        "type": "object", "additionalProperties": False,
+        "required": ["name", *RANK_METRICS],
+        "properties": {"name": {"type": "string"},
+                       **{m: {"type": "number", "minimum": 0, "maximum": 1}
+                          for m in RANK_METRICS}}}}},
+}
+
+
+def compute_score(generalization: float, criticality: float, distinguishability: float,
+                  visibility: float, weights: Optional[Dict[str, float]] = None) -> float:
+    """Overall score = sqrt(gen*crit)*w_quality + dist*w_dist + vis*w_vis (ported kernel)."""
+    if weights is None:
+        weights = RANK_WEIGHTS
+    for s in (generalization, criticality, distinguishability, visibility):
+        if not 0.0 <= s <= 1.0:
+            raise ValueError(f"Score {s} must be between 0.0 and 1.0")
+    quality = (generalization * criticality) ** 0.5
+    return round(quality * weights["quality"]
+                 + distinguishability * weights["distinguishability"]
+                 + visibility * weights["visibility"], 4)
+
+
+# Verdicts eligible for ranking: only candidates that actually verified something.
+# Everything else is reported below the ranked block with the reason it isn't rankable.
+RANKABLE_VERDICTS = frozenset({"HOLDS-BOUNDED", "HOLDS-PROVEN"})
+
+
+def apply_scores(candidates: List[Candidate], metric_scores: List[Dict],
+                 weights: Optional[Dict[str, float]] = None) -> Tuple[List[Dict], List[Dict]]:
+    """Combine LLM metric scores with verdict gating: returns (ranked, unranked).
+    ranked = [{name, overall, <metrics>, candidate}] sorted by overall desc, only for
+    candidates whose verdict is in RANKABLE_VERDICTS; unranked = the rest with reasons."""
+    by_name = {s["name"]: s for s in metric_scores}
+    ranked, unranked = [], []
+    for c in candidates:
+        v = c.verdict.verdict if c.verdict else None
+        if v not in RANKABLE_VERDICTS:
+            unranked.append({"name": c.name, "reason": f"verdict={v or 'unvalidated'}",
+                             "candidate": c})
+            continue
+        s = by_name.get(c.name)
+        if s is None:
+            unranked.append({"name": c.name, "reason": "no metric scores returned",
+                             "candidate": c})
+            continue
+        overall = compute_score(*(float(s[m]) for m in RANK_METRICS), weights=weights)
+        ranked.append({"name": c.name, "overall": overall,
+                       **{m: float(s[m]) for m in RANK_METRICS}, "candidate": c})
+    ranked.sort(key=lambda r: r["overall"], reverse=True)
+    return ranked, unranked
+
+
+def rank_system_prompt() -> str:
+    return ("You are a specification-ranking expert for the P language: you evaluate "
+            "machine-checked candidate specifications by importance. " + RANK_RUBRIC)
+
+
+def rank_user_prompt(benchmark: str, model_summary: str, candidates: List[Candidate]) -> str:
+    lines = []
+    for c in candidates:
+        f = c.formula
+        lines.append(f"- {c.name}: {c.intent or '(no intent given)'}\n"
+                     f"  observes: {', '.join(c.observes)}; guards: {f.guards}; "
+                     f"relations: {f.relations}; sc: {f.sc}")
+    return (f"PROTOCOL: {benchmark}\n\nP MODEL SUMMARY:\n{model_summary}\n\n"
+            f"CANDIDATE SPECIFICATIONS (all machine-checked HOLDS-BOUNDED):\n"
+            + "\n".join(lines)
+            + "\n\nScore EVERY candidate on the four metrics (0.0-1.0). Return JSON "
+              "{\"scores\":[{\"name\",\"generalization\",\"criticality\","
+              "\"distinguishability\",\"visibility\"}]} — one entry per candidate, no other text.")
+
+
 def repair_user_prompt(name: str, benchmark: str, project_dir: str, error: str, source: str) -> str:
     return (f"This P spec monitor for {benchmark} ({project_dir}) FAILED TO COMPILE. Fix ONLY its "
             f"syntax/encoding — keep the property. NEVER invent event names; read {project_dir}/PSrc for real ones.\n"

--- a/Src/PInfer/Scripts/invariant_core.py
+++ b/Src/PInfer/Scripts/invariant_core.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+invariant_core.py — engine-agnostic shared core for agentic invariant learning.
+
+This is the reusable heart of the PInfer agentic workflow, with NO dependency on
+PeasyAI or Claude Code. Both wrappers build on it:
+  * the PeasyAI MCP tool  (Src/PeasyAI/.../tools/invariants.py) drives it via PeasyAI's LLM,
+  * the Claude Code skill  (.claude/skills/learn-invariants) drives it via agents.
+
+It provides two things:
+  1. DETERMINISTIC VALIDATION — wire candidate spec monitors into a P project, compile,
+     bounded-model-check, classify (HOLDS-BOUNDED / FAILS+cex / VACUOUS / UNKNOWN-VACUITY /
+     INCONCLUSIVE / COMPILE-ERR), with vacuity canaries and detection of pre-existing SUT
+     failures. No LLM. See PLAN.md §6.4 for why passing is HOLDS-BOUNDED, not "HOLDS".
+  2. PROMPT BUILDERS — the template (Specy G→W∧H shapes) + intent-lens proposer prompts, the
+     judge rubric (Specy Table 3), and the P-syntax repair rules. Engine-agnostic strings.
+
+`check_candidates.py` is a thin CLI over the validation half of this module.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+SPEC_RE = re.compile(r"^\s*spec\s+([A-Za-z_]\w*)", re.MULTILINE)
+BUG_RE = re.compile(r"Found (\d+) bug")
+FAIL_RE = re.compile(r"(Assertion Failed:.*|detected liveness bug.*|Deadlock detected.*)")
+
+
+# ───────────────────────────── environment ──────────────────────────────
+
+def build_env() -> Dict[str, str]:
+    """Env where `dotnet` and the `p` global tool resolve. Prefers a working
+    PATH/DOTNET_ROOT; else probes common install dirs (Linux + macOS/homebrew)."""
+    env = dict(os.environ)
+    tools = str(Path.home() / ".dotnet" / "tools")
+    if tools not in env.get("PATH", ""):
+        env["PATH"] = tools + os.pathsep + env.get("PATH", "")
+    if shutil.which("dotnet", path=env["PATH"]):
+        return env
+    probes = ([env["DOTNET_ROOT"]] if env.get("DOTNET_ROOT") else []) + [
+        "/usr/share/dotnet", "/usr/local/share/dotnet", str(Path.home() / ".dotnet"),
+    ] + sorted(glob.glob("/opt/homebrew/Cellar/dotnet@*/*/libexec"))
+    for root in probes:
+        if Path(root, "dotnet").exists() or Path(root, "host").is_dir():
+            env["DOTNET_ROOT"] = root
+            env["PATH"] = root + os.pathsep + env["PATH"]
+            return env
+    return env
+
+
+# ───────────────────────────── data model ───────────────────────────────
+#
+# The verdict vocabulary is deliberately explicit about what model-checking proves
+# (see PLAN.md §6.4). `p check -i N` is *bounded* exploration, not a proof, so a
+# passing candidate is HOLDS-BOUNDED — never a bare "HOLDS". HOLDS-PROVEN is reserved
+# for a future PVerifier stage (Phase 5) and is defined here only so the vocabulary is
+# frozen. Vacuity is a first-class outcome: a candidate whose guard is never reached is
+# VACUOUS, and a candidate for which we cannot even decide vacuity (no canary) is
+# UNKNOWN-VACUITY rather than being silently reported as holding.
+
+VERDICTS = frozenset({
+    "HOLDS-BOUNDED",     # passed bounded model checking; guard provably reached (canary tripped)
+    "HOLDS-PROVEN",      # reserved: proven by PVerifier (Phase 5), never emitted by bounded checking
+    "FAILS",             # monitor assertion violated (candidate-owned failure) + counterexample
+    "VACUOUS",           # holds only because the guarded branch is never reached
+    "UNKNOWN-VACUITY",   # holds, but no canary exists to decide vacuity
+    "INCONCLUSIVE",      # a pre-existing SUT failure fired first; the candidate was never tested
+    "COMPILE-ERR",       # candidate did not compile (dropped)
+})
+
+# What the JUDGE may conclude about a model-checked candidate, and the follow-up it implies.
+JUDGE_VERDICTS = frozenset({"verified", "bug", "spurious", "monitor-bug", "vacuous"})
+DEVELOPMENT_ACTIONS = frozenset({"add-to-tests", "debug-bug", "drop-spurious", "drop-vacuous"})
+
+
+@dataclass
+class Verdict:
+    name: str
+    verdict: str                 # one of VERDICTS
+    detail: str = ""
+    bugs: int = 0
+    owner: str = "monitor"       # monitor | sut
+
+
+@dataclass
+class Formula:
+    """Structured formula record — the part of a candidate that makes dedup/merge/ranking
+    well-defined (PLAN.md §5). Proposers fill this alongside the opaque `spec_code` monitor
+    so two candidates expressing the same property collapse regardless of monitor phrasing."""
+    quantifiers: List[Dict[str, str]] = field(default_factory=list)  # [{var,type,kind: forall|exists}]
+    guards: List[str] = field(default_factory=list)                  # conjunct predicates (antecedent)
+    relations: List[str] = field(default_factory=list)              # conjunct predicates (consequent)
+    sc: Optional[Dict[str, str]] = None                             # quorum/cardinality {op, bound}
+    config_event: Optional[str] = None                             # population source for sc
+    uses_index: bool = False                                        # happens-before term present
+
+    @property
+    def arity(self) -> int:
+        return sum(1 for q in self.quantifiers if q.get("kind", "forall") == "forall")
+
+    def to_dict(self) -> Dict:
+        return {"quantifiers": self.quantifiers, "guards": self.guards,
+                "relations": self.relations, "sc": self.sc,
+                "config_event": self.config_event, "uses_index": self.uses_index}
+
+    @classmethod
+    def from_dict(cls, d: Optional[Dict]) -> "Formula":
+        d = d or {}
+        return cls(quantifiers=list(d.get("quantifiers", [])),
+                   guards=list(d.get("guards", [])),
+                   relations=list(d.get("relations", [])),
+                   sc=d.get("sc"), config_event=d.get("config_event"),
+                   uses_index=bool(d.get("uses_index", False)))
+
+
+@dataclass
+class Candidate:
+    """The unit that flows through the whole pipeline. `formula` enables structured dedup;
+    `spec_code` is the compilable monitor; `verdict`/`provenance_run` are filled by the
+    backbone, not the proposer. Field names are mirrored in propose_templated.js's
+    CAND_SCHEMA — the JS↔Python parity test guards drift (PLAN.md §5, N1)."""
+    name: str
+    intent: str = ""
+    category: str = ""
+    provenance: str = "intent"           # templated | intent | enumerative
+    observes: List[str] = field(default_factory=list)
+    formula: Formula = field(default_factory=Formula)
+    spec_code: str = ""
+    canary: Optional[str] = None
+    predicted_bucket: str = "verified"    # verified | bug | spurious | vacuous
+    verdict: Optional[Verdict] = None
+    provenance_run: Dict = field(default_factory=dict)  # {model,temperature,prompt_hash,iters,seed}
+
+    def to_dict(self) -> Dict:
+        return {"name": self.name, "intent": self.intent, "category": self.category,
+                "provenance": self.provenance, "observes": self.observes,
+                "formula": self.formula.to_dict(), "specCode": self.spec_code,
+                "canary": self.canary, "predictedBucket": self.predicted_bucket,
+                "verdict": None if self.verdict is None else {
+                    "name": self.verdict.name, "verdict": self.verdict.verdict,
+                    "detail": self.verdict.detail, "bugs": self.verdict.bugs,
+                    "owner": self.verdict.owner},
+                "provenanceRun": self.provenance_run}
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "Candidate":
+        # Accept both camelCase (JS/JSON) and snake_case (Python) spellings.
+        v = d.get("verdict")
+        return cls(
+            name=d["name"], intent=d.get("intent", ""), category=d.get("category", ""),
+            provenance=d.get("provenance", "intent"), observes=list(d.get("observes", [])),
+            formula=Formula.from_dict(d.get("formula")),
+            spec_code=d.get("specCode", d.get("spec_code", "")),
+            canary=d.get("canary"),
+            predicted_bucket=d.get("predictedBucket", d.get("predicted_bucket", "verified")),
+            verdict=None if not v else Verdict(v["name"], v["verdict"], v.get("detail", ""),
+                                               v.get("bugs", 0), v.get("owner", "monitor")),
+            provenance_run=d.get("provenanceRun", d.get("provenance_run", {})))
+
+
+# Python mirror of propose_templated.js CAND_SCHEMA (the proposer output contract).
+CANDIDATE_FIELDS = ("name", "intent", "category", "provenance", "observes",
+                    "formula", "specCode", "canary", "predictedBucket")
+
+
+def _norm_pred(p: str) -> str:
+    """Whitespace-insensitive predicate normal form for dedup keys."""
+    return re.sub(r"\s+", "", p)
+
+
+def dedup_key(c: Candidate) -> Tuple:
+    """Canonical identity of a candidate's *property* (PLAN.md §5). Two candidates with the
+    same observed events, same (order-insensitive) guard/relation conjuncts, same SC and
+    quantifier structure are the same property regardless of monitor phrasing or name.
+    On collision, callers cluster-and-keep a representative — they must NOT silently drop."""
+    f = c.formula
+    return (
+        tuple(sorted(c.observes)),
+        tuple(sorted(_norm_pred(g) for g in f.guards)),
+        tuple(sorted(_norm_pred(r) for r in f.relations)),
+        (f.sc["op"], _norm_pred(str(f.sc.get("bound", "")))) if f.sc else None,
+        tuple(sorted(q.get("kind", "forall") for q in f.quantifiers)),
+    )
+
+
+def dedup_candidates(cands: List[Candidate]) -> Tuple[List[Candidate], List[List[Candidate]]]:
+    """Return (representatives, clusters). First candidate of each key is the representative;
+    clusters preserves every member so nothing is lost from metrics."""
+    order: List[Tuple] = []
+    groups: Dict[Tuple, List[Candidate]] = {}
+    for c in cands:
+        k = dedup_key(c)
+        if k not in groups:
+            groups[k] = []
+            order.append(k)
+        groups[k].append(c)
+    return [groups[k][0] for k in order], [groups[k] for k in order]
+
+
+# ─────────────────────── deterministic validation ───────────────────────
+
+def split_specs(candidates_src: str) -> Dict[str, str]:
+    """Map each `spec <Name> ... { ... }` block to its source text."""
+    spans = [(m.start(), m.group(1)) for m in SPEC_RE.finditer(candidates_src)]
+    spans.append((len(candidates_src), None))
+    return {spans[i][1]: candidates_src[spans[i][0]:spans[i + 1][0]]
+            for i in range(len(spans) - 1)}
+
+
+def _wire(project: Path, names: List[str], block_of: Dict[str, str],
+          main: str, assert_in: str, env) -> bool:
+    """Write the given specs + one test each into the project; return compile success."""
+    (project / "PSpec" / "_candidates.p").write_text("\n".join(block_of[n] for n in names))
+    (project / "PTst" / "_candidate_tests.p").write_text(
+        "// AUTO-GENERATED\n\n" + "\n".join(
+            f"test tc_{n} [main={main}]:\n  assert {n} in {assert_in};\n" for n in names))
+    out = subprocess.run(["p", "compile"], cwd=project, env=env,
+                         capture_output=True, text=True).stdout
+    return "Compilation succeeded" in out
+
+
+def _check_one(project: Path, name: str, iters: int, env) -> Tuple[int, str, str]:
+    """Run `p check` for one wired candidate; return (bugs, cex, owner)."""
+    bf = project / "PCheckerOutput" / "BugFinding"
+    for f in glob.glob(str(bf / "*_0_*.txt")):
+        os.remove(f)
+    out = subprocess.run(["p", "check", "-tc", f"tc_{name}", "-i", str(iters)],
+                        cwd=project, env=env, capture_output=True, text=True).stdout
+    m = BUG_RE.search(out)
+    bugs = int(m.group(1)) if m else -1
+    cex, owner = "", "monitor"
+    if bugs > 0:
+        tfs = sorted(glob.glob(str(bf / "*_0_*.txt")), key=os.path.getmtime)
+        if tfs:
+            fm = FAIL_RE.search(Path(tfs[-1]).read_text())
+            cex = (fm.group(1) if fm else "").strip()[:160]
+            # Did THIS candidate's monitor fail, or a pre-existing SUT assertion/deadlock?
+            owner = "monitor" if ("_candidates.p" in cex or "liveness" in cex
+                                  or "hot state" in cex) else "sut"
+    return bugs, cex, owner
+
+
+def validate_candidates(project_path: str, candidates_src: str, main: str,
+                        assert_in: str, iters: int = 2000,
+                        keep: bool = False) -> List[Verdict]:
+    """Wire, compile, bounded-check and classify every candidate spec.
+
+    A `<Name>_canary` block is treated as a vacuity probe for `<Name>`: if both
+    `<Name>` and `<Name>_canary` HOLD, the canary's guarded branch is unreachable,
+    so `<Name>` is VACUOUS. Candidates whose model-check failure is owned by a
+    pre-existing SUT assertion are INCONCLUSIVE (the candidate was never tested).
+    """
+    project = Path(project_path).resolve()
+    env = build_env()
+    block_of = split_specs(candidates_src)
+    names = list(block_of)
+    reals = [n for n in names if not n.endswith("_canary")]
+    canaries = {n[:-7] for n in names if n.endswith("_canary")}
+
+    results: Dict[str, Tuple[int, str, str]] = {}
+    compile_err: set = set()
+    try:
+        if _wire(project, names, block_of, main, assert_in, env):       # fast path
+            for n in names:
+                results[n] = _check_one(project, n, iters, env)
+        else:                                                            # robust: isolate
+            for n in names:
+                if _wire(project, [n], block_of, main, assert_in, env):
+                    results[n] = _check_one(project, n, iters, env)
+                else:
+                    compile_err.add(n)
+                    results[n] = (-1, "COMPILE-ERROR", "monitor")
+    finally:
+        if not keep:
+            (project / "PSpec" / "_candidates.p").unlink(missing_ok=True)
+            (project / "PTst" / "_candidate_tests.p").unlink(missing_ok=True)
+
+    out: List[Verdict] = []
+    for n in reals:
+        bugs, cex, owner = results[n]
+        if n in compile_err:
+            out.append(Verdict(n, "COMPILE-ERR", "candidate did not compile (dropped)", bugs, owner))
+        elif bugs > 0 and owner == "sut":
+            out.append(Verdict(n, "INCONCLUSIVE", f"SUT assertion fired first: {cex}", bugs, owner))
+        elif bugs > 0:
+            out.append(Verdict(n, "FAILS", cex, bugs, owner))
+        elif n in canaries:
+            # Canary asserts false inside the guarded branch: if it TRIPPED (bugs>0) the guard is
+            # reachable, so the candidate holds non-vacuously; if it HELD (bugs==0) the guard is
+            # unreachable, so the candidate is vacuous. A canary that itself failed to run (-1)
+            # leaves vacuity undecided.
+            cbugs = results.get(f"{n}_canary", (-1,))[0]
+            if cbugs == 0:
+                out.append(Verdict(n, "VACUOUS", "guarded branch never reached (canary did not trip)", 0, owner))
+            elif cbugs > 0:
+                out.append(Verdict(n, "HOLDS-BOUNDED", "non-vacuous (canary tripped)", 0, owner))
+            else:
+                out.append(Verdict(n, "UNKNOWN-VACUITY", "canary did not run (compile/check error)", 0, owner))
+        else:
+            # No vacuity canary: bounded checking cannot tell a real invariant from a never-fired
+            # guard. PREP should auto-generate a canary (PLAN.md §6.1); until then, don't overclaim.
+            out.append(Verdict(n, "UNKNOWN-VACUITY", "no vacuity canary (run PREP auto-canary)", 0, owner))
+    return out
+
+
+# ───────────────────────── prompt builders (LLM) ─────────────────────────
+# Engine-agnostic strings: the PeasyAI MCP tool and the Claude Code skill both reuse these.
+
+P_SPEC_RULES = """P SPEC MONITOR SYNTAX RULES:
+- NO inline var init (`var x:T = e;`): declare `var x:T;` at the TOP of a block, assign `x = e;` after.
+- ALL var decls come before any statement in their block. No ternary `?:`. No `not`/`not in` (use `!`, `!(x in s)`).
+- format strings use positional args: `format("...{0}", x)`. assert: `assert <bool>, format(...);`.
+- State names unique within a spec. No `is` keyword. `foreach` not `for`. keys()/values() return seq, not set.
+- Build sets with `s += (elem)`; remove with `-=`. Cast Node to machine via `(x as machine)` for set[machine] membership.
+- EVERY observed event handled in EVERY state. Use a `hot state` only for genuine liveness."""
+
+TEMPLATE_GRAMMAR = """PInfer/Specy template grammar (the search space you instantiate):
+    forall e1:E1,...,eA:EA :: Guards(e) => exists* f1:F1,... :: Witness /\\ Hypothesis
+TERMS = payload-field accesses up to depth 2 (e.g. e1.trial, e2.node); PREDICATES = ==,!=,<,<=,>,>=, in.
+GUARDS constrain which event tuples the property ranges over; HYPOTHESIS is what must then hold.
+ARITY A = #forall events; EXISTS = #existentials (0 = pure universal)."""
+
+TEMPLATE_SHAPES = [
+    ("arity1", "ARITY=1, EXISTS=0. forall e:E :: P(e.fields). Single-event domain/validity invariants over EACH event."),
+    ("arity2-same", "ARITY=2 same type, guarded by a key equality. Monotonicity / uniqueness / no-conflict."),
+    ("arity2-cross", "ARITY=2 different types, guarded by a cross-event key equality. Agreement / causality / consistency."),
+    ("exists", "forall e :: G => exists f :: f.id==e.id /\\ R. Completeness / response / justification (encode as outstanding-fact tracking)."),
+]
+
+INTENT_LENSES = [
+    ("agreement", "SAFETY / AGREEMENT / ATOMICITY: a decision is justified by prior events; no contradictory outcomes; all-or-nothing."),
+    ("liveness", "LIVENESS / PROGRESS: every request/round is eventually answered (hot-state monitors)."),
+    ("consistency", "CONSISTENCY / ORDERING / CAUSALITY: read-your-writes, monotonicity, response-preceded-by-request."),
+    ("validity", "VALIDITY / WELL-FORMEDNESS / UNIQUENESS: payload/status domains, unique ids, non-empty sets; include one deliberately-vacuous candidate + a `<Name>_canary` companion that asserts false in the same branch."),
+]
+
+
+def propose_system_prompt() -> str:
+    return ("You are the PROPOSER stage of an agentic invariant-mining pipeline for the P language. "
+            "Derive intent-level correctness specifications a protocol SHOULD satisfy, and encode each "
+            "as a P `spec` monitor. Derive from INTENT, not from the implementation — mirroring the code "
+            "turns a bug into a 'correct' invariant. " + P_SPEC_RULES)
+
+
+def propose_user_prompt(benchmark: str, project_dir: str, events: str,
+                        prior_kind: str, prior_focus: str, design_doc: str = "") -> str:
+    doc = f"\nDESIGN INTENT:\n{design_doc}\n" if design_doc else ""
+    return (f"TARGET: {benchmark} at {project_dir}. Read its PSrc/*.p and PTst/*.p for exact event/payload "
+            f"names.{doc}\nEvent signatures:\n{events}\n\n{TEMPLATE_GRAMMAR}\n\nYOUR PRIOR ({prior_kind}): "
+            f"{prior_focus}\n\nProduce 3-6 candidates with UNIQUE names prefixed '{benchmark}_{prior_kind}_'. "
+            "Return a JSON array; each item: {\"name\",\"intent\",\"predictedBucket\"(verified|bug|spurious|vacuous),"
+            "\"observes\":[...],\"specCode\":\"<compilable P spec monitor>\"}.")
+
+
+JUDGE_RUBRIC = (
+    "Classify a model-checked candidate the way Specy compares golden vs learned specs (Table 3):\n"
+    "- 'verified': holds and is meaningful (antecedent fires).\n"
+    "- 'bug': an intended guarantee the implementation genuinely VIOLATES (highest value; cite the cex).\n"
+    "- 'spurious': plausible but too strong / fails for a benign reason (e.g. a liveness monitor flagging "
+    "legitimate end-of-trace quiescence; a broadcast-to-N-clients 'duplicate'; a timeout that is expected).\n"
+    "- 'monitor-bug': the failure is an artifact of the monitor being mis-encoded, not a system property.\n"
+    "A liveness (hot-state) failure 'at end of program execution' is almost always spurious/monitor-bug, NOT a bug.\n"
+    "NOTE: 'vacuous' is decided upstream by the VALIDATE stage's canary, not by you — you only see "
+    "candidates that FAILED model checking. Every verdict carries a development_action: "
+    "verified->add-to-tests, bug->debug-bug, spurious/monitor-bug->drop-spurious.")
+
+# Structured output contract for the JUDGE (PLAN.md §7 Phase 4). Kept as a plain dict so both the
+# PeasyAI MCP tool and the Claude Code skill can hand it to their respective structured-output layer.
+JUDGE_OUTPUT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["verdict", "confidence", "cex_grounding", "development_action"],
+    "properties": {
+        "verdict": {"type": "string", "enum": sorted(JUDGE_VERDICTS)},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "cex_grounding": {"type": "string", "description": "one-paragraph reasoning grounded in the counterexample"},
+        "development_action": {"type": "string", "enum": sorted(DEVELOPMENT_ACTIONS)},
+    },
+}
+
+
+def judge_system_prompt() -> str:
+    return "You are a JUDGE in an agentic invariant-mining pipeline for P. " + JUDGE_RUBRIC
+
+
+def judge_user_prompt(name: str, benchmark: str, scenario: str, cex: str, spec_src: str = "") -> str:
+    src = f"\nMONITOR SOURCE:\n{spec_src}\n" if spec_src else ""
+    return (f"Candidate {name} on {benchmark} (scenario: {scenario}) FAILED model checking.\n"
+            f"Counterexample: {cex}{src}\nRead the benchmark source + design intent, then return JSON "
+            "{\"verdict\"(bug|spurious|monitor-bug),\"confidence\"(0-1),\"cex_grounding\":\"...\","
+            "\"development_action\"(debug-bug|drop-spurious)} with reasoning grounded in the cex.")
+
+
+def repair_user_prompt(name: str, benchmark: str, project_dir: str, error: str, source: str) -> str:
+    return (f"This P spec monitor for {benchmark} ({project_dir}) FAILED TO COMPILE. Fix ONLY its "
+            f"syntax/encoding — keep the property. NEVER invent event names; read {project_dir}/PSrc for real ones.\n"
+            f"COMPILER ERROR:\n{error}\n\nBROKEN SOURCE:\n{source}\n\n{P_SPEC_RULES}\n\n"
+            f"Return the corrected full `spec {name} ... {{ ... }}` source.")

--- a/Src/PInfer/Scripts/invariant_core.py
+++ b/Src/PInfer/Scripts/invariant_core.py
@@ -204,6 +204,129 @@ def dedup_candidates(cands: List[Candidate]) -> Tuple[List[Candidate], List[List
     return [groups[k][0] for k in order], [groups[k] for k in order]
 
 
+# ─────────────────────── auto-canary (PLAN.md §6.1) ─────────────────────
+# Vacuity detection must not depend on proposer cooperation: PREP derives a
+# `<Name>_canary` companion from the candidate itself by replacing every assert
+# with `assert false` IN PLACE — same states, same handlers, same guards — so the
+# canary trips iff the guarded branch is reachable. A candidate with no assert
+# (e.g. a pure hot-state liveness monitor) has no derivable canary and stays
+# UNKNOWN-VACUITY rather than being overclaimed.
+
+def _replace_asserts(body: str) -> Tuple[str, int]:
+    """Replace each `assert <expr>[, <msg>];` statement with `assert false, "canary";`,
+    respecting string literals (a `;` inside a format string must not end the scan)."""
+    out, i, n = [], 0, 0
+    while True:
+        m = re.search(r"\bassert\b", body[i:])
+        if not m:
+            out.append(body[i:])
+            break
+        start = i + m.start()
+        out.append(body[i:start])
+        j, in_str = i + m.end(), False
+        while j < len(body):
+            ch = body[j]
+            if in_str:
+                if ch == "\\":
+                    j += 1
+                elif ch == '"':
+                    in_str = False
+            elif ch == '"':
+                in_str = True
+            elif ch == ";":
+                break
+            j += 1
+        out.append('assert false, "canary";')
+        n += 1
+        i = j + 1
+    return "".join(out), n
+
+
+def make_canary(name: str, block: str) -> Optional[str]:
+    """Derive the vacuity canary for one `spec <name> ...` block, or None if the block
+    contains no assert (vacuity undecidable -> UNKNOWN-VACUITY)."""
+    replaced, n = _replace_asserts(block)
+    if n == 0:
+        return None
+    return re.sub(rf"\bspec\s+{re.escape(name)}\b", f"spec {name}_canary", replaced, count=1)
+
+
+# ─────────────────── static name gate (PLAN.md §6.2) ────────────────────
+# Deterministic pre-check before any compile/model-check cycle: every observed event
+# must be declared in the project, every handled event must be observed, and every
+# payload-field access must name a real field of that event's payload. Catches
+# hallucinated names early with a precise diagnostic (feeds REPAIR without burning a
+# compile), mirroring PeasyAI's EventDeclarationValidator / PayloadFieldValidator
+# semantics without importing PeasyAI (this module stays dependency-free).
+
+_EVENT_DECL_RE = re.compile(r"\bevent\s+(\w+)\s*(?::\s*([^;]+?))?\s*;")
+_TYPE_DECL_RE = re.compile(r"\btype\s+(\w+)\s*=\s*\(([^;]*)\)\s*;", re.DOTALL)
+_FIELD_RE = re.compile(r"(\w+)\s*:")
+
+
+def parse_event_decls(project_dir: str) -> Dict[str, Optional[frozenset]]:
+    """Map declared event name -> frozenset of payload field names, or None when the
+    payload isn't a named tuple we can resolve (field checks are then skipped)."""
+    texts = []
+    for p in sorted(Path(project_dir).rglob("*.p")):
+        if "PGenerated" in p.parts or p.name.startswith("_"):
+            continue
+        try:
+            texts.append(p.read_text())
+        except OSError:
+            continue
+    src = "\n".join(texts)
+    named_tuples = {m.group(1): frozenset(_FIELD_RE.findall(m.group(2)))
+                    for m in _TYPE_DECL_RE.finditer(src)}
+    events: Dict[str, Optional[frozenset]] = {}
+    for m in _EVENT_DECL_RE.finditer(src):
+        name, payload = m.group(1), (m.group(2) or "").strip()
+        if not payload:
+            events[name] = frozenset()
+        elif payload.startswith("("):
+            events[name] = frozenset(_FIELD_RE.findall(payload))
+        else:
+            events[name] = named_tuples.get(payload)  # None when unresolvable
+    return events
+
+
+_OBSERVES_RE = re.compile(r"\bobserves\s+([\w\s,]+?)\s*\{")
+_HANDLER_RE = re.compile(r"\bon\s+(\w+)\s+do\s*\(\s*(\w+)\s*:")
+
+
+def static_gate(project_dir: str, block_of: Dict[str, str]) -> Dict[str, List[str]]:
+    """Return {candidate name: [errors]} for candidates referencing undeclared events,
+    handling unobserved events, or accessing undeclared payload fields."""
+    declared = parse_event_decls(project_dir)
+    problems: Dict[str, List[str]] = {}
+    for name, block in block_of.items():
+        errs: List[str] = []
+        om = _OBSERVES_RE.search(block)
+        observed = [e.strip() for e in om.group(1).split(",")] if om else []
+        for ev in observed:
+            if ev and ev not in declared:
+                errs.append(f"observes undeclared event '{ev}'")
+        handlers = list(_HANDLER_RE.finditer(block))
+        for i, hm in enumerate(handlers):
+            ev, param = hm.group(1), hm.group(2)
+            if ev not in declared:
+                errs.append(f"handles undeclared event '{ev}'")
+                continue
+            if observed and ev not in observed:
+                errs.append(f"handles '{ev}' which is not in the observes list")
+            fields = declared[ev]
+            if fields is None:
+                continue  # payload type unresolvable; skip field checks
+            body_end = handlers[i + 1].start() if i + 1 < len(handlers) else len(block)
+            for fa in re.finditer(rf"\b{re.escape(param)}\.(\w+)", block[hm.end():body_end]):
+                if fa.group(1) not in fields:
+                    errs.append(f"'{param}.{fa.group(1)}' — event '{ev}' payload has no field "
+                                f"'{fa.group(1)}' (fields: {sorted(fields)})")
+        if errs:
+            problems[name] = errs
+    return problems
+
+
 # ─────────────────────── deterministic validation ───────────────────────
 
 def split_specs(candidates_src: str) -> Dict[str, str]:
@@ -226,7 +349,54 @@ def _wire(project: Path, names: List[str], block_of: Dict[str, str],
     return "Compilation succeeded" in out
 
 
-def _check_one(project: Path, name: str, iters: int, env) -> Tuple[int, str, str]:
+def _norm_sig(cex: str) -> str:
+    """Failure signature for baseline-differential comparison."""
+    return re.sub(r"\s+", " ", cex).strip()
+
+
+def _attribute_owner(cex: str, baseline_sigs: frozenset) -> str:
+    """monitor-vs-SUT attribution (PLAN.md §6.3): a candidate failure is SUT-owned iff the
+    same failure signature already occurs on the UNMODIFIED project (pre-existing), so the
+    candidate was never actually tested. Anything the baseline never produced — including a
+    deadlock the monitor induced — is attributed to the monitor. A cex that names the
+    candidates file is definitively monitor-owned."""
+    if "_candidates.p" in cex:
+        return "monitor"
+    sig = _norm_sig(cex)
+    if sig and any(sig in b or b in sig for b in baseline_sigs):
+        return "sut"
+    return "monitor"
+
+
+def _baseline_failures(project: Path, main: str, assert_in: str, iters: int, env) -> frozenset:
+    """Bounded-check the UNMODIFIED system (no candidate monitors) once and collect the
+    failure signatures that pre-exist. Bounded exploration can under-approximate this set
+    (a SUT failure only reachable under other schedules is missed) — documented in
+    PLAN.md §11 R3; the iters budget should match the per-candidate budget."""
+    (project / "PSpec" / "_candidates.p").write_text("// baseline: no candidates\n")
+    (project / "PTst" / "_candidate_tests.p").write_text(
+        f"// AUTO-GENERATED baseline\n\ntest tc__baseline [main={main}]:\n  {assert_in};\n")
+    out = subprocess.run(["p", "compile"], cwd=project, env=env,
+                         capture_output=True, text=True).stdout
+    if "Compilation succeeded" not in out:
+        return frozenset()
+    bf = project / "PCheckerOutput" / "BugFinding"
+    for f in glob.glob(str(bf / "*_0_*.txt")):
+        os.remove(f)
+    out = subprocess.run(["p", "check", "-tc", "tc__baseline", "-i", str(iters)],
+                         cwd=project, env=env, capture_output=True, text=True).stdout
+    m = BUG_RE.search(out)
+    if not m or int(m.group(1)) == 0:
+        return frozenset()
+    sigs = set()
+    for tf in glob.glob(str(bf / "*_0_*.txt")):
+        for fm in FAIL_RE.finditer(Path(tf).read_text()):
+            sigs.add(_norm_sig(fm.group(1)))
+    return frozenset(sigs)
+
+
+def _check_one(project: Path, name: str, iters: int, env,
+               baseline_sigs: frozenset = frozenset()) -> Tuple[int, str, str]:
     """Run `p check` for one wired candidate; return (bugs, cex, owner)."""
     bf = project / "PCheckerOutput" / "BugFinding"
     for f in glob.glob(str(bf / "*_0_*.txt")):
@@ -241,39 +411,55 @@ def _check_one(project: Path, name: str, iters: int, env) -> Tuple[int, str, str
         if tfs:
             fm = FAIL_RE.search(Path(tfs[-1]).read_text())
             cex = (fm.group(1) if fm else "").strip()[:160]
-            # Did THIS candidate's monitor fail, or a pre-existing SUT assertion/deadlock?
-            owner = "monitor" if ("_candidates.p" in cex or "liveness" in cex
-                                  or "hot state" in cex) else "sut"
+            owner = _attribute_owner(cex, baseline_sigs)
     return bugs, cex, owner
 
 
 def validate_candidates(project_path: str, candidates_src: str, main: str,
-                        assert_in: str, iters: int = 2000,
-                        keep: bool = False) -> List[Verdict]:
+                        assert_in: str, iters: int = 2000, keep: bool = False,
+                        auto_canary: bool = True, gate: bool = True,
+                        baseline: bool = True) -> List[Verdict]:
     """Wire, compile, bounded-check and classify every candidate spec.
 
-    A `<Name>_canary` block is treated as a vacuity probe for `<Name>`: if both
-    `<Name>` and `<Name>_canary` HOLD, the canary's guarded branch is unreachable,
-    so `<Name>` is VACUOUS. Candidates whose model-check failure is owned by a
-    pre-existing SUT assertion are INCONCLUSIVE (the candidate was never tested).
+    Backbone responsibilities (PLAN.md §6):
+    - auto_canary: derive a `<Name>_canary` vacuity probe for every candidate that
+      lacks one (proposer-supplied canaries are kept). If both `<Name>` and its canary
+      HOLD, the guarded branch is unreachable -> VACUOUS; canary trips -> HOLDS-BOUNDED;
+      no derivable canary -> UNKNOWN-VACUITY.
+    - gate: static name check (undeclared events / unobserved handlers / phantom payload
+      fields) rejects candidates before any compile cycle, with a REPAIR-ready diagnostic.
+    - baseline: bounded-check the unmodified project once; a candidate failure whose
+      signature pre-exists there is INCONCLUSIVE (SUT-owned, candidate never tested).
     """
     project = Path(project_path).resolve()
     env = build_env()
     block_of = split_specs(candidates_src)
-    names = list(block_of)
-    reals = [n for n in names if not n.endswith("_canary")]
+    reals = [n for n in block_of if not n.endswith("_canary")]
+
+    if auto_canary:
+        for n in reals:
+            if f"{n}_canary" not in block_of:
+                c = make_canary(n, block_of[n])
+                if c is not None:
+                    block_of[f"{n}_canary"] = c
+
+    gated: Dict[str, List[str]] = static_gate(str(project), {n: block_of[n] for n in reals}) if gate else {}
+    names = [n for n in block_of
+             if n not in gated and (not n.endswith("_canary") or n[:-7] not in gated)]
     canaries = {n[:-7] for n in names if n.endswith("_canary")}
 
     results: Dict[str, Tuple[int, str, str]] = {}
     compile_err: set = set()
     try:
-        if _wire(project, names, block_of, main, assert_in, env):       # fast path
+        baseline_sigs = _baseline_failures(project, main, assert_in, iters, env) \
+            if (baseline and names) else frozenset()
+        if names and _wire(project, names, block_of, main, assert_in, env):  # fast path
             for n in names:
-                results[n] = _check_one(project, n, iters, env)
-        else:                                                            # robust: isolate
+                results[n] = _check_one(project, n, iters, env, baseline_sigs)
+        elif names:                                                          # robust: isolate
             for n in names:
                 if _wire(project, [n], block_of, main, assert_in, env):
-                    results[n] = _check_one(project, n, iters, env)
+                    results[n] = _check_one(project, n, iters, env, baseline_sigs)
                 else:
                     compile_err.add(n)
                     results[n] = (-1, "COMPILE-ERROR", "monitor")
@@ -281,12 +467,16 @@ def validate_candidates(project_path: str, candidates_src: str, main: str,
         if not keep:
             (project / "PSpec" / "_candidates.p").unlink(missing_ok=True)
             (project / "PTst" / "_candidate_tests.p").unlink(missing_ok=True)
+    for n, errs in gated.items():
+        results[n] = (-1, "static-gate: " + "; ".join(errs), "monitor")
+        compile_err.add(n)
 
     out: List[Verdict] = []
     for n in reals:
         bugs, cex, owner = results[n]
         if n in compile_err:
-            out.append(Verdict(n, "COMPILE-ERR", "candidate did not compile (dropped)", bugs, owner))
+            detail = cex if cex.startswith("static-gate:") else "candidate did not compile (dropped)"
+            out.append(Verdict(n, "COMPILE-ERR", detail, bugs, owner))
         elif bugs > 0 and owner == "sut":
             out.append(Verdict(n, "INCONCLUSIVE", f"SUT assertion fired first: {cex}", bugs, owner))
         elif bugs > 0:

--- a/Src/PInfer/Scripts/merge_candidates.py
+++ b/Src/PInfer/Scripts/merge_candidates.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""merge_candidates.py — hybrid merge: union candidate sets from multiple proposers, dedup
+by the structured property key (invariant_core.dedup_key), cluster-and-keep representatives.
+
+Accepts any mix of:
+  * proposer workflow results:  {"<benchmark>": {"dir": ..., "candidates": [...]}, ...}
+    (the shape propose_templated.js / propose_intent.js return)
+  * plain candidate lists:      [{...candidate...}, ...]
+
+Usage:
+    python3 merge_candidates.py --out merged.json templated.json intent.json [enumerative.json]
+
+Output JSON: {"<benchmark>": {"dir": ..., "candidates": [representatives...],
+              "clusters": [[names...], ...], "stats": {in, out, per_provenance}}}
+The PInfer enumerative adapter (PLAN.md §6.5) emits the same shape, so plugging it in is
+just another positional argument. Nothing is silently dropped: every duplicate is recorded
+in its cluster, and stats carry the in/out counts the §8 reduction-ratio metric needs.
+"""
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariant_core import Candidate, dedup_candidates  # noqa: E402
+
+
+def load_by_benchmark(path: str) -> Dict[str, Tuple[str, List[Candidate]]]:
+    """Normalize either accepted input shape to {benchmark: (dir, [Candidate...])}."""
+    data = json.loads(Path(path).read_text())
+    if isinstance(data, dict) and "result" in data:      # raw Workflow tool result wrapper
+        data = data["result"]
+    if isinstance(data, list):                            # plain candidate list
+        return {"_default": ("", [Candidate.from_dict(c) for c in data])}
+    out: Dict[str, Tuple[str, List[Candidate]]] = {}
+    for bench, info in data.items():
+        cands = info.get("candidates", []) if isinstance(info, dict) else info
+        out[bench] = (info.get("dir", "") if isinstance(info, dict) else "",
+                      [Candidate.from_dict(c) for c in cands])
+    return out
+
+
+def merge(paths: List[str]) -> Dict[str, Dict]:
+    pooled: Dict[str, Tuple[str, List[Candidate]]] = {}
+    for p in paths:
+        for bench, (d, cands) in load_by_benchmark(p).items():
+            prev_dir, prev = pooled.get(bench, ("", []))
+            pooled[bench] = (prev_dir or d, prev + cands)
+
+    result: Dict[str, Dict] = {}
+    for bench, (d, cands) in pooled.items():
+        reps, clusters = dedup_candidates(cands)
+        result[bench] = {
+            "dir": d,
+            "candidates": [c.to_dict() for c in reps],
+            "clusters": [[c.name for c in cl] for cl in clusters if len(cl) > 1],
+            "stats": {
+                "in": len(cands),
+                "out": len(reps),
+                "per_provenance": dict(Counter(c.provenance for c in cands)),
+            },
+        }
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("inputs", nargs="+", help="candidate JSON files (workflow results or lists)")
+    ap.add_argument("--out", default="merged_candidates.json")
+    args = ap.parse_args()
+
+    result = merge(args.inputs)
+    Path(args.out).write_text(json.dumps(result, indent=2))
+    for bench, info in result.items():
+        s = info["stats"]
+        dup = ", ".join("+".join(cl) for cl in info["clusters"]) or "none"
+        print(f"{bench}: {s['in']} in -> {s['out']} out "
+              f"({s['per_provenance']}); duplicate clusters: {dup}")
+    print(f"-> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Src/PInfer/Scripts/prep_candidates.py
+++ b/Src/PInfer/Scripts/prep_candidates.py
@@ -5,9 +5,15 @@ Applies the deterministic P fixups that LLM-generated spec monitors most often n
 (the same class PeasyAI's PCodePostProcessor handles): HTML-entity unescape, `x !in s`
 -> `!(x in s)`, `for(` -> `foreach(`, and splitting inline `var x:T = e;` into a hoisted
 declaration + an in-place assignment (P requires var decls at the top of a block).
+
+Also AUTO-GENERATES a `<Name>_canary` vacuity probe for every candidate that lacks one
+(PLAN.md §6.1): vacuity detection is a backbone responsibility, not a proposer favor.
 """
 import html, json, re, sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariant_core import make_canary  # noqa: E402
 
 HANDLER_RE = re.compile(r'(on\s+\w+\s+do\s*\([^)]*\)\s*|on\s+\w+\s+goto\s+\w+\s+with\s*\([^)]*\)\s*|entry\s*(?:\([^)]*\))?\s*|exit\s*)\{')
 VARINIT_RE = re.compile(r'^(\s*)var\s+(\w+)\s*:\s*([^=;]+?)\s*=\s*(.+?);\s*$')
@@ -70,12 +76,20 @@ def main():
     outdir = Path(sys.argv[2]) if len(sys.argv) > 2 else Path('/tmp')
     for bench, info in by.items():
         cands = info['candidates']
-        blocks = []
+        have = {c['name'] for c in cands}
+        blocks, n_canaries = [], 0
         for c in cands:
+            cleaned = clean(c['specCode'])
             blocks.append(f"// [{c.get('lens','?')}/{c['predictedBucket']}] {c['name']}: {c['intent']}\n"
-                          + clean(c['specCode']))
+                          + cleaned)
+            if not c['name'].endswith('_canary') and f"{c['name']}_canary" not in have:
+                canary = make_canary(c['name'], cleaned)
+                if canary is not None:
+                    blocks.append(f"// auto-canary (vacuity probe) for {c['name']}\n" + canary)
+                    n_canaries += 1
         (outdir / f"cand_{bench}.p").write_text('\n\n'.join(blocks) + '\n')
-        print(f"{bench}: {len(cands)} candidates -> {outdir}/cand_{bench}.p  (dir={info['dir']})")
+        print(f"{bench}: {len(cands)} candidates (+{n_canaries} auto-canaries) -> "
+              f"{outdir}/cand_{bench}.p  (dir={info['dir']})")
 
 
 if __name__ == '__main__':

--- a/Src/PInfer/Scripts/prep_candidates.py
+++ b/Src/PInfer/Scripts/prep_candidates.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Turn a propose-invariants workflow result into per-benchmark candidate .p files.
+
+Applies the deterministic P fixups that LLM-generated spec monitors most often need
+(the same class PeasyAI's PCodePostProcessor handles): HTML-entity unescape, `x !in s`
+-> `!(x in s)`, `for(` -> `foreach(`, and splitting inline `var x:T = e;` into a hoisted
+declaration + an in-place assignment (P requires var decls at the top of a block).
+"""
+import html, json, re, sys
+from pathlib import Path
+
+HANDLER_RE = re.compile(r'(on\s+\w+\s+do\s*\([^)]*\)\s*|on\s+\w+\s+goto\s+\w+\s+with\s*\([^)]*\)\s*|entry\s*(?:\([^)]*\))?\s*|exit\s*)\{')
+VARINIT_RE = re.compile(r'^(\s*)var\s+(\w+)\s*:\s*([^=;]+?)\s*=\s*(.+?);\s*$')
+VARDECL_RE = re.compile(r'^(\s*)var\s+(\w+)\s*:\s*([^=;]+?)\s*;\s*$')
+
+
+def hoist_block(body):
+    """Within one handler body (no outer braces), hoist all var decls to the top,
+    leaving assignments in place."""
+    lines = body.split('\n')
+    decls, rest = [], []
+    for ln in lines:
+        mi = VARINIT_RE.match(ln)
+        md = VARDECL_RE.match(ln)
+        if mi:
+            indent, name, typ, expr = mi.groups()
+            decls.append(f'{indent}var {name}: {typ.strip()};')
+            rest.append(f'{indent}{name} = {expr.strip()};')
+        elif md:
+            indent, name, typ = md.groups()
+            decls.append(f'{indent}var {name}: {typ.strip()};')
+        else:
+            rest.append(ln)
+    return '\n'.join(decls + rest)
+
+
+def fix_handlers(src):
+    """Find each handler body by brace-matching and hoist its var decls."""
+    out, i = [], 0
+    for m in HANDLER_RE.finditer(src):
+        head_end = m.end()  # position just after the '{'
+        depth, j = 1, head_end
+        while j < len(src) and depth:
+            if src[j] == '{':
+                depth += 1
+            elif src[j] == '}':
+                depth -= 1
+            j += 1
+        body = src[head_end:j - 1]
+        if i <= m.start():
+            out.append(src[i:head_end])
+            out.append(hoist_block(body))
+            out.append('}')
+            i = j
+    out.append(src[i:])
+    return ''.join(out)
+
+
+def clean(code):
+    code = html.unescape(code)
+    # `a !in b` -> `!(a in b)` (operands are simple identifiers / field / index accesses)
+    code = re.sub(r'([\w.]+(?:\[[^\]]+\])?)\s*!in\s+([\w.]+(?:\[[^\]]+\])?)', r'!(\1 in \2)', code)
+    code = re.sub(r'\bfor\s*\(', 'foreach (', code)
+    return fix_handlers(code)
+
+
+def main():
+    data = json.loads(Path(sys.argv[1]).read_text())
+    by = data.get('result', data)
+    outdir = Path(sys.argv[2]) if len(sys.argv) > 2 else Path('/tmp')
+    for bench, info in by.items():
+        cands = info['candidates']
+        blocks = []
+        for c in cands:
+            blocks.append(f"// [{c.get('lens','?')}/{c['predictedBucket']}] {c['name']}: {c['intent']}\n"
+                          + clean(c['specCode']))
+        (outdir / f"cand_{bench}.p").write_text('\n\n'.join(blocks) + '\n')
+        print(f"{bench}: {len(cands)} candidates -> {outdir}/cand_{bench}.p  (dir={info['dir']})")
+
+
+if __name__ == '__main__':
+    main()

--- a/Src/PInfer/Scripts/propose_intent.js
+++ b/Src/PInfer/Scripts/propose_intent.js
@@ -1,0 +1,99 @@
+// Intent-lens invariant proposer for P — derives candidates from DESIGN INTENT (docs +
+// source comments), not from the implementation's structure. This is the complement of
+// propose_templated.js: that one systematically instantiates the PInfer grammar shapes
+// (fill-in-the-blank enumeration); this one asks "what SHOULD this protocol guarantee?"
+// through four soft lenses. The two proposers share the CAND_SCHEMA output contract and
+// are deduped downstream by invariant_core.dedup_candidates (PLAN.md Phase 2b).
+//
+// Lens table mirrors invariant_core.INTENT_LENSES (Python is the source of truth);
+// test_invariant_core.py::TestProposerParity guards drift.
+//
+// args = { benchmark, dir, events, designDoc? } — designDoc is optional prose (a
+// README/design excerpt); when absent, agents read design intent from source comments.
+// Returns { <benchmark>: { dir, candidates: [...] } } — the shape prep_candidates.py reads.
+export const meta = {
+  name: 'propose-intent',
+  description: 'Propose P invariants from design intent through agreement/liveness/consistency/validity lenses',
+  phases: [{ title: 'Propose' }],
+}
+
+const A = (typeof args === 'object' && args) ? args : JSON.parse(args)
+
+// Same contract as propose_templated.js (mirrored by invariant_core.Candidate).
+const CAND_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['candidates'],
+  properties: {
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['name', 'intent', 'category', 'predictedBucket', 'observes', 'specCode'],
+        properties: {
+          name: { type: 'string' }, intent: { type: 'string' }, category: { type: 'string' },
+          provenance: { type: 'string', enum: ['templated', 'intent', 'enumerative'] },
+          predictedBucket: { type: 'string', enum: ['verified', 'bug', 'spurious', 'vacuous'] },
+          observes: { type: 'array', items: { type: 'string' } },
+          formula: {
+            type: 'object', additionalProperties: false,
+            properties: {
+              quantifiers: { type: 'array', items: { type: 'object' } },
+              guards: { type: 'array', items: { type: 'string' } },
+              relations: { type: 'array', items: { type: 'string' } },
+              sc: { type: ['object', 'null'] },
+              config_event: { type: ['string', 'null'] },
+              uses_index: { type: 'boolean' },
+            },
+          },
+          canary: { type: ['string', 'null'] },
+          specCode: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const RULES = `P SPEC MONITOR SYNTAX RULES:
+- NO inline var init (\`var x:T = e;\`): declare \`var x:T;\` at the TOP of a block, assign \`x = e;\` after.
+- ALL var decls come before any statement in their block. No ternary \`?:\`. No \`not\`/\`not in\` (use \`!\`, \`!(x in s)\`).
+- format strings use positional args: \`format("...{0}", x)\`. assert: \`assert <bool>, format(...);\`.
+- State names unique within a spec. No \`is\` keyword. \`foreach\` not \`for\`. keys()/values() return seq, not set.
+- Build sets with \`s += (elem)\`; remove with \`-=\`. Cast Node to machine via \`(x as machine)\` for set[machine] membership.
+- EVERY observed event handled in EVERY state. Use a \`hot state\` only for genuine liveness.`
+
+// Mirrors invariant_core.INTENT_LENSES — keep keys and focus text in sync (parity-tested).
+const LENSES = [
+  { key: 'agreement', focus: 'SAFETY / AGREEMENT / ATOMICITY: a decision is justified by prior events; no contradictory outcomes; all-or-nothing.' },
+  { key: 'liveness', focus: 'LIVENESS / PROGRESS: every request/round is eventually answered (hot-state monitors).' },
+  { key: 'consistency', focus: 'CONSISTENCY / ORDERING / CAUSALITY: read-your-writes, monotonicity, response-preceded-by-request.' },
+  { key: 'validity', focus: 'VALIDITY / WELL-FORMEDNESS / UNIQUENESS: payload/status domains, unique ids, non-empty sets; include one deliberately-vacuous candidate + a `<Name>_canary` companion that asserts false in the same branch.' },
+]
+
+const DOC = A.designDoc ? `\nDESIGN INTENT (verbatim, from the design doc):\n${A.designDoc}\n` : ''
+
+phase('Propose')
+const results = (await parallel(LENSES.map(l => () =>
+  agent(
+`You are the INTENT-LENS PROPOSER of an agentic invariant-mining pipeline for the P language (cwd = repo root).
+
+TARGET: ${A.benchmark} at ${A.dir}. Read its PSrc/*.p and PTst/*.p — for EXACT event/payload names AND for design-intent comments (the prose above machines/states/handlers that says what the protocol is SUPPOSED to guarantee).${DOC}
+Event signatures:
+${A.events}
+
+Derive candidates from INTENT, not from the implementation: mirroring the code turns a bug into a "correct" invariant. The valuable candidates live in the gap between what the design promises and what the code does. Propose what a careful protocol designer would DEMAND, even if you suspect the implementation might violate it — a FAILS verdict on a required property is a found bug, the highest-value outcome.
+
+YOUR LENS: ${l.focus}
+
+Produce 3-6 candidates through this lens, each encoded as a compilable P spec monitor:
+- UNIQUE names prefixed '${A.benchmark}_${l.key}_'.
+- provenance: "intent".
+- Fill the structured formula record: quantifiers ([{var,type,kind:"forall"|"exists"}]), guards (antecedent conjuncts as predicate strings, e.g. "e0.transId == e1.transId"), relations (consequent conjuncts), sc (quorum/cardinality {op,bound} or null), config_event (population-announcing event or null), uses_index (true if the property needs happens-before/ordering).
+- observes: exactly the events the monitor observes.
+- predictedBucket: your honest prediction (verified|bug|spurious|vacuous).
+
+${RULES}`,
+    { label: `propose:${l.key}`, phase: 'Propose', schema: CAND_SCHEMA }
+  ).then(r => (r && r.candidates ? r.candidates.map(c => ({ lens: l.key, provenance: 'intent', ...c })) : []))
+))).flat()
+
+log(`${results.length} intent-lens candidates for ${A.benchmark}`)
+return { [A.benchmark]: { dir: A.dir, candidates: results } }

--- a/Src/PInfer/Scripts/propose_templated.js
+++ b/Src/PInfer/Scripts/propose_templated.js
@@ -1,0 +1,101 @@
+// Template-scaffolded invariant proposer for P — uses PInfer's formula grammar
+// (forall* G -> exists* F /\ R, bounded by term-depth/arity/#guards/#filters) as a
+// fill-in-the-blank scaffold, instead of soft natural-language "intent lenses".
+//
+// args = { benchmark, dir, events } where `events` documents the event signatures.
+// Returns { <benchmark>: { dir, candidates: [...] } } — the shape prep_candidates.py reads.
+export const meta = {
+  name: 'propose-templated',
+  description: 'Propose invariants by systematically instantiating PInfer templates over a benchmark',
+  phases: [{ title: 'Templates' }],
+}
+
+const A = (typeof args === 'object' && args) ? args : JSON.parse(args)
+
+// Candidate output contract. Field names are mirrored by the Python `Candidate` dataclass in
+// invariant_core.py; test_invariant_core.py::TestSchemaParity guards drift (PLAN.md §5, N1).
+// `formula` is the structured record that makes dedup/merge/ranking well-defined; `provenance`
+// tags the proposer. Both are optional in the schema (the backbone back-fills when absent) but
+// proposers SHOULD emit `formula` so structured dedup works.
+const CAND_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['candidates'],
+  properties: {
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['name', 'intent', 'category', 'predictedBucket', 'observes', 'specCode'],
+        properties: {
+          name: { type: 'string' }, intent: { type: 'string' }, category: { type: 'string' },
+          provenance: { type: 'string', enum: ['templated', 'intent', 'enumerative'] },
+          predictedBucket: { type: 'string', enum: ['verified', 'bug', 'spurious', 'vacuous'] },
+          observes: { type: 'array', items: { type: 'string' } },
+          formula: {
+            type: 'object', additionalProperties: false,
+            properties: {
+              quantifiers: { type: 'array', items: { type: 'object' } },
+              guards: { type: 'array', items: { type: 'string' } },
+              relations: { type: 'array', items: { type: 'string' } },
+              sc: { type: ['object', 'null'] },
+              config_event: { type: ['string', 'null'] },
+              uses_index: { type: 'boolean' },
+            },
+          },
+          canary: { type: ['string', 'null'] },
+          specCode: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const GRAMMAR = `PInfer TEMPLATE GRAMMAR — the search space you are instantiating:
+
+    forall e1:E1, ..., eA:EA ::  Guards(e1..eA)  =>  exists* f1:F1, ..., fX:FX :: Filters /\\ Relations
+
+where:
+- TERMS are payload-field accesses on the quantified events, up to TERM-DEPTH 2
+  (e.g. e1.trial, e2.node, e1.transId; one level of tuple/field nesting).
+- PREDICATES are comparisons between same-typed terms: ==, !=, <, <=, >, >=, and set/map membership (in).
+- GUARDS = a conjunction of predicates that constrain which event tuples the property ranges over
+  (e.g. e1.transId == e2.transId, e1.node == e2.node).
+- RELATIONS/FILTERS = the predicates asserted to hold on the guarded tuples.
+- ARITY A = number of forall-quantified events; EXISTS X = number of existentials (0 = pure universal).
+
+Systematically enumerate this shape for your assigned configuration over the benchmark's events.
+For each instantiation that expresses a meaningful property, emit a P spec monitor that ENCODES it
+(monitors observe events and accumulate the terms needed to evaluate the predicate across a trace).
+A "forall ... exists" template becomes a monitor that records the forall-side facts and asserts the
+exists-side was eventually satisfied. Skip trivially-true or type-incompatible instantiations.`
+
+const SHAPES = [
+  { key: 'arity1', focus: `ARITY=1, EXISTS=0. forall e:E :: Relations(e.fields). Single-event well-formedness/domain invariants: every payload field stays in its valid range/domain, status enums are restricted, identifiers are bounded. Enumerate over EACH event type.` },
+  { key: 'arity2-same', focus: `ARITY=2, EXISTS=0, both events the SAME type, guarded by an equality on a key field. forall e1:E,e2:E :: e1.key==e2.key => Relation(e1.term, e2.term). Captures monotonicity, uniqueness, and "no two conflicting" properties (e.g. same node/txn never gets two contradictory values; a counter only grows).` },
+  { key: 'arity2-cross', focus: `ARITY=2, EXISTS=0, DIFFERENT event types, guarded by a cross-event key equality. forall e1:E1,e2:E2 :: e1.id==e2.id => Relation. Captures agreement/causality/consistency between a request and its response, a vote and an outcome, a write and a read.` },
+  { key: 'exists', focus: `ARITY>=1, EXISTS>=1. forall e:E :: Guards => exists f:F :: f.id==e.id /\\ Relation. Captures completeness/response/justification: every X is eventually matched by some Y (e.g. every shutdown is eventually reported; every reported-down node had a triggering event). Encode as a monitor tracking outstanding forall-facts and asserting the existential match arrives.` },
+]
+
+phase('Templates')
+const results = (await parallel(SHAPES.map(s => () =>
+  agent(
+`You are a TEMPLATE-SCAFFOLDED invariant proposer for the P language (cwd = repo root).
+
+TARGET: ${A.benchmark} at ${A.dir}. Read its PSrc/*.p and PTst/*.p for EXACT event/payload names and design intent. Event signatures:
+${A.events}
+
+${GRAMMAR}
+
+YOUR ASSIGNED TEMPLATE CONFIGURATION:
+${s.focus}
+
+Enumerate this configuration systematically over the events above (try the relevant event/field combinations, not just the obvious one). Derive properties from the protocol's INTENT (what it should guarantee), not from mirroring the code. Tag each predictedBucket (verified/bug/spurious/vacuous). Produce 3-6 candidates with UNIQUE names prefixed "${A.benchmark}_tmpl_${s.key}_". Each specCode must be a self-contained, compilable P spec monitor (single-state preferred; every observed event handled in every state; var decls at top; format("...{0}", x) for messages; build sets with += ; no ternary/not/inline-var-init). Return structured candidates.`,
+    { label: `tmpl:${s.key}`, phase: 'Templates', schema: CAND_SCHEMA, agentType: 'Explore' }
+  ).then(r => ({ candidates: (r && r.candidates) || [], shape: s.key }))
+))).filter(Boolean)
+
+const candidates = []
+for (const r of results) for (const c of r.candidates) candidates.push({ ...c, lens: 'tmpl_' + r.shape })
+log(`${A.benchmark}: ${candidates.length} template-instantiated candidates`)
+const out = {}
+out[A.benchmark] = { dir: A.dir, candidates }
+return out

--- a/Src/PInfer/Scripts/rank_candidates.py
+++ b/Src/PInfer/Scripts/rank_candidates.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""rank_candidates.py — deterministic half of the RANK stage (PLAN.md Phase 4).
+
+The LLM half (scoring the four metrics) runs in whatever wrapper owns the provider —
+the Claude Code skill, the PeasyAI MCP tool, or a Workflow agent. This CLI covers the
+deterministic ends of that seam:
+
+  1. --emit-prompt : build the ranking prompt for the merged candidate file, so the
+     wrapper only has to relay it and collect RANK_OUTPUT_SCHEMA-shaped scores.
+  2. --apply       : combine returned metric scores with the candidates' verdicts
+     (compute_score kernel + verdict gating) and emit the final ranked report.
+
+Usage:
+    python3 rank_candidates.py --emit-prompt merged.json --benchmark FD --summary summary.txt
+    python3 rank_candidates.py --apply merged.json --scores scores.json --out ranked.json
+
+Only HOLDS-BOUNDED/HOLDS-PROVEN candidates are ranked; everything else is listed
+unranked with its verdict, so nothing silently disappears from the report.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariant_core import (Candidate, apply_scores, rank_system_prompt,  # noqa: E402
+                            rank_user_prompt)
+
+
+def load_candidates(path: str, benchmark: str = None):
+    data = json.loads(Path(path).read_text())
+    if isinstance(data, dict) and "result" in data:
+        data = data["result"]
+    if isinstance(data, list):
+        return [Candidate.from_dict(c) for c in data]
+    if benchmark is None:
+        if len(data) != 1:
+            sys.exit(f"--benchmark required: file has {sorted(data)}")
+        benchmark = next(iter(data))
+    return [Candidate.from_dict(c) for c in data[benchmark]["candidates"]]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--benchmark", help="benchmark key when the file holds several")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--emit-prompt", metavar="MERGED_JSON",
+                      help="print system+user ranking prompts for these candidates")
+    mode.add_argument("--apply", metavar="MERGED_JSON",
+                      help="apply LLM metric scores to these candidates")
+    ap.add_argument("--summary", help="path to a P-model summary text (for --emit-prompt)")
+    ap.add_argument("--scores", help="RANK_OUTPUT_SCHEMA-shaped JSON (for --apply)")
+    ap.add_argument("--out", default="ranked.json")
+    args = ap.parse_args()
+
+    if args.emit_prompt:
+        cands = load_candidates(args.emit_prompt, args.benchmark)
+        summary = Path(args.summary).read_text() if args.summary else "(no summary provided)"
+        print(json.dumps({"system": rank_system_prompt(),
+                          "user": rank_user_prompt(args.benchmark or "?", summary, cands)}))
+        return
+
+    cands = load_candidates(args.apply, args.benchmark)
+    scores = json.loads(Path(args.scores).read_text())
+    scores = scores.get("scores", scores)
+    ranked, unranked = apply_scores(cands, scores)
+
+    print(f"{'#':<4}{'CANDIDATE':<42}{'OVERALL':<9}gen/crit/dist/vis")
+    print("-" * 100)
+    for i, r in enumerate(ranked, 1):
+        print(f"{i:<4}{r['name']:<42}{r['overall']:<9}"
+              f"{r['generalization']}/{r['criticality']}/{r['distinguishability']}/{r['visibility']}")
+    if unranked:
+        print(f"\nUNRANKED ({len(unranked)}):")
+        for u in unranked:
+            print(f"    {u['name']:<42}{u['reason']}")
+
+    Path(args.out).write_text(json.dumps({
+        "ranked": [{k: v for k, v in r.items() if k != "candidate"} |
+                   {"candidate": r["candidate"].to_dict()} for r in ranked],
+        "unranked": [{"name": u["name"], "reason": u["reason"],
+                      "candidate": u["candidate"].to_dict()} for u in unranked],
+    }, indent=2))
+    print(f"-> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Src/PInfer/Scripts/repair_workflow.js
+++ b/Src/PInfer/Scripts/repair_workflow.js
@@ -1,0 +1,52 @@
+export const meta = {
+  name: 'repair-candidates',
+  description: 'LLM-repair P spec monitors that failed to compile, given the exact compiler error',
+  phases: [{ title: 'Repair' }],
+}
+
+const SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['fixedSource', 'changes'],
+  properties: {
+    fixedSource: { type: 'string', description: 'the full corrected `spec ... { ... }` P source, same property, compilable' },
+    changes: { type: 'string', description: 'one-line summary of what was fixed' },
+  },
+}
+
+const RULES = `P SPEC MONITOR SYNTAX RULES (the candidate violated one or more):
+- NO inline var init. Write \`var x: T;\` at the TOP of a handler body, then assign \`x = e;\` as a statement. A spec-level field is \`var x: T;\` only — it CANNOT be initialized at declaration; if you need a constant, inline the literal at use sites, or assign it in the start state's \`entry { }\`.
+- ALL \`var\` declarations must come BEFORE any statement in their block (function/entry/handler). Hoist them to the top.
+- NO ternary \`cond ? a : b\`. Use if/else with a temp var.
+- NO \`not\` / \`not in\`. Use \`!\` and \`!(x in s)\`.
+- format strings use POSITIONAL args: \`format("... {0} ... {1}", a, b)\`. NEVER \`"... {a} ..."\` interpolation. assert form: \`assert <bool>, format(...);\` or \`assert <bool>, "literal";\`.
+- State names must be UNIQUE within a spec (do not reuse a name across hot/cold/normal states).
+- NO \`is\` keyword (PVerifier-only). Compare fields/enum values instead.
+- \`keys(m)\` / \`values(m)\` return seq; iterate with \`foreach (x in keys(m))\`. Use \`foreach\`, never \`for\`.
+- Membership: \`x in set\`/\`k in map\`. Build sets with \`s += (elem)\`; remove with \`s -= (elem)\` / \`m -= (key)\`. There is NO \`delete\`.
+- A set element type must match exactly; cast a Node to machine via \`(x as machine)\` when testing membership in set[machine].
+- EVERY observed event must be handled in EVERY state of the monitor.
+- A liveness monitor uses a \`hot state\`; do not mark a state hot unless the system must always leave it.`
+
+const FINDINGS = Array.isArray(args) ? args : JSON.parse(args)
+
+phase('Repair')
+const repaired = await parallel(FINDINGS.map(f => () =>
+  agent(
+`You are the REPAIR stage of an agentic invariant-mining pipeline for the P language (cwd = repo root). A candidate spec monitor FAILED TO COMPILE. Fix ONLY its syntax/encoding so it compiles — do NOT change the property it expresses.
+
+Benchmark: ${f.benchmark} (source dir: ${f.dir}). Read ${f.dir}/PSrc/*.p AND ${f.dir}/PTst/*.p to get EXACT event names and payload field names. NEVER invent an event name (e.g. do not assume an "eSpec_..._Init" event exists — only use events that actually appear in the source). Build a set with successive \`s += (elem)\` (keys()/values() return seq, NOT set). A reference to an undeclared event/identifier is a hard error.
+
+COMPILER ERROR:
+${f.error}
+
+BROKEN SPEC SOURCE:
+${f.source || `(no source inline — read the spec named "${f.name}" from the candidate file at ${f.sourceFile || `<your candidates file for ${f.benchmark}>`}, grep for "spec ${f.name}". On a repeat round, start from your PRIOR fix for this spec and address the NEW error above.)`}
+
+${RULES}
+
+Return the corrected full \`spec ${f.name} ... { ... }\` source (keep the same spec name and the same intent/property) plus a one-line summary of what you changed. If a property fundamentally cannot be expressed as a P monitor (e.g. it needs the ternary only for a value the property doesn't really need), simplify minimally while preserving the property's meaning.`,
+    { label: `repair:${f.name}`, phase: 'Repair', schema: SCHEMA, agentType: 'Explore' }
+  ).then(r => ({ benchmark: f.benchmark, name: f.name, changes: r && r.changes, fixedSource: r && r.fixedSource }))
+)).then(a => a.filter(Boolean))
+
+return repaired

--- a/Src/PInfer/Scripts/test_invariant_core.py
+++ b/Src/PInfer/Scripts/test_invariant_core.py
@@ -264,8 +264,10 @@ class TestClassificationMatrix(unittest.TestCase):
     def _run(self, wire_ok=True):
         with mock.patch.object(core, "build_env", return_value={}), \
              mock.patch.object(core, "_wire", return_value=wire_ok), \
+             mock.patch.object(core, "static_gate", return_value={}), \
+             mock.patch.object(core, "_baseline_failures", return_value=frozenset()), \
              mock.patch.object(core, "_check_one",
-                               side_effect=lambda proj, n, iters, env: self.CHECK[n]):
+                               side_effect=lambda proj, n, iters, env, base: self.CHECK[n]):
             return {v.name: v for v in core.validate_candidates(
                 "/tmp/does-not-exist-proj", self.SRC, "TestMain", "M", iters=10)}
 
@@ -296,12 +298,126 @@ class TestClassificationMatrix(unittest.TestCase):
 
         with mock.patch.object(core, "build_env", return_value={}), \
              mock.patch.object(core, "_wire", side_effect=fake_wire), \
+             mock.patch.object(core, "static_gate", return_value={}), \
+             mock.patch.object(core, "_baseline_failures", return_value=frozenset()), \
              mock.patch.object(core, "_check_one",
-                               side_effect=lambda proj, n, iters, env: check[n]):
+                               side_effect=lambda proj, n, iters, env, base: check[n]):
             v = {x.name: x for x in core.validate_candidates(
                 "/tmp/does-not-exist-proj", src, "TestMain", "M", iters=10)}
         self.assertEqual(v["CE"].verdict, "COMPILE-ERR")
         self.assertEqual(v["OK"].verdict, "HOLDS-BOUNDED")
+
+
+class TestAutoCanary(unittest.TestCase):
+    def test_replaces_assert_and_renames(self):
+        block = ('spec M observes eX {\n  start state S {\n    on eX do (p: tP) {\n'
+                 '      if (p.v > 0) { assert p.v < 10, format("bad; v={0}", p.v); }\n'
+                 '    }\n  }\n}\n')
+        canary = core.make_canary("M", block)
+        self.assertIsNotNone(canary)
+        self.assertIn("spec M_canary", canary)
+        self.assertNotIn("p.v < 10", canary)                    # original condition gone
+        self.assertIn('assert false, "canary";', canary)
+        self.assertIn("if (p.v > 0)", canary)                    # guard preserved
+        # the `;` inside the format string must not have truncated the replacement
+        self.assertNotIn("bad; v=", canary)
+
+    def test_no_assert_means_no_canary(self):
+        self.assertIsNone(core.make_canary("L", "spec L observes eX { start state S { } }"))
+
+    def test_multiple_asserts_all_replaced(self):
+        block = "spec M observes eX { assert a == b; assert c > d, \"m\"; }"
+        _, n = core._replace_asserts(block)
+        self.assertEqual(n, 2)
+
+    def test_validate_autogenerates_canary(self):
+        # One candidate WITH an assert and NO proposer canary: auto-canary is derived and,
+        # since it trips (guard reachable), the candidate is HOLDS-BOUNDED, not UNKNOWN-VACUITY.
+        src = "spec A observes eX {\n  start state S { on eX do (p: tP) { assert p.v > 0; } }\n}\n"
+        check = {"A": (0, "", "monitor"), "A_canary": (1, "", "monitor")}
+        with mock.patch.object(core, "build_env", return_value={}), \
+             mock.patch.object(core, "_wire", return_value=True), \
+             mock.patch.object(core, "static_gate", return_value={}), \
+             mock.patch.object(core, "_baseline_failures", return_value=frozenset()), \
+             mock.patch.object(core, "_check_one",
+                               side_effect=lambda proj, n, iters, env, base: check[n]):
+            v = {x.name: x for x in core.validate_candidates(
+                "/tmp/does-not-exist-proj", src, "TestMain", "M", iters=10)}
+        self.assertEqual(v["A"].verdict, "HOLDS-BOUNDED")
+
+
+class TestAttribution(unittest.TestCase):
+    def test_candidates_file_is_definitively_monitor(self):
+        self.assertEqual(core._attribute_owner(
+            "Assertion Failed: _candidates.p:12", frozenset({"anything"})), "monitor")
+
+    def test_preexisting_signature_is_sut(self):
+        base = frozenset({"Assertion Failed: Atomicity.p:33 all-or-nothing"})
+        self.assertEqual(core._attribute_owner(
+            "Assertion Failed: Atomicity.p:33  all-or-nothing", base), "sut")
+
+    def test_novel_deadlock_is_monitor(self):
+        # The M5 regression: a monitor-induced deadlock has no trigger substring and no
+        # baseline match — must be attributed to the monitor, not silently dropped as SUT.
+        self.assertEqual(core._attribute_owner(
+            "Deadlock detected. TestMain is waiting", frozenset()), "monitor")
+
+    def test_empty_cex_defaults_to_monitor(self):
+        self.assertEqual(core._attribute_owner("", frozenset({"sig"})), "monitor")
+
+
+class TestStaticGate(unittest.TestCase):
+    def _project(self, tmp: Path) -> Path:
+        (tmp / "PSrc").mkdir()
+        (tmp / "PSrc" / "decls.p").write_text(
+            "type tPing = (fd: machine, trial: int);\n"
+            "event ePing: tPing;\n"
+            "event ePong: (node: machine);\n"
+            "event eShutdown;\n")
+        return tmp
+
+    def test_clean_candidate_passes(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            proj = self._project(Path(td))
+            block = ("spec OK observes ePing, ePong {\n  start state S {\n"
+                     "    on ePing do (p: tPing) { assert p.trial >= 0; }\n"
+                     "    on ePong do (q: (node: machine)) { assert q.node == q.node; }\n  }\n}")
+            self.assertEqual(core.static_gate(str(proj), {"OK": block}), {})
+
+    def test_flags_undeclared_event_unobserved_handler_and_phantom_field(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            proj = self._project(Path(td))
+            block = ("spec BAD observes ePing, eNoSuch {\n  start state S {\n"
+                     "    on ePing do (p: tPing) { assert p.attempt >= 0; }\n"
+                     "    on ePong do (q: (node: machine)) { }\n  }\n}")
+            errs = core.static_gate(str(proj), {"BAD": block})["BAD"]
+        joined = " | ".join(errs)
+        self.assertIn("eNoSuch", joined)                       # undeclared observed event
+        self.assertIn("not in the observes list", joined)       # ePong handled, not observed
+        self.assertIn("p.attempt", joined)                      # phantom payload field
+        self.assertIn("trial", joined)                          # ...with the real fields named
+
+    def test_gated_candidate_becomes_compile_err_with_diagnostic(self):
+        import tempfile
+        src = ("spec BAD observes eNoSuch { start state S { } }\n"
+               "spec OK observes ePing {\n  start state S { on ePing do (p: tPing) "
+               "{ assert p.trial >= 0; } }\n}\n")
+        check = {"OK": (0, "", "monitor"), "OK_canary": (1, "", "monitor")}
+        with tempfile.TemporaryDirectory() as td:
+            proj = self._project(Path(td))
+            with mock.patch.object(core, "build_env", return_value={}), \
+                 mock.patch.object(core, "_wire", return_value=True), \
+                 mock.patch.object(core, "_baseline_failures", return_value=frozenset()), \
+                 mock.patch.object(core, "_check_one",
+                                   side_effect=lambda p, n, iters, env, base: check[n]):
+                v = {x.name: x for x in core.validate_candidates(
+                    str(proj), src, "TestMain", "M", iters=10)}
+        self.assertEqual(v["BAD"].verdict, "COMPILE-ERR")
+        self.assertIn("static-gate:", v["BAD"].detail)
+        self.assertIn("eNoSuch", v["BAD"].detail)
+        self.assertEqual(v["OK"].verdict, "HOLDS-BOUNDED")     # gate didn't block the good one
 
 
 if __name__ == "__main__":

--- a/Src/PInfer/Scripts/test_invariant_core.py
+++ b/Src/PInfer/Scripts/test_invariant_core.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure (no-toolchain) parts of invariant_core.
+
+Run: python3 Src/PInfer/Scripts/test_invariant_core.py
+
+These cover the Phase-1 "frozen contract": the candidate schema (round-trip), the dedup key,
+the judge output schema, JS<->Python schema parity, and the full verdict-classification matrix
+of validate_candidates driven by mocked model-checking (so no `p` toolchain is needed). The
+model-checking half itself is exercised end-to-end by check_candidates.py against the tutorials.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import invariant_core as core
+
+
+class TestSplitSpecs(unittest.TestCase):
+    def test_splits_multiple(self):
+        src = (
+            "spec A observes eX {\n  start state S { on eX do {} }\n}\n\n"
+            "spec B_canary observes eY {\n  start state S { on eY do {} }\n}\n"
+        )
+        blocks = core.split_specs(src)
+        self.assertEqual(set(blocks), {"A", "B_canary"})
+        self.assertIn("spec A", blocks["A"])
+        self.assertIn("spec B_canary", blocks["B_canary"])
+
+    def test_empty(self):
+        self.assertEqual(core.split_specs("// no specs here"), {})
+
+
+class TestPromptBuilders(unittest.TestCase):
+    def test_propose_prompt_mentions_target_and_grammar(self):
+        p = core.propose_user_prompt("FailureDetector", "Tutorial/4_FailureDetector",
+                                     "ePing: (fd, trial)", "tmpl_arity1", "single-event invariants")
+        self.assertIn("FailureDetector", p)
+        self.assertIn("forall", p.lower())
+        self.assertIn("JSON array", p)
+
+    def test_judge_prompt_includes_cex_and_structured_output(self):
+        p = core.judge_user_prompt("FD_x", "FailureDetector", "TestMain",
+                                   "Assertion Failed: ... false positive")
+        self.assertIn("false positive", p)
+        self.assertIn("development_action", p)
+
+    def test_repair_prompt_includes_error_and_rules(self):
+        p = core.repair_user_prompt("S", "B", "dir", "mismatched input '='", "spec S {}")
+        self.assertIn("mismatched input", p)
+        self.assertIn("NO inline var init", p)
+
+    def test_priors_nonempty(self):
+        self.assertTrue(core.TEMPLATE_SHAPES and core.INTENT_LENSES)
+        self.assertTrue(all(len(t) == 2 for t in core.TEMPLATE_SHAPES))
+
+
+class TestEnv(unittest.TestCase):
+    def test_build_env_has_path(self):
+        env = core.build_env()
+        self.assertIn("PATH", env)
+        self.assertIn(".dotnet", env["PATH"])  # global tools dir is prepended
+
+
+class TestVerdictModel(unittest.TestCase):
+    def test_verdict_defaults(self):
+        v = core.Verdict("n", "HOLDS-BOUNDED")
+        self.assertEqual(v.owner, "monitor")
+        self.assertEqual(v.bugs, 0)
+
+    def test_verdict_vocabulary_frozen(self):
+        # Guard against accidental verdict renames — PLAN.md §6.4 depends on these exact strings.
+        self.assertEqual(core.VERDICTS, {
+            "HOLDS-BOUNDED", "HOLDS-PROVEN", "FAILS", "VACUOUS",
+            "UNKNOWN-VACUITY", "INCONCLUSIVE", "COMPILE-ERR"})
+
+
+class TestCandidateSchema(unittest.TestCase):
+    def _sample(self) -> core.Candidate:
+        return core.Candidate(
+            name="TPC_agreement_atomicity", intent="all-or-nothing", category="atomicity",
+            provenance="intent", observes=["eCommit", "eAbort"],
+            formula=core.Formula(
+                quantifiers=[{"var": "e0", "type": "eDecide", "kind": "forall"},
+                             {"var": "e1", "type": "eVote", "kind": "exists"}],
+                guards=["e0.transId == e1.transId"], relations=["e1.vote == SUCCESS"],
+                sc={"op": "==", "bound": "numParticipants"}, config_event="eConfig",
+                uses_index=True),
+            spec_code="spec TPC_agreement_atomicity observes eCommit, eAbort { start state S {} }",
+            canary=None, predicted_bucket="verified")
+
+    def test_round_trip(self):
+        c = self._sample()
+        c2 = core.Candidate.from_dict(c.to_dict())
+        self.assertEqual(c2.to_dict(), c.to_dict())
+        self.assertEqual(c2.formula.arity, 1)  # one forall among the two quantifiers
+        self.assertTrue(c2.formula.uses_index)
+        self.assertEqual(c2.spec_code, c.spec_code)
+
+    def test_from_dict_accepts_camelcase_specCode(self):
+        c = core.Candidate.from_dict({"name": "X", "specCode": "spec X {}",
+                                      "predictedBucket": "bug", "observes": ["eA"]})
+        self.assertEqual(c.spec_code, "spec X {}")
+        self.assertEqual(c.predicted_bucket, "bug")
+
+    def test_verdict_serialized_when_present(self):
+        c = self._sample()
+        c.verdict = core.Verdict("TPC_agreement_atomicity", "HOLDS-BOUNDED", "ok")
+        rt = core.Candidate.from_dict(c.to_dict())
+        self.assertIsNotNone(rt.verdict)
+        self.assertEqual(rt.verdict.verdict, "HOLDS-BOUNDED")
+
+
+class TestDedupKey(unittest.TestCase):
+    def _cand(self, name, observes, guards, relations, sc=None, kinds=("forall",)):
+        return core.Candidate(name=name, observes=observes, formula=core.Formula(
+            quantifiers=[{"kind": k} for k in kinds], guards=guards, relations=relations, sc=sc))
+
+    def test_whitespace_and_order_insensitive(self):
+        a = self._cand("a", ["eY", "eX"], ["e0.k == e1.k", "e0.t>0"], ["e0.v==e1.v"])
+        b = self._cand("b", ["eX", "eY"], ["e0.t > 0", "e0.k==e1.k"], ["e0.v == e1.v"])
+        self.assertEqual(core.dedup_key(a), core.dedup_key(b))
+
+    def test_different_relation_distinguished(self):
+        a = self._cand("a", ["eX"], ["e0.k==e1.k"], ["e0.v < e1.v"])
+        b = self._cand("b", ["eX"], ["e0.k==e1.k"], ["e0.v <= e1.v"])
+        self.assertNotEqual(core.dedup_key(a), core.dedup_key(b))
+
+    def test_sc_distinguishes(self):
+        a = self._cand("a", ["eX"], [], ["r"], sc={"op": "==", "bound": "N"})
+        b = self._cand("b", ["eX"], [], ["r"], sc=None)
+        self.assertNotEqual(core.dedup_key(a), core.dedup_key(b))
+
+    def test_dedup_clusters_and_keeps_representative(self):
+        a = self._cand("a", ["eX"], ["g"], ["r"])
+        b = self._cand("b", ["eX"], ["g"], ["r"])          # same property as a
+        c = self._cand("c", ["eX"], ["g"], ["r2"])          # distinct
+        reps, clusters = core.dedup_candidates([a, b, c])
+        self.assertEqual([r.name for r in reps], ["a", "c"])       # first-wins, nothing dropped
+        self.assertEqual([len(cl) for cl in clusters], [2, 1])     # a+b cluster; c alone
+
+
+class TestJudgeSchema(unittest.TestCase):
+    def test_judge_output_schema_shape(self):
+        s = core.JUDGE_OUTPUT_SCHEMA
+        self.assertEqual(set(s["required"]),
+                         {"verdict", "confidence", "cex_grounding", "development_action"})
+        self.assertEqual(set(s["properties"]["development_action"]["enum"]),
+                         core.DEVELOPMENT_ACTIONS)
+        self.assertEqual(set(s["properties"]["verdict"]["enum"]), core.JUDGE_VERDICTS)
+
+
+class TestSchemaParity(unittest.TestCase):
+    """The proposer output contract lives in propose_templated.js; the consumer contract lives in
+    the Python Candidate dataclass. This guards drift between the two (PLAN.md §5, N1)."""
+    def setUp(self):
+        self.js = (HERE / "propose_templated.js").read_text()
+
+    def test_python_fields_present_in_js_schema(self):
+        for field in core.CANDIDATE_FIELDS:
+            self.assertIn(field, self.js, f"{field} missing from propose_templated.js CAND_SCHEMA")
+
+    def test_js_required_fields_are_known_to_python(self):
+        m = re.search(r"required:\s*\[([^\]]*)\]", self.js)  # first required[] is the candidate's
+        self.assertIsNotNone(m)
+        required = set(re.findall(r"'([^']+)'", m.group(1)))
+        # The candidates-wrapper required is ['candidates']; the item required is the real one.
+        item = re.findall(r"required:\s*\[([^\]]*)\]", self.js)
+        fields = set(re.findall(r"'([^']+)'", item[1]))
+        self.assertTrue(fields.issubset(set(core.CANDIDATE_FIELDS)),
+                        f"JS-required fields not modeled in Python: {fields - set(core.CANDIDATE_FIELDS)}")
+
+
+class TestClassificationMatrix(unittest.TestCase):
+    """validate_candidates classification, every branch, with model-checking mocked out."""
+
+    SRC = (
+        "spec HB observes eX {}\n"          # holds, canary trips -> HOLDS-BOUNDED
+        "spec HB_canary observes eX {}\n"
+        "spec VAC observes eX {}\n"          # holds, canary holds -> VACUOUS
+        "spec VAC_canary observes eX {}\n"
+        "spec UNKC observes eX {}\n"         # holds, canary errored -> UNKNOWN-VACUITY
+        "spec UNKC_canary observes eX {}\n"
+        "spec NOCAN observes eX {}\n"        # holds, no canary -> UNKNOWN-VACUITY
+        "spec FAIL observes eX {}\n"         # bugs, monitor-owned -> FAILS
+        "spec INC observes eX {}\n"          # bugs, sut-owned -> INCONCLUSIVE
+    )
+    CHECK = {  # name -> (bugs, cex, owner)
+        "HB": (0, "", "monitor"), "HB_canary": (1, "", "monitor"),
+        "VAC": (0, "", "monitor"), "VAC_canary": (0, "", "monitor"),
+        "UNKC": (0, "", "monitor"), "UNKC_canary": (-1, "COMPILE-ERROR", "monitor"),
+        "NOCAN": (0, "", "monitor"),
+        "FAIL": (1, "Assertion Failed: _candidates.p", "monitor"),
+        "INC": (1, "Assertion Failed: SUT", "sut"),
+    }
+
+    def _run(self, wire_ok=True):
+        with mock.patch.object(core, "build_env", return_value={}), \
+             mock.patch.object(core, "_wire", return_value=wire_ok), \
+             mock.patch.object(core, "_check_one",
+                               side_effect=lambda proj, n, iters, env: self.CHECK[n]):
+            return {v.name: v for v in core.validate_candidates(
+                "/tmp/does-not-exist-proj", self.SRC, "TestMain", "M", iters=10)}
+
+    def test_all_branches(self):
+        v = self._run()
+        self.assertEqual(v["HB"].verdict, "HOLDS-BOUNDED")
+        self.assertEqual(v["VAC"].verdict, "VACUOUS")
+        self.assertEqual(v["UNKC"].verdict, "UNKNOWN-VACUITY")
+        self.assertEqual(v["NOCAN"].verdict, "UNKNOWN-VACUITY")
+        self.assertEqual(v["FAIL"].verdict, "FAILS")
+        self.assertEqual(v["INC"].verdict, "INCONCLUSIVE")
+        # canaries are probes, not reported as real candidates
+        self.assertNotIn("HB_canary", v)
+
+    def test_all_emitted_verdicts_are_in_vocabulary(self):
+        for verdict in self._run().values():
+            self.assertIn(verdict.verdict, core.VERDICTS)
+
+    def test_compile_error_branch(self):
+        # Batch wire fails, and single-wire fails only for CE.
+        src = "spec OK observes eX {}\nspec OK_canary observes eX {}\nspec CE observes eX {}\n"
+        check = {"OK": (0, "", "monitor"), "OK_canary": (1, "", "monitor")}
+
+        def fake_wire(project, names, block_of, main, assert_in, env):
+            if len(names) > 1:
+                return False               # force the isolate path
+            return names[0] != "CE"        # CE never compiles
+
+        with mock.patch.object(core, "build_env", return_value={}), \
+             mock.patch.object(core, "_wire", side_effect=fake_wire), \
+             mock.patch.object(core, "_check_one",
+                               side_effect=lambda proj, n, iters, env: check[n]):
+            v = {x.name: x for x in core.validate_candidates(
+                "/tmp/does-not-exist-proj", src, "TestMain", "M", iters=10)}
+        self.assertEqual(v["CE"].verdict, "COMPILE-ERR")
+        self.assertEqual(v["OK"].verdict, "HOLDS-BOUNDED")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Src/PInfer/Scripts/test_invariant_core.py
+++ b/Src/PInfer/Scripts/test_invariant_core.py
@@ -238,6 +238,58 @@ class TestMergeCandidates(unittest.TestCase):
         self.assertEqual(merged["_default"]["stats"]["in"], 1)
 
 
+class TestRanking(unittest.TestCase):
+    def _cand(self, name, verdict=None):
+        c = core.Candidate(name=name, intent=f"intent of {name}", observes=["eX"],
+                           formula=core.Formula(guards=["g"], relations=["r"]))
+        if verdict:
+            c.verdict = core.Verdict(name, verdict)
+        return c
+
+    def test_compute_score_kernel(self):
+        # sqrt(0.9*0.6)*0.8 + 0.5*0.2 + 1.0*0.0  (ported formula, default weights)
+        self.assertEqual(core.compute_score(0.9, 0.6, 0.5, 1.0),
+                         round((0.9 * 0.6) ** 0.5 * 0.8 + 0.5 * 0.2, 4))
+
+    def test_compute_score_validates_range(self):
+        with self.assertRaises(ValueError):
+            core.compute_score(1.2, 0.5, 0.5, 0.5)
+
+    def test_compute_score_custom_weights(self):
+        w = {"quality": 0.0, "distinguishability": 1.0, "visibility": 0.0}
+        self.assertEqual(core.compute_score(0.1, 0.1, 0.7, 0.0, weights=w), 0.7)
+
+    def test_apply_scores_gates_and_sorts(self):
+        cands = [self._cand("low", "HOLDS-BOUNDED"), self._cand("high", "HOLDS-BOUNDED"),
+                 self._cand("vac", "VACUOUS"), self._cand("fails", "FAILS"),
+                 self._cand("unvalidated"), self._cand("noscores", "HOLDS-BOUNDED")]
+        scores = [
+            {"name": "low", "generalization": 0.2, "criticality": 0.2,
+             "distinguishability": 0.2, "visibility": 0.0},
+            {"name": "high", "generalization": 0.9, "criticality": 0.9,
+             "distinguishability": 0.9, "visibility": 0.0},
+            {"name": "vac", "generalization": 1.0, "criticality": 1.0,   # gated out anyway
+             "distinguishability": 1.0, "visibility": 1.0},
+        ]
+        ranked, unranked = core.apply_scores(cands, scores)
+        self.assertEqual([r["name"] for r in ranked], ["high", "low"])
+        reasons = {u["name"]: u["reason"] for u in unranked}
+        self.assertEqual(reasons["vac"], "verdict=VACUOUS")          # perfect scores can't rescue it
+        self.assertEqual(reasons["fails"], "verdict=FAILS")
+        self.assertEqual(reasons["unvalidated"], "verdict=unvalidated")
+        self.assertEqual(reasons["noscores"], "no metric scores returned")
+
+    def test_rank_prompts_and_schema(self):
+        c = self._cand("FD_x", "HOLDS-BOUNDED")
+        up = core.rank_user_prompt("FD", "summary text", [c])
+        self.assertIn("FD_x", up)
+        self.assertIn("summary text", up)
+        for m in core.RANK_METRICS:
+            self.assertIn(m, core.rank_system_prompt().lower())
+        item = core.RANK_OUTPUT_SCHEMA["properties"]["scores"]["items"]
+        self.assertEqual(set(item["required"]), {"name", *core.RANK_METRICS})
+
+
 class TestClassificationMatrix(unittest.TestCase):
     """validate_candidates classification, every branch, with model-checking mocked out."""
 

--- a/Src/PInfer/Scripts/test_invariant_core.py
+++ b/Src/PInfer/Scripts/test_invariant_core.py
@@ -174,6 +174,70 @@ class TestSchemaParity(unittest.TestCase):
                         f"JS-required fields not modeled in Python: {fields - set(core.CANDIDATE_FIELDS)}")
 
 
+class TestProposerParity(unittest.TestCase):
+    """invariant_core.INTENT_LENSES is the source of truth; propose_intent.js mirrors it
+    (same pattern as TestSchemaParity). Guards lens drift between Python and the workflow."""
+    def setUp(self):
+        self.js = (HERE / "propose_intent.js").read_text()
+
+    def test_all_lenses_present_in_js(self):
+        for key, _focus in core.INTENT_LENSES:
+            self.assertIn(f"key: '{key}'", self.js, f"lens '{key}' missing from propose_intent.js")
+
+    def test_js_declares_intent_provenance_and_schema_fields(self):
+        self.assertIn("provenance: 'intent'", self.js)
+        for field in ("formula", "canary", "specCode", "predictedBucket"):
+            self.assertIn(field, self.js)
+
+
+class TestMergeCandidates(unittest.TestCase):
+    def setUp(self):
+        import merge_candidates
+        self.mc = merge_candidates
+
+    def _write(self, tmp: Path, name: str, payload) -> str:
+        p = tmp / name
+        p.write_text(__import__("json").dumps(payload))
+        return str(p)
+
+    def _cand(self, name, provenance, guards, relations):
+        return {"name": name, "intent": "", "category": "", "provenance": provenance,
+                "observes": ["eX"], "specCode": f"spec {name} observes eX {{}}",
+                "predictedBucket": "verified",
+                "formula": {"quantifiers": [{"kind": "forall"}], "guards": guards,
+                            "relations": relations, "sc": None, "config_event": None,
+                            "uses_index": False}}
+
+    def test_merge_dedups_across_proposers_and_keeps_stats(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            templated = {"FD": {"dir": "Tutorial/4_FailureDetector", "candidates": [
+                self._cand("FD_tmpl_mono", "templated", ["e0.k==e1.k"], ["e0.v <= e1.v"]),
+                self._cand("FD_tmpl_uniq", "templated", [], ["e0.id != e1.id"])]}}
+            intent = {"FD": {"dir": "Tutorial/4_FailureDetector", "candidates": [
+                # same property as FD_tmpl_mono, different name/phrasing/whitespace
+                self._cand("FD_intent_mono", "intent", ["e0.k == e1.k"], ["e0.v<=e1.v"]),
+                self._cand("FD_intent_resp", "intent", ["g"], ["r"])]}}
+            merged = self.mc.merge([self._write(tmp, "t.json", templated),
+                                    self._write(tmp, "i.json", intent)])
+        fd = merged["FD"]
+        self.assertEqual(fd["stats"], {"in": 4, "out": 3,
+                                       "per_provenance": {"templated": 2, "intent": 2}})
+        names = [c["name"] for c in fd["candidates"]]
+        self.assertEqual(names, ["FD_tmpl_mono", "FD_tmpl_uniq", "FD_intent_resp"])
+        self.assertEqual(fd["clusters"], [["FD_tmpl_mono", "FD_intent_mono"]])  # nothing silently dropped
+        self.assertEqual(fd["dir"], "Tutorial/4_FailureDetector")
+
+    def test_merge_accepts_plain_list(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            merged = self.mc.merge([self._write(tmp, "l.json",
+                                                [self._cand("A", "intent", [], ["r"])])])
+        self.assertEqual(merged["_default"]["stats"]["in"], 1)
+
+
 class TestClassificationMatrix(unittest.TestCase):
     """validate_candidates classification, every branch, with model-checking mocked out."""
 

--- a/Src/PInfer/Scripts/verify_repairs.py
+++ b/Src/PInfer/Scripts/verify_repairs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Verify LLM-repaired spec monitors: wire each fixed spec alone into its project and
+recompile, reporting how many of the previously-broken candidates now compile.
+
+Input JSON (the repair workflow result): [{benchmark, dir, name, fixedSource, changes?}]
+Usage: python3 verify_repairs.py repairs.json
+"""
+import json, subprocess, sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from invariant_core import build_env  # noqa: E402  (single source of the dotnet/`p` resolver)
+
+
+def main():
+    env = build_env()
+    data = json.loads(Path(sys.argv[1]).read_text())
+    ok, bad = [], []
+    for r in data:
+        d = r["dir"]
+        diag = Path(d) / "PSpec" / "_diag.p"
+        diag.write_text(r["fixedSource"])
+        out = subprocess.run(["p", "compile"], cwd=d, env=env, capture_output=True, text=True).stdout
+        diag.unlink(missing_ok=True)
+        if "Compilation succeeded" in out:
+            ok.append(r["name"])
+            print(f"  OK   {r['name']}  ({r.get('changes','')[:70]})")
+        else:
+            first = next((l.strip() for l in out.splitlines()
+                          if "error" in l.lower() and "0 Error" not in l), "")
+            bad.append((r["name"], first[:120]))
+            print(f"  FAIL {r['name']}: {first[:100]}")
+    print(f"\nRepaired-and-compiles: {len(ok)}/{len(data)}")
+    if bad:
+        print("Still failing (feed these errors back for another repair round):")
+        for n, e in bad:
+            print(f"  - {n}: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Implements the machine-independent core of the **unified P specification-inference plan** ([`Src/PInfer/Scripts/PLAN.md`](https://github.com/p-org/P/blob/claude/quizzical-mclaren-c279df/Src/PInfer/Scripts/PLAN.md)): a single validate→prune→rank→judge backbone with pluggable proposers, where LLM proposers derive candidate `spec` monitors from design intent and **PChecker is the sound oracle**. Supersedes the scripts in #974 (same lineage, hardened).

The plan is v2 — it incorporates a 44-finding multi-agent review of the v1 design; §13 of PLAN.md maps every finding to its resolution. The three silent-failure classes that review surfaced are fixed here:

| Review finding | Fix in this PR |
|---|---|
| Vacuity depended on the proposer emitting a canary — vacuous specs reported as verified | **Auto-canary** (`make_canary`): backbone derives a `<Name>_canary` probe from any candidate by replacing its asserts in place; canary-less monitors report `UNKNOWN-VACUITY`, never a bare pass |
| Monitor-vs-SUT attribution by substring match — a monitor-induced deadlock was silently dropped | **Baseline-differential attribution**: bounded-check the unmodified project once; a failure is SUT-owned iff its signature pre-exists (regression-tested on the deadlock case) |
| Hallucinated event/field names survived to model-checking | **Static name gate**: parses project `event`/`type` decls; rejects undeclared events, unobserved handlers, phantom payload fields — before any compile cycle, with a repair-ready diagnostic |

## Structure (`Src/PInfer/Scripts/`)

- **`invariant_core.py`** — the hub: frozen `Candidate`/`Formula` schema (structured guards/relations/SC/quorum fields), canonical dedup key (cluster-and-keep, nothing silently dropped), honest verdict vocabulary (`HOLDS-BOUNDED` vs reserved `HOLDS-PROVEN`, `VACUOUS`, `UNKNOWN-VACUITY`, `INCONCLUSIVE`), judge contract with `development_action`, ranking kernel (`compute_score`, ported from `experimental/pinfer`'s `ranking_with_llm.py` minus Strands/Bedrock coupling) — all engine-agnostic; wrappers own the LLM provider.
- **Proposers**: `propose_templated.js` (grammar-scaffold enumeration) + `propose_intent.js` (new: design-intent lenses) emitting one schema; JS↔Python parity is unit-tested.
- **Pipeline CLIs**: `merge_candidates.py` (hybrid merge + per-provenance stats), `prep_candidates.py` (P fixups + auto-canaries), `check_candidates.py` (gate → baseline → wire → bounded-check → classify), `diag_compile.py`/`repair_workflow.js`/`verify_repairs.py` (compile-repair loop), `rank_candidates.py` (verdict-gated ranking).

## Testing

- 42 unit tests (`test_invariant_core.py`), no toolchain needed: schema round-trip, dedup, full mocked verdict-classification matrix, attribution (incl. the deadlock regression), gate, canary derivation (incl. `;`-inside-format-string), ranking kernel + gating, JS↔Python parity.
- `rank_candidates.py`/`merge_candidates.py` smoke-tested end-to-end on fixtures.
- **Not yet run**: live `p compile`/`p check` acceptance on FD/TPC (+ fault-injected variant, N≥3 seeds, §8 metrics) — needs a box with .NET 8 + `p install` + an LLM runtime; that is the milestone's remaining exit criterion and is called out in PLAN.md §12.

## Reviewer notes

- PInfer's C# enumerator and Z3 remain **optional plug-in tiers** (PLAN.md §3); nothing here depends on `experimental/pinfer` building.
- The verdict vocabulary is deliberately conservative: nothing is labeled verified/sound on bounded checking alone.
- Experimental tooling; no compiler/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)