### PR TITLE
Fix three critical silent-failure bugs (constant folding, PObserve parse abort, PeasyAI validator)

### DIFF
--- a/Src/PCompiler/CompilerCore/TypeChecker/SimpleExprEval.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/SimpleExprEval.cs
@@ -75,7 +75,7 @@ public abstract class SimpleExprEval
                 {
                     BinOpType.Add => new IntLiteralExpr(ForceInt(lhs) + ForceInt(rhs)),
                     BinOpType.Sub => new IntLiteralExpr(ForceInt(lhs) - ForceInt(rhs)),
-                    BinOpType.Mul => new IntLiteralExpr(ForceInt(lhs) + ForceInt(rhs)),
+                    BinOpType.Mul => new IntLiteralExpr(ForceInt(lhs) * ForceInt(rhs)),
                     BinOpType.Div => new IntLiteralExpr(ForceInt(lhs) / ForceInt(rhs)),
                     BinOpType.Mod => new IntLiteralExpr(ForceInt(lhs) % ForceInt(rhs)),
                     BinOpType.Eq => EvalEq(lhs, rhs),

--- a/Src/PObserve/PObserve/src/main/java/pobserve/executor/ParseEventStream.java
+++ b/Src/PObserve/PObserve/src/main/java/pobserve/executor/ParseEventStream.java
@@ -25,23 +25,26 @@ public class ParseEventStream {
      * @throws Exception when parsing fails for any of the log lines
      */
     public static Stream<? extends PObserveEvent<?>> parseToPObserveEvents(Stream<Object> inputStream) throws Exception {
-        try {
-            return inputStream.flatMap(logLine -> {
-                try {
-                    return ParseLogLine(logLine).filter(event -> {
-                        boolean keep = EventFilterUtils.filterBasedOnSpecObservation(event);
-                        if (keep) {
-                            getPObserveMetrics().addMetric(MetricConstants.TOTAL_EVENTS_READ, 1);
-                        }
-                        return keep;
-                    });
-                } catch (PObserveLogParsingException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } catch (RuntimeException ignored) {
-            return Stream.empty();
-        }
+        return inputStream.flatMap(logLine -> {
+            try {
+                return ParseLogLine(logLine).filter(event -> {
+                    boolean keep = EventFilterUtils.filterBasedOnSpecObservation(event);
+                    if (keep) {
+                        getPObserveMetrics().addMetric(MetricConstants.TOTAL_EVENTS_READ, 1);
+                    }
+                    return keep;
+                });
+            } catch (PObserveLogParsingException e) {
+                // A single unparseable log line must NOT abort verification of the whole
+                // stream. The stream is lazy, so throwing here would surface during the
+                // downstream terminal operation and escape to PObserveExecutor.run()'s
+                // blanket handler, which increments TOTAL_UNKNOWN_ERRORS and aborts the
+                // entire run -- masquerading as a "no bugs found" result. ParseLogLine has
+                // already recorded this failure (TOTAL_PARSER_ERRORS + TrackErrors), so we
+                // skip only this line and continue parsing the rest of the stream.
+                return Stream.<PObserveEvent<?>>empty();
+            }
+        });
     }
 
     /**

--- a/Src/PeasyAI/src/core/validation/validators.py
+++ b/Src/PeasyAI/src/core/validation/validators.py
@@ -243,6 +243,7 @@ class VarDeclarationOrderValidator(Validator):
     ) -> ValidationResult:
         issues: List[ValidationIssue] = []
         replacements = []
+        reorder_blocks: List[str] = []
 
         for block_name, header, body, start_pos, close_pos in iter_all_code_blocks(code):
             lines = body.split("\n")
@@ -283,13 +284,25 @@ class VarDeclarationOrderValidator(Validator):
                 new_body = "\n".join(var_lines + other_lines)
                 replacement = header + "{" + new_body + "}"
                 replacements.append((start_pos, close_pos + 1, replacement))
+                reorder_blocks.append(block_name)
+
+        # Emit one ERROR per offending block (for accurate reporting), but attach
+        # the auto-fix to ONLY the first issue. That single fixer rewrites all
+        # offending blocks in one reversed-splice pass over the original code.
+        # Previously each issue captured a growing prefix of `replacements`
+        # (via replacements[:]) and the pipeline applied them independently to the
+        # already-mutated code, so with 2+ reorderable blocks the later fixers
+        # spliced with stale offsets and corrupted the saved P source.
+        if replacements:
+            bulk_fix = self._make_bulk_fix(replacements)
+            for idx, block_name in enumerate(reorder_blocks):
                 issues.append(ValidationIssue(
                     severity=IssueSeverity.ERROR,
                     validator=self.name,
                     message=f"Variable declaration after statement in '{block_name}'",
                     suggestion="Move var declarations to the start of the block",
-                    auto_fixable=True,
-                    fix_function=self._make_bulk_fix(replacements[:]),
+                    auto_fixable=(idx == 0),
+                    fix_function=bulk_fix if idx == 0 else None,
                 ))
 
         # Also detect vars declared inside while/foreach loops
@@ -315,7 +328,10 @@ class VarDeclarationOrderValidator(Validator):
     @staticmethod
     def _make_bulk_fix(repls):
         def fixer(code: str) -> str:
-            for start, end, repl in reversed(repls):
+            # Splice from the highest offset to the lowest so earlier offsets stay
+            # valid as later regions are replaced. Sort explicitly rather than
+            # relying on insertion order so the splice is deterministic.
+            for start, end, repl in sorted(repls, key=lambda r: r[0], reverse=True):
                 code = code[:start] + repl + code[end:]
             return code
         return fixer

--- a/Src/PeasyAI/tests/test_validation.py
+++ b/Src/PeasyAI/tests/test_validation.py
@@ -23,6 +23,7 @@ from core.validation import (
     ProjectPathValidator,
     IssueSeverity,
     NamedTupleConstructionValidator,
+    VarDeclarationOrderValidator,
 )
 
 
@@ -869,6 +870,74 @@ class TestDocumentationReviewParser:
         import inspect
         sig = inspect.signature(PCodePostProcessor.process)
         assert "design_doc" not in sig.parameters
+
+
+class TestVarDeclarationOrderValidator:
+    """Tests for VarDeclarationOrderValidator, especially the multi-block auto-fix."""
+
+    @staticmethod
+    def _apply_like_pipeline(code):
+        """Mirror pipeline.py: apply each auto-fixable issue's fix sequentially
+        to the evolving code (this is exactly the loop that used to corrupt
+        output when >1 block carried a cumulative replacement snapshot)."""
+        validator = VarDeclarationOrderValidator()
+        result = validator.validate(code)
+        current = code
+        applied = 0
+        for issue in result.issues:
+            if issue.auto_fixable and issue.fix_function:
+                new_code = issue.apply_fix(current)
+                if new_code != current:
+                    current = new_code
+                    applied += 1
+        errors = sum(1 for i in result.issues if i.severity == IssueSeverity.ERROR)
+        return current, applied, errors
+
+    def test_two_blocks_reorder_without_corruption(self):
+        """Regression: two blocks each needing reorder must not corrupt the code.
+
+        Previously each issue captured a growing prefix of the replacement list
+        and the pipeline applied them independently against already-mutated text,
+        splicing with stale offsets and duplicating/garbling declarations.
+        """
+        code = (
+            "fun foo() {\n"
+            "x = 1;\n"
+            "var x: int;\n"
+            "}\n"
+            "fun bar() {\n"
+            "y = 2;\n"
+            "var y: int;\n"
+            "}\n"
+        )
+        fixed_code, applied, errors = self._apply_like_pipeline(code)
+
+        # Nothing duplicated or lost
+        assert fixed_code.count("var x: int;") == 1
+        assert fixed_code.count("var y: int;") == 1
+        assert fixed_code.count("x = 1;") == 1
+        assert fixed_code.count("y = 2;") == 1
+        # Each declaration now precedes its assignment
+        assert fixed_code.index("var x: int;") < fixed_code.index("x = 1;")
+        assert fixed_code.index("var y: int;") < fixed_code.index("y = 2;")
+        # One consolidated fix, but both offending blocks still reported
+        assert applied == 1
+        assert errors == 2
+
+    def test_single_block_reorder(self):
+        code = "fun foo() {\nx = 1;\nvar x: int;\n}\n"
+        fixed_code, applied, errors = self._apply_like_pipeline(code)
+        assert fixed_code.count("var x: int;") == 1
+        assert fixed_code.index("var x: int;") < fixed_code.index("x = 1;")
+        assert applied == 1
+        assert errors == 1
+
+    def test_already_ordered_no_fix(self):
+        code = "fun foo() {\nvar x: int;\nx = 1;\n}\n"
+        fixed_code, applied, errors = self._apply_like_pipeline(code)
+        assert applied == 0
+        assert errors == 0
+        assert fixed_code == code
 
 
 if __name__ == "__main__":

--- a/Tst/UnitTests/TypeChecker/SimpleExprEvalTest.cs
+++ b/Tst/UnitTests/TypeChecker/SimpleExprEvalTest.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Plang.Compiler.TypeChecker;
+using Plang.Compiler.TypeChecker.AST;
+using Plang.Compiler.TypeChecker.AST.Declarations;
+using Plang.Compiler.TypeChecker.AST.Expressions;
+
+namespace UnitTests.TypeChecker;
+
+[TestFixture]
+[TestOf(typeof(SimpleExprEval))]
+public class SimpleExprEvalTest
+{
+    private static readonly Dictionary<Variable, IPExpr> EmptyStore = new();
+
+    private static int EvalInt(BinOpType op, int lhs, int rhs)
+    {
+        var expr = new BinOpExpr(null, op, new IntLiteralExpr(lhs), new IntLiteralExpr(rhs));
+        return ((IntLiteralExpr)SimpleExprEval.Eval(EmptyStore, expr)).Value;
+    }
+
+    private static bool EvalBool(BinOpType op, int lhs, int rhs)
+    {
+        var expr = new BinOpExpr(null, op, new IntLiteralExpr(lhs), new IntLiteralExpr(rhs));
+        return ((BoolLiteralExpr)SimpleExprEval.Eval(EmptyStore, expr)).Value;
+    }
+
+    // 6 and 7 are chosen so every arithmetic operator yields a distinct result
+    // (Add=13, Sub=-1, Mul=42, Div=0, Mod=6). This is what makes the test able to
+    // catch a copy-paste operator swap such as Mul folding to lhs + rhs (=13).
+    [Test]
+    public void TestArithmeticOperators()
+    {
+        Assert.AreEqual(13, EvalInt(BinOpType.Add, 6, 7));
+        Assert.AreEqual(-1, EvalInt(BinOpType.Sub, 6, 7));
+        Assert.AreEqual(42, EvalInt(BinOpType.Mul, 6, 7), "Mul must multiply, not add");
+        Assert.AreEqual(3, EvalInt(BinOpType.Div, 7, 2));
+        Assert.AreEqual(1, EvalInt(BinOpType.Mod, 7, 2));
+    }
+
+    [Test]
+    public void TestComparisonOperators()
+    {
+        Assert.IsTrue(EvalBool(BinOpType.Eq, 5, 5));
+        Assert.IsFalse(EvalBool(BinOpType.Neq, 5, 5));
+        Assert.IsTrue(EvalBool(BinOpType.Lt, 3, 4));
+        Assert.IsTrue(EvalBool(BinOpType.Le, 4, 4));
+        Assert.IsTrue(EvalBool(BinOpType.Gt, 5, 4));
+        Assert.IsTrue(EvalBool(BinOpType.Ge, 4, 4));
+    }
+
+    [Test]
+    public void TestNestedArithmetic()
+    {
+        // (2 * 3) + 4 == 10  — guards the Mul path when nested under another op.
+        var mul = new BinOpExpr(null, BinOpType.Mul, new IntLiteralExpr(2), new IntLiteralExpr(3));
+        var add = new BinOpExpr(null, BinOpType.Add, mul, new IntLiteralExpr(4));
+        Assert.AreEqual(10, ((IntLiteralExpr)SimpleExprEval.Eval(EmptyStore, add)).Value);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes three **critical, independently-verified** bugs surfaced by a codebase-wide review. All three share the same failure mode — they corrupt or falsify results **silently, without surfacing an error** — which is the worst class of defect for a verification toolchain.

### 1. Compiler: constant folder evaluated multiplication as addition
`Src/PCompiler/CompilerCore/TypeChecker/SimpleExprEval.cs` — `BinOpType.Mul` was a copy-paste of the `Add` case using `+`:

```diff
- BinOpType.Mul => new IntLiteralExpr(ForceInt(lhs) + ForceInt(rhs)),
+ BinOpType.Mul => new IntLiteralExpr(ForceInt(lhs) * ForceInt(rhs)),
```

This evaluator folds `assume` predicates during PVerifier safety-test generation, so any assumption containing `*` silently admitted/rejected the wrong global-parameter assignments — a wrong verification setup with no error.

### 2. PObserve: one unparseable log line aborted the entire run
`Src/PObserve/.../executor/ParseEventStream.java` — the lazy `flatMap` rethrew a parse failure as a `RuntimeException` that surfaced during the downstream terminal operation, escaped to `PObserveExecutor.run()`'s blanket handler, and aborted verification of **all** partitions — reporting a false "no bugs found". The bad line is now skipped (its error is already recorded in `ParseLogLine`) and the rest of the stream is parsed. Removed the dead outer `try/catch`.

### 3. PeasyAI: var-reorder auto-fix corrupted saved P source
`Src/PeasyAI/src/core/validation/validators.py` — `VarDeclarationOrderValidator` gave each offending block a `fix_function` capturing a **growing snapshot** of the replacement list; the pipeline applied them independently against already-mutated code, splicing with stale offsets and duplicating/garbling declarations for any file with ≥2 reorderable blocks. Now a single consolidated fix rewrites all blocks in one reversed-splice pass; `_make_bulk_fix` sorts descending by offset for order-independence.

## Tests added
- `Tst/UnitTests/TypeChecker/SimpleExprEvalTest.cs` — every arithmetic and comparison operator plus a nested expression (`6*7` must be `42`, not `13`).
- `test_validation.py::TestVarDeclarationOrderValidator` — two-block no-corruption case, single-block, and already-ordered.

## Verification
- **C#:** full regression suite green — `dotnet build/test --configuration Release`, **725/725 passed** (same steps as `ubuntuci.yml`).
- **Python:** PeasyAI validation suite green — **107 tests, 0 failures**.
- **Java:** the two-return `flatMap` generics type-checked and ran via a standalone reproduction (PObserve's Gradle build needs network-resolved plugins and has no wrapper, so a full build wasn't run here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
