### PR TITLE
Add official Docker image for the P toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Keep the build context small and the image clean. The build stage only
+# needs the source required to `dotnet pack` the P command-line tool.
+
+.git
+.github
+
+# Build outputs / drops (regenerated inside the build stage)
+Bld/Drops
+**/bin
+**/obj
+**/target
+
+# Docs site (not needed to build the tool)
+Docs
+
+# Local editor / OS cruft
+.idea
+.vs
+.vscode
+**/.DS_Store
+
+# The Dockerfile and its ignore file themselves
+Dockerfile
+.dockerignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep the base image in the Dockerfile up to date. The Dockerfile floats on
+  # `mcr.microsoft.com/dotnet/sdk:8.0`, so this mostly opens PRs if the pinned
+  # major/minor changes or a digest is added later; it also keeps things
+  # automated if the maintainers decide to pin by digest.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  # Keep the GitHub Actions used by the Docker workflows (and others) current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,75 @@
+name: Docker image
+
+# Build and smoke-test the P toolchain image. This runs only when the image
+# definition changes (or on manual dispatch) -- it is redundant with the
+# normal build/test CI on every push, so there is no need to run it always.
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docker-image.yml'
+  push:
+    branches: [ master ]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docker-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build & test (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Native runners for each architecture -- no QEMU emulation, so the
+          # arm64 build is exercised on real arm64 hardware. arm64 hosted
+          # runners are free for public repositories.
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build the image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: p:ci-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Smoke test (compile & check a tutorial)
+        run: |
+          docker run --rm -v "$PWD/Tutorial/1_ClientServer":/workspace p:ci-${{ matrix.arch }} bash -c '
+            set -euo pipefail
+            p --version
+            java -version
+            dot -V
+            p compile
+            p check -tc tcSingleClient -i 100
+          '
+
+      # Export the built image to a tar so Trivy scans it directly, rather than
+      # via a daemon image reference (Trivy's image-name parser rejects some
+      # local tags that Docker itself accepts).
+      - name: Export image for scanning
+        run: docker save p:ci-${{ matrix.arch }} -o /tmp/p-image.tar
+
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          input: /tmp/p-image.tar
+          format: table
+          exit-code: '0'          # report only; do not fail the build on findings
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,125 @@
+name: Publish Docker image
+
+# Build the multi-arch P toolchain image and push it to the GitHub Container
+# Registry (GHCR) when a GitHub Release is published. Can also be run manually
+# to (re)publish for a given tag.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to publish (e.g. 2.2.6). Defaults to 'latest' only."
+        required: false
+        default: ""
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}   # -> ghcr.io/p-org/p
+
+jobs:
+  # Build each architecture natively (no QEMU) and push it by digest.
+  build:
+    name: Build & push (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/${{ matrix.arch }}
+          # Push an untagged, by-digest image; the manifest list is assembled
+          # in the merge job below.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export the digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into a single multi-arch manifest and tag it.
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # On release: tag with the semver from the release tag (git tags are
+          # of the form `p-<version>`) plus a rolling `latest`. On manual runs:
+          # honor the optional `tag` input.
+          tags: |
+            type=match,pattern=p-(.*),group=1,event=tag
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
+            type=raw,value=latest
+
+      - name: Create and push the manifest list
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect the published image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}   # -> ghcr.io/p-org/p
+  # Spelled out in lowercase rather than derived from `github.repository`:
+  # that yields `p-org/P`, and Docker/OCI reference names must be lowercase,
+  # so `ghcr.io/p-org/P` is rejected as an invalid reference.
+  IMAGE_NAME: p-org/p                    # -> ghcr.io/p-org/p
 
 jobs:
   # Build each architecture natively (no QEMU) and push it by digest.
@@ -107,8 +110,12 @@ jobs:
           # On release: tag with the semver from the release tag (git tags are
           # of the form `p-<version>`) plus a rolling `latest`. On manual runs:
           # honor the optional `tag` input.
+          #
+          # `type=match` takes no `event` qualifier (it is only meaningful for
+          # `type=ref`); it already applies only when the ref is a tag, which is
+          # the case for `release: published`.
           tags: |
-            type=match,pattern=p-(.*),group=1,event=tag
+            type=match,pattern=p-(.*),group=1
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
             type=raw,value=latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -117,7 +117,7 @@ jobs:
           tags: |
             type=match,pattern=p-(.*),group=1
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.event_name != 'release' || !github.event.release.prerelease }}
 
       - name: Create and push the manifest list
         working-directory: /tmp/digests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Official P toolchain image.
+#
+# Bundles everything needed to compile and check P programs:
+#   - .NET SDK 8.0   (the P compiler / PChecker are implemented in C#)
+#   - JDK 17 + Maven (the PEx / PSym checker backends run on the JVM; the P
+#                     Java sources target Java 17 -- see Src/PEx/pom.xml)
+#   - graphviz       (used to render coverage / state-machine diagrams)
+#   - the `p` CLI    (built from this repository and installed as a global
+#                     dotnet tool)
+#
+# Build:   docker build -t p .
+# Run:     docker run --rm -it -v "$PWD":/workspace p
+# ---------------------------------------------------------------------------
+
+# --- Stage 1: build the P tool from the repository source ------------------
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+# The P compiler build runs the ANTLR4 code generator, which shells out to
+# `java`, so a JDK is required even just to `dotnet pack` the tool.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Pack the `p` command-line tool into a local NuGet package. This mirrors the
+# `dotnet pack` step used by the release workflow; the resulting .nupkg lands
+# under Bld/Drops/Release/Binaries/ (see Directory.Build.props).
+RUN dotnet pack Src/PCompiler/PCommandLine/PCommandLine.csproj -c Release \
+    && mkdir -p /nupkg \
+    && cp Bld/Drops/Release/Binaries/[Pp].*.nupkg /nupkg/
+
+# --- Stage 2: the toolchain image ------------------------------------------
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+
+LABEL org.opencontainers.image.title="P" \
+      org.opencontainers.image.description="Toolchain image for the P formal modeling language (P compiler, PChecker, PEx). Includes .NET 8, JDK 17, Maven and graphviz." \
+      org.opencontainers.image.source="https://github.com/p-org/P" \
+      org.opencontainers.image.documentation="https://p-org.github.io/P/" \
+      org.opencontainers.image.licenses="MIT"
+
+# Install the JVM toolchain (PEx/PSym backends) and graphviz. openjdk-17 is
+# available for both amd64 and arm64 in the Debian repositories used by the
+# .NET SDK base image, so this image builds natively on both architectures.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openjdk-17-jdk-headless \
+        maven \
+        graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+# The JDK install path is arch-specific in the Debian layout
+# (java-17-openjdk-amd64 vs -arm64), so point a stable symlink at whichever
+# one this build produced and set JAVA_HOME to that fixed location. This keeps
+# JAVA_HOME identical and correct on both amd64 and arm64.
+RUN JAVA_BIN="$(readlink -f "$(command -v java)")" \
+    && JAVA_DIR="$(dirname "$(dirname "$JAVA_BIN")")" \
+    && ln -s "$JAVA_DIR" /usr/lib/jvm/default-jdk
+ENV JAVA_HOME=/usr/lib/jvm/default-jdk
+
+# Install the `p` tool built in stage 1 from the local package source.
+COPY --from=build /nupkg /tmp/nupkg
+RUN dotnet tool install --global --add-source /tmp/nupkg P \
+    && rm -rf /tmp/nupkg
+ENV PATH="${PATH}:/root/.dotnet/tools"
+
+# Also expose the tools directory to login shells (which re-source
+# /etc/profile and would otherwise drop the ENV above).
+RUN echo 'export PATH="$PATH:/root/.dotnet/tools"' > /etc/profile.d/dotnet-tools.sh
+
+# Sanity check: fail the build if the CLI is not runnable.
+RUN p --help > /dev/null
+
+WORKDIR /workspace
+CMD ["bash"]

--- a/Docs/docs/getstarted/install.md
+++ b/Docs/docs/getstarted/install.md
@@ -8,6 +8,12 @@ P is built to be **cross-platform** and can be used on MacOS, Linux, and Windows
 !!! success "Verify each step"
     After each step, use the troubleshooting check to ensure the installation succeeded.
 
+!!! tip "Prefer Docker? Skip the manual setup"
+    If you just want to try P, or you are running in CI, you can use the
+    official Docker image instead of installing the toolchain by hand. It
+    bundles the .NET SDK, JDK, Maven, graphviz, and the `p` CLI. Jump to
+    [Alternative: Use the Docker image](#alternative-use-the-docker-image).
+
 ---
 
 ### :material-numeric-1-circle:{ .lg } Install .NET SDK
@@ -145,6 +151,60 @@ dotnet tool install --global P
     ```shell
     dotnet tool update --global P
     ```
+
+---
+
+## Alternative: Use the Docker image
+
+Instead of installing the .NET SDK, Java, and the `p` tool separately, you can
+use the official P Docker image. This is the fastest way to get a working P
+toolchain, and is especially convenient for **CI pipelines** and for trying P
+without changing your machine's setup.
+
+The image is published to the GitHub Container Registry (GHCR) and is built for
+both `linux/amd64` and `linux/arm64`.
+
+!!! info "Prerequisite"
+    You need [Docker](https://docs.docker.com/get-docker/) (or a compatible
+    runtime such as Finch/Podman) installed.
+
+### Pull the image
+
+```shell
+docker pull ghcr.io/p-org/p:latest
+```
+
+You can also pin a specific version, e.g. `ghcr.io/p-org/p:2.2.6`.
+
+### Compile and check a P project
+
+Mount your P project into the container's `/workspace` directory and run the
+`p` commands as usual:
+
+```shell
+# From the root of your P project (where the .pproj file lives)
+docker run --rm -it -v "$PWD":/workspace ghcr.io/p-org/p:latest bash
+
+# Now, inside the container:
+p compile
+p check -tc <testcase> -i 1000
+```
+
+Anything the tool writes (e.g. `PGenerated/`, `PCheckerOutput/`) lands back in
+your project directory on the host, because it is a mounted volume.
+
+You can also run a one-shot command without an interactive shell:
+
+```shell
+docker run --rm -v "$PWD":/workspace ghcr.io/p-org/p:latest p compile
+```
+
+??? hint "Troubleshoot: verify the toolchain inside the image"
+    ```shell
+    docker run --rm ghcr.io/p-org/p:latest bash -c 'p --version && java -version'
+    ```
+
+    You should see the P version and a Java 17 runtime.
 
 ---
 

--- a/Docs/docs/getstarted/install.md
+++ b/Docs/docs/getstarted/install.md
@@ -154,6 +154,18 @@ dotnet tool install --global P
 
 ---
 
+### :material-numeric-4-circle:{ .lg } Recommended IDE (Optional)
+
+| Purpose | Recommended Tool |
+|---------|-----------------|
+| Developing P programs | [**Peasy**](https://marketplace.visualstudio.com/items?itemName=PLanguage.peasy-extension) (VS Code extension) |
+| AI-assisted P development | [**PeasyAI**](peasyai.md) (Cursor / Claude Code) |
+
+!!! success ""
+    Great :smile:! You are all set to compile and check your first P program :mortar_board:!
+
+---
+
 ## Alternative: Use the Docker image
 
 Instead of installing the .NET SDK, Java, and the `p` tool separately, you can
@@ -205,15 +217,3 @@ docker run --rm -v "$PWD":/workspace ghcr.io/p-org/p:latest p compile
     ```
 
     You should see the P version and a Java 17 runtime.
-
----
-
-### :material-numeric-4-circle:{ .lg } Recommended IDE (Optional)
-
-| Purpose | Recommended Tool |
-|---------|-----------------|
-| Developing P programs | [**Peasy**](https://marketplace.visualstudio.com/items?itemName=PLanguage.peasy-extension) (VS Code extension) |
-| AI-assisted P development | [**PeasyAI**](peasyai.md) (Cursor / Claude Code) |
-
-!!! success ""
-    Great :smile:! You are all set to compile and check your first P program :mortar_board:!

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 </div>
 
 [![NuGet](https://img.shields.io/nuget/v/p.svg)](https://www.nuget.org/packages/P/)
+[![Docker image](https://img.shields.io/badge/ghcr.io-p--org%2Fp-blue?logo=docker)](https://github.com/p-org/P/pkgs/container/p)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/p-org/P/master/LICENSE.txt)
 ![GitHub Action (CI on Windows)](https://github.com/p-org/P/workflows/CI%20on%20Windows/badge.svg?branch=master)
 ![GitHub Action (CI on Ubuntu)](https://github.com/p-org/P/workflows/CI%20on%20Ubuntu/badge.svg?branch=master)
@@ -98,6 +99,12 @@ round-trips per N errors.
 ## Let the fun begin!
 
 You can find most of the information about the P framework on: **[https://p-org.github.io/P/](https://p-org.github.io/P/)**
+
+> 🐳 **Want to skip the setup?** Use the official Docker image, which bundles the P CLI, .NET SDK, JDK, Maven, and graphviz (available for `amd64` and `arm64`):
+> ```shell
+> docker run --rm -it -v "$PWD":/workspace ghcr.io/p-org/p:latest
+> ```
+> See the [installation guide](https://p-org.github.io/P/getstarted/install/#alternative-use-the-docker-image) for details.
 
 [What is P?](https://p-org.github.io/P/whatisP/) | [Getting Started](https://p-org.github.io/P/getstarted/install/) | [PeasyAI](https://p-org.github.io/P/getstarted/peasyai/) | [Tutorials](https://p-org.github.io/P/tutsoutline/) | [Case Studies](https://p-org.github.io/P/casestudies/) | [Publications](https://p-org.github.io/P/publications/)
 


### PR DESCRIPTION
Closes #980.

Adds an official Docker image for the P toolchain so P can be compiled and checked without installing the .NET SDK, Java, Maven, and graphviz by hand — especially handy for CI and for trying P out.

## What's included

- **`Dockerfile`** — multi-stage build.
  - Stage 1 builds the `p` CLI **from this repository's source** (`dotnet pack`), so the image always matches the committed/released code (no dependency on the NuGet package already being published).
  - Stage 2 is the toolchain image: **.NET SDK 8.0, JDK 17, Maven, graphviz**, and the `p` tool installed from the locally-built package.
  - JDK **17** is used deliberately: `Src/PEx/pom.xml` targets Java 17, so the PEx/PSym backends need a JVM that can run Java-17 bytecode.
  - `JAVA_HOME` is resolved via a stable symlink so it's correct on both amd64 and arm64 (the Debian JDK path is arch-specific).
- **`.dockerignore`** — keeps the build context small (excludes `.git`, build drops, docs, etc.).
- **`.github/workflows/docker-image.yml`** — PR CI. Path-filtered so it only runs when the `Dockerfile`, `.dockerignore`, or the workflow itself changes (plus manual dispatch) rather than on every push. Builds **natively** on amd64 (`ubuntu-latest`) and arm64 (`ubuntu-24.04-arm`), smoke-tests `p compile` + `p check` on a tutorial inside the container, and runs a Trivy vulnerability scan (report-only).
- **`.github/workflows/docker-publish.yml`** — on a published GitHub Release, builds per-arch natively, pushes each by digest, and assembles a **multi-arch manifest** to `ghcr.io/p-org/p` tagged with the release version + `latest`.
- **`.github/dependabot.yml`** — keeps the base image and the GitHub Actions used here up to date.
- **Docs** — a Docker section in the [installation guide](Docs/docs/getstarted/install.md) (referenced from the quick start), plus a README badge and run snippet.

## Usage

```shell
docker run --rm -it -v "$PWD":/workspace ghcr.io/p-org/p:latest
# inside the container:
p compile
p check -tc <testcase> -i 1000
```

## Testing done

Built and ran locally on arm64:
- `docker build` succeeds.
- Inside the container: `p compile` + `p check -tc tcSingleClient -i 200` runs the Java PEx backend end-to-end (200 schedules explored, 0 bugs, coverage report written); JDK 17, Maven, graphviz, and `JAVA_HOME` all verified in both login and non-login shells.

CI in this PR exercises the build + smoke test on both amd64 and arm64.

## Note on availability

The image is only published when a GitHub Release is created, and a repo's first GHCR package is created **private**. So before anyone can `docker pull ghcr.io/p-org/p`, a maintainer will need to:

1. Cut a release (or run the publish workflow manually) to push the first image, and
2. Flip the `ghcr.io/p-org/p` package to **public** (optionally linking it to the repo).

No code change needed for that — it's a one-time settings step around the first release.

## Choices made (happy to change)

- **Version tag source** — the publish workflow derives the image version from the release's git tag (`p-<version>`), plus `latest`. Releases cut without that tag format would only get `latest`.
- **Trivy is report-only** (`exit-code: 0`) so new upstream CVEs don't block PRs. Can be made blocking (keeping `ignore-unfixed: true`) if preferred.
- **Image scope** — this is a toolchain/dev image (SDK-based, not slim). A smaller runtime image could be a separate tagged variant later.
- Kept the image and workflows close to the Dockerfile proposed in #980.
