### PR TITLE
Harden compiler literal parsing: located diagnostic instead of crash

### DIFF
--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -248,7 +248,11 @@ namespace Plang.Compiler.TypeChecker
         {
             // name=iden ASSIGN value=IntLiteral
             var elem = (EnumElem) nodesToDeclarations.Get(context);
-            elem.Value = int.Parse(context.value.Text);
+            if (!LiteralParsingUtils.TryParseIntLiteral(context.value.Text, out var enumValue))
+            {
+                throw Handler.ValueOutOfRange(context, "int");
+            }
+            elem.Value = enumValue;
             return elem;
         }
 

--- a/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
@@ -1116,7 +1116,7 @@ namespace Plang.Compiler.TypeChecker
 
             if (!LiteralParsingUtils.TryParseIntLiteral(context.@int().GetText(), out var field))
             {
-                handler.Diagnostics.Report(handler.ValueOutOfRange(context, "int"));
+                handler.Diagnostics.Report(handler.ValueOutOfRange(context.@int(), "int"));
                 return new ErrorExpr(context);
             }
             if (field >= type.Types.Count)

--- a/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ExprVisitor.cs
@@ -168,7 +168,11 @@ namespace Plang.Compiler.TypeChecker
             var subExpr = Visit(context.expr());
             if (subExpr.Type is ErrorType) return new ErrorExpr(context);
 
-            var fieldNo = int.Parse(context.field.GetText());
+            if (!LiteralParsingUtils.TryParseIntLiteral(context.field.GetText(), out var fieldNo))
+            {
+                handler.Diagnostics.Report(handler.ValueOutOfRange(context, "int"));
+                return new ErrorExpr(context);
+            }
             if (!(subExpr.Type.Canonicalize() is TupleType tuple))
             {
                 handler.Diagnostics.Report(handler.TypeMismatch(subExpr, TypeKind.Tuple, TypeKind.NamedTuple));
@@ -916,7 +920,12 @@ namespace Plang.Compiler.TypeChecker
 
             if (context.IntLiteral() != null)
             {
-                return new IntLiteralExpr(context, int.Parse(context.IntLiteral().GetText()));
+                if (!LiteralParsingUtils.TryParseIntLiteral(context.IntLiteral().GetText(), out var intValue))
+                {
+                    handler.Diagnostics.Report(handler.ValueOutOfRange(context, "int"));
+                    return new ErrorExpr(context);
+                }
+                return new IntLiteralExpr(context, intValue);
             }
 
             if (context.NullLiteral() != null)
@@ -1020,7 +1029,11 @@ namespace Plang.Compiler.TypeChecker
 
         public override IPExpr VisitDecimalFloat(PParser.DecimalFloatContext context)
         {
-            var value = double.Parse($"{context.pre?.Text ?? ""}.{context.post.Text}");
+            if (!LiteralParsingUtils.TryParseFloatLiteral($"{context.pre?.Text ?? ""}.{context.post.Text}", out var value))
+            {
+                handler.Diagnostics.Report(handler.ValueOutOfRange(context, "float"));
+                return new ErrorExpr(context);
+            }
             return new FloatLiteralExpr(context, value);
         }
 
@@ -1101,7 +1114,11 @@ namespace Plang.Compiler.TypeChecker
                 return new ErrorExpr(context);
             }
 
-            var field = int.Parse(context.@int().GetText());
+            if (!LiteralParsingUtils.TryParseIntLiteral(context.@int().GetText(), out var field))
+            {
+                handler.Diagnostics.Report(handler.ValueOutOfRange(context, "int"));
+                return new ErrorExpr(context);
+            }
             if (field >= type.Types.Count)
             {
                 handler.Diagnostics.Report(handler.OutOfBoundsTupleAccess(context.@int(), type));

--- a/Src/PCompiler/CompilerCore/TypeChecker/LiteralParsingUtils.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/LiteralParsingUtils.cs
@@ -23,7 +23,9 @@ namespace Plang.Compiler.TypeChecker
         /// </summary>
         public static bool TryParseIntLiteral(string text, out int value)
         {
-            return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+            // NumberStyles.None matches the grammar's IntLiteral ([0-9]+): digits only,
+            // no leading sign or whitespace (the sign is handled by the grammar).
+            return int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
         }
 
         /// <summary>

--- a/Src/PCompiler/CompilerCore/TypeChecker/LiteralParsingUtils.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/LiteralParsingUtils.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+
+namespace Plang.Compiler.TypeChecker
+{
+    /// <summary>
+    /// Culture-invariant parsing of numeric literals taken verbatim from P source
+    /// lexemes. Centralizes the parse so that:
+    ///   * overflow / malformed input is reported as a located P diagnostic
+    ///     (callers surface <see cref="ITranslationErrorHandler.ValueOutOfRange"/>)
+    ///     instead of the raw <see cref="System.OverflowException"/> /
+    ///     <see cref="System.FormatException"/> escaping the diagnostic machinery and
+    ///     aborting the whole compilation with a stack trace; and
+    ///   * float parsing never depends on the host machine's current culture (a
+    ///     comma-decimal locale such as de-DE / fr-FR would otherwise misparse or
+    ///     reject a valid P float literal).
+    /// </summary>
+    internal static class LiteralParsingUtils
+    {
+        /// <summary>
+        /// Parses an integer literal lexeme (unsigned digits; the grammar handles the
+        /// sign separately). Returns <c>false</c> on overflow or malformed input rather
+        /// than throwing, so callers can emit a located diagnostic and recover.
+        /// </summary>
+        public static bool TryParseIntLiteral(string text, out int value)
+        {
+            return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        }
+
+        /// <summary>
+        /// Parses a decimal float literal assembled from grammar tokens (always
+        /// '.'-separated, e.g. "3.14"). Uses invariant culture so the host locale
+        /// cannot affect the result. Returns <c>false</c> on malformed input.
+        /// </summary>
+        public static bool TryParseFloatLiteral(string text, out double value)
+        {
+            return double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+        }
+    }
+}

--- a/Src/PCompiler/CompilerCore/TypeChecker/ModuleExprVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ModuleExprVisitor.cs
@@ -78,7 +78,10 @@ namespace Plang.Compiler.TypeChecker
                     }
                     else if (context.twise().WISE() != null)
                     {
-                        var t = int.Parse(context.twise().IntLiteral().GetText());
+                        if (!LiteralParsingUtils.TryParseIntLiteral(context.twise().IntLiteral().GetText(), out var t))
+                        {
+                            throw handler.ValueOutOfRange(context.twise(), "int");
+                        }
                         var (isValid, errMsg) = ParamAssignment.TwiseNumWellFormednessCheck(t, test.ParamExprMap.Count);
                         if (!isValid)
                         {

--- a/Src/PCompiler/CompilerCore/TypeChecker/ParamVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/ParamVisitor.cs
@@ -50,13 +50,19 @@ namespace Plang.Compiler.TypeChecker
 
             if (context.SUB() != null && context.IntLiteral() != null)
             {
-                int value = -int.Parse(context.IntLiteral().GetText());
-                return new IntLiteralExpr(context, value);
+                if (!LiteralParsingUtils.TryParseIntLiteral(context.IntLiteral().GetText(), out var magnitude))
+                {
+                    throw handler.ValueOutOfRange(context, "int");
+                }
+                return new IntLiteralExpr(context, -magnitude);
             }
 
             if (context.IntLiteral() != null)
             {
-                int value = int.Parse(context.IntLiteral().GetText());
+                if (!LiteralParsingUtils.TryParseIntLiteral(context.IntLiteral().GetText(), out var value))
+                {
+                    throw handler.ValueOutOfRange(context, "int");
+                }
                 return new IntLiteralExpr(context, value);
             }
 
@@ -114,7 +120,11 @@ namespace Plang.Compiler.TypeChecker
 
             if (context.IntLiteral() != null)
             {
-                return new IntLiteralExpr(context, int.Parse(context.IntLiteral().GetText()));
+                if (!LiteralParsingUtils.TryParseIntLiteral(context.IntLiteral().GetText(), out var intValue))
+                {
+                    throw handler.ValueOutOfRange(context, "int");
+                }
+                return new IntLiteralExpr(context, intValue);
             }
 
             if (context.NullLiteral() != null)
@@ -132,12 +142,19 @@ namespace Plang.Compiler.TypeChecker
 
         public override IPExpr VisitDecimalFloat(PParser.DecimalFloatContext context)
         {
-            var value = double.Parse($"{context.pre?.Text ?? ""}.{context.post.Text}");
+            if (!LiteralParsingUtils.TryParseFloatLiteral($"{context.pre?.Text ?? ""}.{context.post.Text}", out var value))
+            {
+                throw handler.ValueOutOfRange(context, "float");
+            }
             return new FloatLiteralExpr(context, value);
         }
         public override IPExpr VisitInt([NotNull] PParser.IntContext context)
         {
-            return new IntLiteralExpr(context, int.Parse(context.IntLiteral().GetText()));
+            if (!LiteralParsingUtils.TryParseIntLiteral(context.IntLiteral().GetText(), out var value))
+            {
+                throw handler.ValueOutOfRange(context, "int");
+            }
+            return new IntLiteralExpr(context, value);
         }
         
     }

--- a/Tst/RegressionTests/Feature3Exprs/StaticError/IntLiteralOutOfRange/IntLiteralOutOfRange.p
+++ b/Tst/RegressionTests/Feature3Exprs/StaticError/IntLiteralOutOfRange/IntLiteralOutOfRange.p
@@ -1,0 +1,11 @@
+// Regression: an integer literal larger than Int32 must produce a clean,
+// located "value is out of range" diagnostic (exit code 1), NOT crash the
+// compiler with an OverflowException escaping the type checker.
+machine Main {
+    start state Init {
+        entry {
+            var a : int;
+            a = 9999999999999;
+        }
+    }
+}

--- a/Tst/RegressionTests/Feature3Exprs/StaticError/TupleIndexOutOfRange/TupleIndexOutOfRange.p
+++ b/Tst/RegressionTests/Feature3Exprs/StaticError/TupleIndexOutOfRange/TupleIndexOutOfRange.p
@@ -1,0 +1,13 @@
+// Regression: a tuple field index larger than Int32 must produce a clean,
+// located "value is out of range" diagnostic (exit code 1), NOT crash the
+// compiler with an OverflowException from parsing the field number.
+machine Main {
+    start state Init {
+        entry {
+            var t : (int, int);
+            var x : int;
+            t = (1, 2);
+            x = t.99999999999;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Integer and float **literals** (and tuple field indices) were parsed straight from the ANTLR lexeme with `int.Parse` / `double.Parse` and **no guard**. This had two silent-failure consequences:

- An out-of-range literal (`a = 9999999999999;`) or an oversized tuple index (`t.99999999999`) threw `OverflowException`.
- On a comma-decimal host locale (de-DE, fr-FR, …), `double.Parse` misparsed or rejected a valid P float.

Those are **not** `TranslationException`s, so they escaped `Analyzer.TolerantStep`'s collecting-diagnostics machinery and **aborted the entire compilation with an opaque .NET stack trace** — instead of the clean, located error the P 3.0 multi-error architecture promises, and taking every other diagnostic down with them.

## Change

- New `LiteralParsingUtils` with culture-invariant `TryParseIntLiteral` / `TryParseFloatLiteral` that return `false` instead of throwing.
- All **10** parse sites routed through it, each using the idiom its file already follows:
  - **`ExprVisitor`** (int literal, decimal float, two tuple-access indices) → collecting idiom: `handler.Diagnostics.Report(handler.ValueOutOfRange(...))` + `return new ErrorExpr(context)`.
  - **`ParamVisitor`** (5 sites), **`DeclarationVisitor`** (enum value), **`ModuleExprVisitor`** (t-wise count) → throw idiom: `throw handler.ValueOutOfRange(...)` (a `TranslationException`).
- Invariant culture also fixes the float **locale** bug at both float sites.

## Tests

Two `StaticError` fixtures (the validator fails on a thrown exception and passes only on exit code 1 — so these directly guard "clean diagnostic, not crash"):

- `Tst/RegressionTests/Feature3Exprs/StaticError/IntLiteralOutOfRange`
- `Tst/RegressionTests/Feature3Exprs/StaticError/TupleIndexOutOfRange`

Both now emit `value is out of range for type 'int'` with a source location.

## Verification

Full Release regression suite green — `dotnet build/test --configuration Release`, **726/726 passed, 0 failures** (same steps as `ubuntuci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
