### PR TITLE
Fest: scenario coverage, feedback-search fidelity, and pluggable timeline representations (+ evaluation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,7 +526,7 @@ PYTHONPATH=src pytest tests/test_workflow_persistence.py -v
 When working with P programs, be aware of these syntax patterns and common pitfalls:
 
 ### Reserved Keywords
-Never use these as identifiers: `var`, `type`, `enum`, `event`, `on`, `do`, `goto`, `data`, `send`, `announce`, `receive`, `case`, `raise`, `machine`, `state`, `hot`, `cold`, `start`, `spec`, `module`, `test`, `main`, `fun`, `observes`, `entry`, `exit`, `with`, `union`, `foreach`, `else`, `while`, `return`, `break`, `continue`, `ignore`, `defer`, `assert`, `print`, `new`, `sizeof`, `keys`, `values`, `choose`, `format`, `if`, `halt`, `this`, `as`, `to`, `in`, `default`, `Interface`, `true`, `false`, `int`, `bool`, `float`, `string`, `seq`, `map`, `set`, `any`
+Never use these as identifiers: `var`, `type`, `enum`, `event`, `on`, `do`, `goto`, `data`, `send`, `announce`, `receive`, `case`, `raise`, `machine`, `state`, `hot`, `cold`, `start`, `spec`, `scenario`, `module`, `test`, `main`, `fun`, `observes`, `entry`, `exit`, `with`, `union`, `foreach`, `else`, `while`, `return`, `break`, `continue`, `ignore`, `defer`, `assert`, `print`, `new`, `sizeof`, `keys`, `values`, `choose`, `format`, `if`, `halt`, `this`, `as`, `to`, `in`, `default`, `Interface`, `true`, `false`, `int`, `bool`, `float`, `string`, `seq`, `map`, `set`, `any`
 
 ### Common P Syntax Mistakes to Avoid
 

--- a/Src/PChecker/CheckerCore/CheckerConfiguration.cs
+++ b/Src/PChecker/CheckerCore/CheckerConfiguration.cs
@@ -154,6 +154,27 @@ namespace PChecker
         public int StrategyBound { get; set; }
 
         /// <summary>
+        /// How the feedback-guided search represents a schedule's "timeline" (the diversity
+        /// signal): "pairwise" (default, local event-type pairs), "kgram" (local k-grams),
+        /// "causal" (cross-machine happens-before via vector clocks), or "hybrid".
+        /// </summary>
+        [DataMember]
+        public string TimelineRepresentation { get; set; }
+
+        /// <summary>
+        /// Gram length for the "kgram"/"hybrid" timeline representations.
+        /// </summary>
+        [DataMember]
+        public int TimelineKGram { get; set; }
+
+        /// <summary>
+        /// If enabled, timeline event labels are enriched with a stable hash of the event
+        /// payload (so deliveries differing only by payload value are not conflated).
+        /// </summary>
+        [DataMember]
+        public bool TimelinePayload { get; set; }
+
+        /// <summary>
         /// If this option is enabled, liveness checking is enabled during bug-finding.
         /// </summary>
         [DataMember]
@@ -313,6 +334,9 @@ namespace PChecker
             TestingProcessId = 0;
             ConsiderDepthBoundHitAsBug = false;
             StrategyBound = 0;
+            TimelineRepresentation = "pairwise";
+            TimelineKGram = 3;
+            TimelinePayload = false;
 
             IsLivenessCheckingEnabled = true;
             LivenessTemperatureThreshold = 0;

--- a/Src/PChecker/CheckerCore/CheckerConfiguration.cs
+++ b/Src/PChecker/CheckerCore/CheckerConfiguration.cs
@@ -547,9 +547,18 @@ namespace PChecker
         /// </summary>
         public void SetOutputDirectory()
         {
+            // Group output by test case so each test case gets its OWN rotated history
+            // (PCheckerOutput/<testCase>/<Mode>/...). Test cases no longer clobber each
+            // other's history, concurrent runs of different test cases don't race on a shared
+            // directory, and "the latest run of test case X" is unambiguous (the non-numbered
+            // <Mode>/ dir). With no test case (a single anonymous test) the layout is unchanged.
+            var suffix = string.IsNullOrEmpty(TestCaseName)
+                ? Mode.ToString()
+                : SanitizePathSegment(TestCaseName) + Path.DirectorySeparatorChar + Mode.ToString();
+
             // Do not create the output directory yet if we have to scroll back the history first.
             OutputDirectory = Reporter.GetOutputDirectory(OutputPath, AssemblyToBeAnalyzed,
-                Mode.ToString(), createDir: false);
+                suffix, createDir: false);
 
             // The MaxHistory previous results are kept under the directory name with a suffix scrolling back from 0 to 9 (oldest).
             const int MaxHistory = 10;
@@ -581,6 +590,24 @@ namespace PChecker
 
             // Now create the new directory.
             Directory.CreateDirectory(OutputDirectory);
+        }
+
+        /// <summary>
+        /// Makes a test-case name safe to use as a single path segment (identifiers and
+        /// parameterized names are already close; this just neutralizes any stray separators).
+        /// </summary>
+        private static string SanitizePathSegment(string name)
+        {
+            var chars = name.ToCharArray();
+            for (var i = 0; i < chars.Length; i++)
+            {
+                var c = chars[i];
+                if (!(char.IsLetterOrDigit(c) || c == '.' || c == '-' || c == '_'))
+                {
+                    chars[i] = '_';
+                }
+            }
+            return new string(chars);
         }
     }
 #pragma warning restore CA1724 // Type names should not match namespaces

--- a/Src/PChecker/CheckerCore/Coverage/ControlledRuntimeLogEventCoverage.cs
+++ b/Src/PChecker/CheckerCore/Coverage/ControlledRuntimeLogEventCoverage.cs
@@ -130,7 +130,7 @@ namespace PChecker.Coverage
             Dequeued = DefaultEvent.Instance;
         }
 
-        public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
+        public void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime)
         {
             Dequeued = e;
         }

--- a/Src/PChecker/CheckerCore/Coverage/ControlledRuntimeLogGraphBuilder.cs
+++ b/Src/PChecker/CheckerCore/Coverage/ControlledRuntimeLogGraphBuilder.cs
@@ -128,7 +128,7 @@ namespace PChecker.Coverage
         }
 
         /// <inheritdoc/>
-        public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
+        public void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime)
         {
             lock (Inbox)
             {

--- a/Src/PChecker/CheckerCore/Runtime/Logging/IControlledRuntimeLog.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Logging/IControlledRuntimeLog.cs
@@ -63,7 +63,9 @@ namespace PChecker.Runtime.Logging
         /// <param name="id">The id of the state machine that the event is being dequeued by.</param>
         /// <param name="stateName">The state name, if the state machine is a state machine and a state exists, else null.</param>
         /// <param name="e">The event being dequeued.</param>
-        void OnDequeueEvent(StateMachineId id, string stateName, Event e);
+        /// <param name="senderId">The id of the machine that sent the event, or null if none.</param>
+        /// <param name="deliveryTime">The receiver's vector clock at delivery (post-merge), for causal timeline analysis.</param>
+        void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime);
 
         /// <summary>
         /// Invoked when the specified event is received by an state machine.

--- a/Src/PChecker/CheckerCore/Runtime/Logging/LogWriter.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Logging/LogWriter.cs
@@ -144,13 +144,14 @@ namespace PChecker.Runtime.Logging
         /// <param name="id">The id of the state machine that the event is being dequeued by.</param>
         /// <param name="stateName">The state name, if the state machine is a state machine and a state exists, else null.</param>
         /// <param name="e">The event being dequeued.</param>
-        public void LogDequeueEvent(StateMachineId id, string stateName, Event e)
+        public void LogDequeueEvent(StateMachineId id, string stateName, Event e,
+            StateMachineId senderId, VectorTime deliveryTime)
         {
             if (Logs.Count > 0)
             {
                 foreach (var log in Logs)
                 {
-                    log.OnDequeueEvent(id, stateName, e);
+                    log.OnDequeueEvent(id, stateName, e, senderId, deliveryTime);
                 }
             }
         }

--- a/Src/PChecker/CheckerCore/Runtime/Logging/PCheckerLogJsonFormatter.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Logging/PCheckerLogJsonFormatter.cs
@@ -157,7 +157,7 @@ namespace PChecker.Runtime.Logging
         /// <param name="id">The id of the state machine that the event is being dequeued by.</param>
         /// <param name="stateName">The state name, if the state machine is a state machine and a state exists, else null.</param>
         /// <param name="e">The event being dequeued.</param>
-        public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
+        public void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime)
         {
             var eventName = GetEventNameWithPayload(e);
             var log = stateName is null

--- a/Src/PChecker/CheckerCore/Runtime/Logging/PCheckerLogTextFormatter.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Logging/PCheckerLogTextFormatter.cs
@@ -176,7 +176,7 @@ namespace PChecker.Runtime.Logging
         }
 
         /// <inheritdoc/>
-        public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
+        public void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime)
         {
             stateName = GetShortName(stateName);
             var eventName = GetEventNameWithPayload(e);

--- a/Src/PChecker/CheckerCore/Runtime/Logging/PCheckerLogXmlFormatter.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Logging/PCheckerLogXmlFormatter.cs
@@ -88,7 +88,7 @@ namespace PChecker.Runtime.Logging
             Writer.WriteEndElement();
         }
 
-        public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
+        public void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime)
         {
             if (Closed)
             {

--- a/Src/PChecker/CheckerCore/Runtime/PModule.cs
+++ b/Src/PChecker/CheckerCore/Runtime/PModule.cs
@@ -18,6 +18,12 @@ namespace PChecker.Runtime
         /// </summary>
         public static HashSet<Type> coverageMonitors = new HashSet<Type>();
 
+        /// <summary>
+        /// Total number of states in each scenario (coverage) monitor, used to report
+        /// partial coverage (distinct states reached / total states).
+        /// </summary>
+        public static Dictionary<Type, int> scenarioStateCounts = new Dictionary<Type, int>();
+
         public static IDictionary<string, Dictionary<string, string>> linkMap =
             new Dictionary<string, Dictionary<string, string>>();
 

--- a/Src/PChecker/CheckerCore/Runtime/PModule.cs
+++ b/Src/PChecker/CheckerCore/Runtime/PModule.cs
@@ -10,6 +10,14 @@ namespace PChecker.Runtime
         public static Dictionary<string, List<Type>> monitorMap = new Dictionary<string, List<Type>>();
         public static Dictionary<string, List<string>> monitorObserves = new Dictionary<string, List<string>>();
 
+        /// <summary>
+        /// Monitor types declared with the <c>scenario</c> keyword. These are "coverage"
+        /// monitors: their satisfaction (reaching an accepting/cold state) is counted for
+        /// scenario coverage, and they are exempt from the end-of-run liveness check
+        /// (an unsatisfied scenario is not a bug, just uncovered).
+        /// </summary>
+        public static HashSet<Type> coverageMonitors = new HashSet<Type>();
+
         public static IDictionary<string, Dictionary<string, string>> linkMap =
             new Dictionary<string, Dictionary<string, string>>();
 

--- a/Src/PChecker/CheckerCore/Runtime/Specifications/Monitor.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Specifications/Monitor.cs
@@ -618,6 +618,13 @@ namespace PChecker.Runtime.Specifications
         /// </summary>
         internal void CheckLivenessTemperature()
         {
+            // Coverage (scenario) monitors are exempt from liveness checking: an
+            // unsatisfied scenario lingering in a hot state is uncovered, not a bug.
+            if (PChecker.Runtime.PModule.coverageMonitors.Contains(GetType()))
+            {
+                return;
+            }
+
             if (ActiveState.IsHot &&
                 Runtime.CheckerConfiguration.LivenessTemperatureThreshold > 0)
             {

--- a/Src/PChecker/CheckerCore/Runtime/Values/PMap.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Values/PMap.cs
@@ -179,7 +179,9 @@ namespace PChecker.Runtime.Values
             var sb = new StringBuilder();
             sb.Append("(");
             var sep = "";
-            foreach (var value in map)
+            // Iterate keys in a deterministic order (the backing store is unordered):
+            // a stable ToString is required for reproducible hashing/logging.
+            foreach (var value in map.OrderBy(kv => kv.Key?.ToString() ?? string.Empty, System.StringComparer.Ordinal))
             {
                 sb.Append(sep);
                 sb.Append("<");

--- a/Src/PChecker/CheckerCore/Runtime/Values/PSet.cs
+++ b/Src/PChecker/CheckerCore/Runtime/Values/PSet.cs
@@ -119,7 +119,9 @@ namespace PChecker.Runtime.Values
             var sb = new StringBuilder();
             sb.Append("(");
             var sep = "";
-            foreach (var value in set)
+            // Iterate in a deterministic order (the backing store is an unordered HashSet):
+            // a stable ToString is required for reproducible hashing/logging.
+            foreach (var value in set.OrderBy(v => v?.ToString() ?? string.Empty, System.StringComparer.Ordinal))
             {
                 sb.Append(sep);
                 sb.Append("<");

--- a/Src/PChecker/CheckerCore/Runtime/VectorTime.cs
+++ b/Src/PChecker/CheckerCore/Runtime/VectorTime.cs
@@ -52,18 +52,21 @@ public class VectorTime
         }
     }
     
-    // Compare this vector clock to another for sorting purposes
-    // Rturn value: -1 = This vector clock happens after the other, 1 = This vector clock happens before the other,
-    // 0 = Clocks are equal or concurrent
+    // Compare this vector clock to another (partial order over vector clocks).
+    // Follows the IComparable convention: negative => this happens-BEFORE other;
+    // positive => this happens-AFTER other; 0 => clocks are equal or concurrent.
+    // Missing entries are treated as 0, so the comparison must range over the UNION of
+    // both clocks' keys — otherwise a machine present only in `other` is never examined
+    // and a genuine ordering can be silently misreported as concurrent.
     public int CompareTo(VectorTime other)
     {
         bool atLeastOneLess = false;
         bool atLeastOneGreater = false;
 
-        foreach (var machineId in Clock.Keys)
+        foreach (var machineId in Clock.Keys.Union(other.Clock.Keys))
         {
-            int thisTime = Clock[machineId];
-            int otherTime = other.Clock.ContainsKey(machineId) ? other.Clock[machineId] : 0;
+            int thisTime = Clock.TryGetValue(machineId, out var t) ? t : 0;
+            int otherTime = other.Clock.TryGetValue(machineId, out var o) ? o : 0;
 
             if (thisTime < otherTime)
             {

--- a/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
@@ -1056,7 +1056,10 @@ namespace PChecker.SystematicTesting
             }
 
             var stateName = stateMachine.CurrentStateName;
-            LogWriter.LogDequeueEvent(stateMachine.Id, stateName, e);
+            // stateMachine.VectorTime is the receive-event timestamp here: NotifyDequeuedEvent
+            // is called after StateMachine merges the delivered event's clock (StateMachine.cs).
+            LogWriter.LogDequeueEvent(stateMachine.Id, stateName, e,
+                eventInfo?.OriginInfo?.SenderStateMachineId, stateMachine.VectorTime);
         }
 
         /// <summary>

--- a/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ControlledRuntime.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using PChecker.Coverage;
 using PChecker.Exceptions;
 using PChecker.Random;
+using PChecker.Runtime;
 using PChecker.Runtime.Events;
 using PChecker.Runtime.Logging;
 using PChecker.Runtime.StateMachines;
@@ -926,6 +927,13 @@ namespace PChecker.SystematicTesting
 
             foreach (var monitor in Monitors)
             {
+                // Coverage (scenario) monitors are exempt: an unsatisfied scenario left in
+                // a hot state is uncovered, not a liveness bug.
+                if (PModule.coverageMonitors.Contains(monitor.GetType()))
+                {
+                    continue;
+                }
+
                 if (monitor.IsInHotState(out var stateName))
                 {
                     var message = string.Format(CultureInfo.InvariantCulture,

--- a/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
@@ -78,7 +78,8 @@ namespace PChecker.SystematicTesting
         public static string MergeDirectory(string directory)
         {
             var artifacts = new List<ScenarioCoverageArtifact>();
-            foreach (var file in Directory.GetFiles(directory, "*" + FileSuffix))
+            // Recurse: the checker writes each run's artifact into its own output subdirectory.
+            foreach (var file in Directory.GetFiles(directory, "*" + FileSuffix, SearchOption.AllDirectories))
             {
                 try
                 {

--- a/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
@@ -77,21 +77,30 @@ namespace PChecker.SystematicTesting
         /// </summary>
         public static string MergeDirectory(string directory)
         {
-            var artifacts = new List<ScenarioCoverageArtifact>();
-            // Recurse: the checker writes each run's artifact into its own output subdirectory.
+            // Keep only the LATEST artifact per test case. The checker rotates each run into
+            // history dirs (<Mode>0..9) and the recursion also picks those up, so without this
+            // a re-run of a test case would be counted twice. Test-case identity is the JSON's
+            // TestCase field; the newest file (by write time) is that test case's latest run.
+            var latest = new Dictionary<string, (ScenarioCoverageArtifact artifact, DateTime when)>();
             foreach (var file in Directory.GetFiles(directory, "*" + FileSuffix, SearchOption.AllDirectories))
             {
                 try
                 {
                     var a = JsonSerializer.Deserialize<ScenarioCoverageArtifact>(File.ReadAllText(file));
-                    if (a != null) artifacts.Add(a);
+                    if (a == null) continue;
+                    var when = File.GetLastWriteTimeUtc(file);
+                    var key = a.TestCase ?? string.Empty;
+                    if (!latest.TryGetValue(key, out var cur) || when > cur.when)
+                    {
+                        latest[key] = (a, when);
+                    }
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine($"... Skipping unreadable scenario artifact {file}: {e.Message}");
                 }
             }
-            return Merge(artifacts);
+            return Merge(latest.Values.Select(v => v.artifact).ToList());
         }
 
         /// <summary>

--- a/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
@@ -94,39 +94,67 @@ namespace PChecker.SystematicTesting
             return Merge(artifacts);
         }
 
-        /// <summary>Aggregates artifacts into a unified textual report.</summary>
+        /// <summary>
+        /// Aggregates artifacts into a unified, human-readable report: a one-line summary,
+        /// then the covered scenarios (with WHICH test cases covered them), then the coverage
+        /// gaps (never satisfied anywhere) called out last with their best progress.
+        /// </summary>
         public static string Merge(IReadOnlyList<ScenarioCoverageArtifact> artifacts)
         {
             // scenario name -> aggregate
             var triggered = new Dictionary<string, int>();
             var uniqueTimelines = new Dictionary<string, int>();
-            var testCasesCovered = new Dictionary<string, int>();
             var testCasesTotal = new Dictionary<string, int>();
+            var coveringCases = new Dictionary<string, List<string>>(); // which test cases covered it
             var bestReached = new Dictionary<string, int>();
             var totalStates = new Dictionary<string, int>();
 
             foreach (var artifact in artifacts)
             {
+                var tcName = string.IsNullOrEmpty(artifact.TestCase) ? "(default)" : artifact.TestCase;
                 foreach (var s in artifact.Scenarios)
                 {
                     triggered[s.Name] = triggered.GetValueOrDefault(s.Name) + s.Triggered;
                     uniqueTimelines[s.Name] = uniqueTimelines.GetValueOrDefault(s.Name) + s.UniqueTimelines;
                     testCasesTotal[s.Name] = testCasesTotal.GetValueOrDefault(s.Name) + 1;
-                    if (s.Triggered > 0) testCasesCovered[s.Name] = testCasesCovered.GetValueOrDefault(s.Name) + 1;
+                    if (s.Triggered > 0)
+                    {
+                        if (!coveringCases.TryGetValue(s.Name, out var lst))
+                        {
+                            lst = new List<string>();
+                            coveringCases[s.Name] = lst;
+                        }
+                        lst.Add(tcName);
+                    }
                     if (s.MaxStatesReached > bestReached.GetValueOrDefault(s.Name)) bestReached[s.Name] = s.MaxStatesReached;
                     if (s.TotalStates > 0) totalStates[s.Name] = s.TotalStates;
                 }
             }
 
+            var names = triggered.Keys.OrderBy(k => k).ToList();
+            var covered = names.Where(n => triggered[n] > 0).ToList();
+            var gaps = names.Where(n => triggered[n] == 0).ToList();
+
             var report = new StringBuilder();
-            report.AppendLine($"Unified scenario coverage across {artifacts.Count} test case(s):");
-            foreach (var scenario in triggered.Keys.OrderBy(k => k))
+            report.AppendLine($"Unified scenario coverage across {artifacts.Count} test case{(artifacts.Count == 1 ? "" : "s")}:");
+            report.AppendLine($"  {covered.Count}/{names.Count} scenarios covered in >=1 test case" +
+                (gaps.Count > 0 ? $"; {gaps.Count} coverage gap{(gaps.Count == 1 ? "" : "s")}." : "."));
+
+            foreach (var scenario in covered)
             {
-                report.Append($"  {scenario}: covered in {testCasesCovered.GetValueOrDefault(scenario)}/{testCasesTotal[scenario]} test cases, ");
-                report.Append($"{triggered[scenario]} total triggers, {uniqueTimelines[scenario]} unique satisfying timelines");
-                if (triggered[scenario] == 0 && totalStates.TryGetValue(scenario, out var total) && total > 0)
+                var cases = coveringCases.TryGetValue(scenario, out var lst) ? lst : new List<string>();
+                report.AppendLine(
+                    $"  [covered] {scenario}: covered in {cases.Count}/{testCasesTotal[scenario]} test cases " +
+                    $"({string.Join(", ", cases)}); {triggered[scenario]} total triggers, " +
+                    $"{uniqueTimelines[scenario]} unique satisfying timelines");
+            }
+            foreach (var scenario in gaps)
+            {
+                report.Append($"  [  GAP  ] {scenario}: never covered in any of {testCasesTotal[scenario]} " +
+                              $"test case{(testCasesTotal[scenario] == 1 ? "" : "s")}");
+                if (totalStates.TryGetValue(scenario, out var total) && total > 0)
                 {
-                    report.Append($" (best partial progress: {bestReached.GetValueOrDefault(scenario)}/{total} states)");
+                    report.Append($"; best progress anywhere {bestReached.GetValueOrDefault(scenario)}/{total} states");
                 }
                 report.AppendLine();
             }

--- a/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/ScenarioCoverageMerger.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace PChecker.SystematicTesting
+{
+    /// <summary>
+    /// Per-scenario coverage for one test case, in a machine-readable form so that
+    /// scenario coverage can be aggregated across the many test cases in a suite
+    /// (each `p check` runs a single test case).
+    /// </summary>
+    public class ScenarioCoverageEntry
+    {
+        public string Name { get; set; }
+        public int Triggered { get; set; }
+        public int UniqueTimelines { get; set; }
+        public int MaxStatesReached { get; set; }
+        public int TotalStates { get; set; }
+    }
+
+    public class ScenarioCoverageArtifact
+    {
+        public string TestCase { get; set; }
+        public List<ScenarioCoverageEntry> Scenarios { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Writes a per-test-case scenario-coverage artifact and merges a directory of them
+    /// into one unified, suite-wide scenario-coverage report.
+    /// </summary>
+    public static class ScenarioCoverageMerger
+    {
+        /// <summary>Suffix identifying a per-run scenario-coverage artifact.</summary>
+        public const string FileSuffix = "_scenario_coverage.json";
+
+        private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+        /// <summary>Builds the artifact for a single completed test case from its report.</summary>
+        public static ScenarioCoverageArtifact FromReport(TestReport report, string testCaseName)
+        {
+            var artifact = new ScenarioCoverageArtifact { TestCase = testCaseName };
+            foreach (var scenario in report.ScenarioTriggerCounts.Keys.OrderBy(k => k))
+            {
+                artifact.Scenarios.Add(new ScenarioCoverageEntry
+                {
+                    Name = scenario,
+                    Triggered = report.ScenarioTriggerCounts[scenario],
+                    UniqueTimelines = report.ScenarioSatisfyingTimelines.TryGetValue(scenario, out var tls) ? tls.Count : 0,
+                    MaxStatesReached = report.ScenarioMaxStatesReached.TryGetValue(scenario, out var r) ? r : 0,
+                    TotalStates = report.ScenarioTotalStates.TryGetValue(scenario, out var t) ? t : 0,
+                });
+            }
+            return artifact;
+        }
+
+        /// <summary>Serializes the artifact to <paramref name="path"/> (no-op if no scenarios).</summary>
+        public static void Write(TestReport report, string testCaseName, string path)
+        {
+            if (report.ScenarioTriggerCounts.Count == 0)
+            {
+                return;
+            }
+            File.WriteAllText(path, JsonSerializer.Serialize(FromReport(report, testCaseName), JsonOptions));
+        }
+
+        /// <summary>
+        /// Reads every <c>*_scenario_coverage.json</c> artifact under <paramref name="directory"/>
+        /// and produces a unified suite-wide report: per scenario, the total triggers and unique
+        /// satisfying timelines summed across test cases, the number of test cases that covered it,
+        /// and the best partial progress anywhere.
+        /// </summary>
+        public static string MergeDirectory(string directory)
+        {
+            var artifacts = new List<ScenarioCoverageArtifact>();
+            foreach (var file in Directory.GetFiles(directory, "*" + FileSuffix))
+            {
+                try
+                {
+                    var a = JsonSerializer.Deserialize<ScenarioCoverageArtifact>(File.ReadAllText(file));
+                    if (a != null) artifacts.Add(a);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"... Skipping unreadable scenario artifact {file}: {e.Message}");
+                }
+            }
+            return Merge(artifacts);
+        }
+
+        /// <summary>Aggregates artifacts into a unified textual report.</summary>
+        public static string Merge(IReadOnlyList<ScenarioCoverageArtifact> artifacts)
+        {
+            // scenario name -> aggregate
+            var triggered = new Dictionary<string, int>();
+            var uniqueTimelines = new Dictionary<string, int>();
+            var testCasesCovered = new Dictionary<string, int>();
+            var testCasesTotal = new Dictionary<string, int>();
+            var bestReached = new Dictionary<string, int>();
+            var totalStates = new Dictionary<string, int>();
+
+            foreach (var artifact in artifacts)
+            {
+                foreach (var s in artifact.Scenarios)
+                {
+                    triggered[s.Name] = triggered.GetValueOrDefault(s.Name) + s.Triggered;
+                    uniqueTimelines[s.Name] = uniqueTimelines.GetValueOrDefault(s.Name) + s.UniqueTimelines;
+                    testCasesTotal[s.Name] = testCasesTotal.GetValueOrDefault(s.Name) + 1;
+                    if (s.Triggered > 0) testCasesCovered[s.Name] = testCasesCovered.GetValueOrDefault(s.Name) + 1;
+                    if (s.MaxStatesReached > bestReached.GetValueOrDefault(s.Name)) bestReached[s.Name] = s.MaxStatesReached;
+                    if (s.TotalStates > 0) totalStates[s.Name] = s.TotalStates;
+                }
+            }
+
+            var report = new StringBuilder();
+            report.AppendLine($"Unified scenario coverage across {artifacts.Count} test case(s):");
+            foreach (var scenario in triggered.Keys.OrderBy(k => k))
+            {
+                report.Append($"  {scenario}: covered in {testCasesCovered.GetValueOrDefault(scenario)}/{testCasesTotal[scenario]} test cases, ");
+                report.Append($"{triggered[scenario]} total triggers, {uniqueTimelines[scenario]} unique satisfying timelines");
+                if (triggered[scenario] == 0 && totalStates.TryGetValue(scenario, out var total) && total > 0)
+                {
+                    report.Append($" (best partial progress: {bestReached.GetValueOrDefault(scenario)}/{total} states)");
+                }
+                report.AppendLine();
+            }
+            return report.ToString();
+        }
+    }
+}

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
@@ -23,10 +23,20 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
     // Short names (P scenario names) of scenarios satisfied at least once this iteration.
     private readonly HashSet<string> _satisfied = new();
 
+    // Short name -> distinct states entered this iteration (partial-progress signal).
+    private readonly Dictionary<string, HashSet<string>> _statesReached = new();
+
+    // Short name -> total number of states in that scenario.
+    private readonly Dictionary<string, int> _totalStates = new();
+
     public ScenarioComplianceObserver()
     {
         _coverageMonitorNames = PModule.coverageMonitors.Select(t => t.FullName).ToHashSet();
         AllScenarioNames = _coverageMonitorNames.Select(ShortName).ToList();
+        foreach (var kv in PModule.scenarioStateCounts)
+        {
+            _totalStates[ShortName(kv.Key.FullName)] = kv.Value;
+        }
     }
 
     /// <summary>Scenarios (by short name) satisfied at least once during this iteration.</summary>
@@ -38,6 +48,29 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
     /// <summary>True if any scenario monitors are active for this run.</summary>
     public bool HasScenarios => _coverageMonitorNames.Count > 0;
 
+    /// <summary>Distinct states <paramref name="scenario"/> entered this iteration.</summary>
+    public int StatesReached(string scenario) => _statesReached.TryGetValue(scenario, out var s) ? s.Count : 0;
+
+    /// <summary>Total states declared in <paramref name="scenario"/> (0 if unknown).</summary>
+    public int TotalStates(string scenario) => _totalStates.TryGetValue(scenario, out var n) ? n : 0;
+
+    /// <summary>
+    /// Run-level compliance in [0,1]: the maximum partial-progress fraction across all
+    /// scenarios this iteration (how close the run got to satisfying any scenario). Used
+    /// to steer the feedback-guided search toward under-covered scenarios.
+    /// </summary>
+    public double RunCompliance()
+    {
+        double max = 0;
+        foreach (var scenario in AllScenarioNames)
+        {
+            var total = TotalStates(scenario);
+            if (total <= 0) continue;
+            max = System.Math.Max(max, (double)StatesReached(scenario) / total);
+        }
+        return max;
+    }
+
     private static string ShortName(string fullName)
     {
         var idx = fullName.LastIndexOf('.');
@@ -46,10 +79,24 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
 
     public void OnMonitorStateTransition(string monitorType, string stateName, bool isEntry, bool? isInHotState)
     {
-        // A coverage monitor entering a cold (accepting) state == scenario satisfied.
-        if (isEntry && isInHotState == false && _coverageMonitorNames.Contains(monitorType))
+        if (!isEntry || !_coverageMonitorNames.Contains(monitorType))
         {
-            _satisfied.Add(ShortName(monitorType));
+            return;
+        }
+        var scenario = ShortName(monitorType);
+
+        // Track partial progress: distinct states this scenario has entered.
+        if (!_statesReached.TryGetValue(scenario, out var states))
+        {
+            states = new HashSet<string>();
+            _statesReached[scenario] = states;
+        }
+        states.Add(stateName);
+
+        // Entering a cold (accepting) state == scenario satisfied.
+        if (isInHotState == false)
+        {
+            _satisfied.Add(scenario);
         }
     }
 

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PChecker.Runtime;
+using PChecker.Runtime.Events;
+using PChecker.Runtime.Logging;
+using PChecker.Runtime.StateMachines;
+
+namespace PChecker.Feedback;
+
+/// <summary>
+/// Per-iteration observer that detects when a scenario (coverage) monitor is satisfied.
+/// A scenario is satisfied when its monitor enters an accepting (cold) state: the runtime
+/// surfaces that as <see cref="OnMonitorStateTransition"/> with <c>isInHotState == false</c>.
+/// The set of coverage monitors is provided by <see cref="PModule.coverageMonitors"/> at
+/// generation time. Aggregation across iterations lives in <c>TestReport</c>.
+/// </summary>
+internal class ScenarioComplianceObserver : IControlledRuntimeLog
+{
+    // FullName of every coverage (scenario) monitor for this run.
+    private readonly HashSet<string> _coverageMonitorNames;
+
+    // Short names (P scenario names) of scenarios satisfied at least once this iteration.
+    private readonly HashSet<string> _satisfied = new();
+
+    public ScenarioComplianceObserver()
+    {
+        _coverageMonitorNames = PModule.coverageMonitors.Select(t => t.FullName).ToHashSet();
+        AllScenarioNames = _coverageMonitorNames.Select(ShortName).ToList();
+    }
+
+    /// <summary>Scenarios (by short name) satisfied at least once during this iteration.</summary>
+    public IReadOnlyCollection<string> SatisfiedScenarios => _satisfied;
+
+    /// <summary>Short names of all declared scenarios (so 0-coverage ones are reported too).</summary>
+    public IReadOnlyCollection<string> AllScenarioNames { get; }
+
+    /// <summary>True if any scenario monitors are active for this run.</summary>
+    public bool HasScenarios => _coverageMonitorNames.Count > 0;
+
+    private static string ShortName(string fullName)
+    {
+        var idx = fullName.LastIndexOf('.');
+        return idx >= 0 ? fullName.Substring(idx + 1) : fullName;
+    }
+
+    public void OnMonitorStateTransition(string monitorType, string stateName, bool isEntry, bool? isInHotState)
+    {
+        // A coverage monitor entering a cold (accepting) state == scenario satisfied.
+        if (isEntry && isInHotState == false && _coverageMonitorNames.Contains(monitorType))
+        {
+            _satisfied.Add(ShortName(monitorType));
+        }
+    }
+
+    // ── Remaining IControlledRuntimeLog hooks are not needed here ──
+    public void OnCreateStateMachine(StateMachineId id, string creatorName, string creatorType) { }
+    public void OnExecuteAction(StateMachineId id, string handlingStateName, string currentStateName, string actionName) { }
+    public void OnSendEvent(StateMachineId targetStateMachineId, string senderName, string senderType, string senderStateName, Event e, bool isTargetHalted) { }
+    public void OnRaiseEvent(StateMachineId id, string stateName, Event e) { }
+    public void OnEnqueueEvent(StateMachineId id, Event e) { }
+    public void OnDequeueEvent(StateMachineId id, string stateName, Event e) { }
+    public void OnReceiveEvent(StateMachineId id, string stateName, Event e, bool wasBlocked) { }
+    public void OnWaitEvent(StateMachineId id, string stateName, Type eventType) { }
+    public void OnWaitEvent(StateMachineId id, string stateName, params Type[] eventTypes) { }
+    public void OnStateTransition(StateMachineId id, string stateName, bool isEntry) { }
+    public void OnGotoState(StateMachineId id, string currentStateName, string newStateName) { }
+    public void OnDefaultEventHandler(StateMachineId id, string stateName) { }
+    public void OnHalt(StateMachineId id, int inboxSize) { }
+    public void OnHandleRaisedEvent(StateMachineId id, string stateName, Event e) { }
+    public void OnPopStateUnhandledEvent(StateMachineId id, string stateName, Event e) { }
+    public void OnExceptionThrown(StateMachineId id, string stateName, string actionName, Exception ex) { }
+    public void OnExceptionHandled(StateMachineId id, string stateName, string actionName, Exception ex) { }
+    public void OnCreateMonitor(string monitorType) { }
+    public void OnMonitorExecuteAction(string monitorType, string stateName, string actionName) { }
+    public void OnMonitorProcessEvent(string monitorType, string stateName, string senderName, string senderType, string senderStateName, Event e) { }
+    public void OnMonitorRaiseEvent(string monitorType, string stateName, Event e) { }
+    public void OnMonitorError(string monitorType, string stateName, bool? isInHotState) { }
+    public void OnRandom(object result, string callerName, string callerType) { }
+    public void OnAssertionFailure(string error) { }
+    public void OnStrategyDescription(string strategyName, string description) { }
+    public void OnCompleted() { }
+}

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
@@ -55,20 +55,19 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
     public int TotalStates(string scenario) => _totalStates.TryGetValue(scenario, out var n) ? n : 0;
 
     /// <summary>
-    /// Run-level compliance in [0,1]: the maximum partial-progress fraction across all
-    /// scenarios this iteration (how close the run got to satisfying any scenario). Used
-    /// to steer the feedback-guided search toward under-covered scenarios.
+    /// Snapshot of distinct states reached this iteration, per scenario. Fed (with
+    /// <see cref="SatisfiedScenarios"/> and the suite-so-far state) to
+    /// <see cref="ScenarioSteering.NoveltyCompliance"/> to produce the coverage-novelty
+    /// steering signal for the feedback-guided search.
     /// </summary>
-    public double RunCompliance()
+    public IReadOnlyDictionary<string, int> ReachedSnapshot()
     {
-        double max = 0;
+        var snapshot = new Dictionary<string, int>();
         foreach (var scenario in AllScenarioNames)
         {
-            var total = TotalStates(scenario);
-            if (total <= 0) continue;
-            max = System.Math.Max(max, (double)StatesReached(scenario) / total);
+            snapshot[scenario] = StatesReached(scenario);
         }
-        return max;
+        return snapshot;
     }
 
     private static string ShortName(string fullName)

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
@@ -17,8 +17,16 @@ namespace PChecker.Feedback;
 /// </summary>
 internal class ScenarioComplianceObserver : IControlledRuntimeLog
 {
-    // FullName of every coverage (scenario) monitor for this run.
-    private readonly HashSet<string> _coverageMonitorNames;
+    // Coverage-monitor metadata, snapshotted from PModule. PModule.coverageMonitors /
+    // scenarioStateCounts are populated by the generated InitializeMonitorMap during test
+    // setup — i.e. AFTER this observer is constructed — so we must NOT snapshot them in the
+    // ctor (that would make the first iteration, and any 1-schedule run, see an empty set and
+    // silently drop all scenario coverage). Instead Refresh() re-reads PModule whenever it has
+    // grown, so every transition — including the monitor's initial (start) state-entry logged
+    // during RegisterMonitor — is classified.
+    private HashSet<string> _coverageMonitorNames = new();
+    private List<string> _allScenarioNames = new();
+    private int _snapshotCount = -1;
 
     // Short names (P scenario names) of scenarios satisfied at least once this iteration.
     private readonly HashSet<string> _satisfied = new();
@@ -29,10 +37,15 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
     // Short name -> total number of states in that scenario.
     private readonly Dictionary<string, int> _totalStates = new();
 
-    public ScenarioComplianceObserver()
+    private void Refresh()
     {
+        if (PModule.coverageMonitors.Count == _snapshotCount)
+        {
+            return; // unchanged since the last read
+        }
+        _snapshotCount = PModule.coverageMonitors.Count;
         _coverageMonitorNames = PModule.coverageMonitors.Select(t => t.FullName).ToHashSet();
-        AllScenarioNames = _coverageMonitorNames.Select(ShortName).ToList();
+        _allScenarioNames = _coverageMonitorNames.Select(ShortName).ToList();
         foreach (var kv in PModule.scenarioStateCounts)
         {
             _totalStates[ShortName(kv.Key.FullName)] = kv.Value;
@@ -43,10 +56,16 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
     public IReadOnlyCollection<string> SatisfiedScenarios => _satisfied;
 
     /// <summary>Short names of all declared scenarios (so 0-coverage ones are reported too).</summary>
-    public IReadOnlyCollection<string> AllScenarioNames { get; }
+    public IReadOnlyCollection<string> AllScenarioNames
+    {
+        get { Refresh(); return _allScenarioNames; }
+    }
 
     /// <summary>True if any scenario monitors are active for this run.</summary>
-    public bool HasScenarios => _coverageMonitorNames.Count > 0;
+    public bool HasScenarios
+    {
+        get { Refresh(); return _coverageMonitorNames.Count > 0; }
+    }
 
     /// <summary>Distinct states <paramref name="scenario"/> entered this iteration.</summary>
     public int StatesReached(string scenario) => _statesReached.TryGetValue(scenario, out var s) ? s.Count : 0;
@@ -78,6 +97,9 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
 
     public void OnMonitorStateTransition(string monitorType, string stateName, bool isEntry, bool? isInHotState)
     {
+        // Pick up coverage monitors registered since construction (see Refresh) so early
+        // transitions — including the initial state-entry during RegisterMonitor — are counted.
+        Refresh();
         if (!isEntry || !_coverageMonitorNames.Contains(monitorType))
         {
             return;

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioComplianceObserver.cs
@@ -105,7 +105,7 @@ internal class ScenarioComplianceObserver : IControlledRuntimeLog
     public void OnSendEvent(StateMachineId targetStateMachineId, string senderName, string senderType, string senderStateName, Event e, bool isTargetHalted) { }
     public void OnRaiseEvent(StateMachineId id, string stateName, Event e) { }
     public void OnEnqueueEvent(StateMachineId id, Event e) { }
-    public void OnDequeueEvent(StateMachineId id, string stateName, Event e) { }
+    public void OnDequeueEvent(StateMachineId id, string stateName, Event e, StateMachineId senderId, VectorTime deliveryTime) { }
     public void OnReceiveEvent(StateMachineId id, string stateName, Event e, bool wasBlocked) { }
     public void OnWaitEvent(StateMachineId id, string stateName, Type eventType) { }
     public void OnWaitEvent(StateMachineId id, string stateName, params Type[] eventTypes) { }

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioSteering.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/ScenarioSteering.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace PChecker.Feedback;
+
+/// <summary>
+/// Computes the scenario-coverage steering signal ("compliance") for the
+/// feedback-guided search.
+///
+/// A naive signal — the maximum partial-progress fraction across ALL scenarios
+/// this run — saturates at 1.0 whenever any easily-satisfied scenario is met
+/// (which is essentially every run, since scenarios are auto-attached). A
+/// constant signal applies a constant factor to <c>priority</c> and therefore
+/// cannot re-order saved generators: it does not steer.
+///
+/// Instead we reward only <em>new coverage progress</em>: a run earns compliance
+/// 1.0 iff it first-satisfies a scenario, or advances the furthest state reached
+/// for a not-yet-satisfied scenario beyond the best seen so far in the suite.
+/// This is sparse (most runs earn 0, so their priority stays == diversity) and
+/// cannot saturate (once a scenario plateaus — including an unsatisfiable one at
+/// its ceiling — it stops earning), so it genuinely biases the search toward
+/// coverage gaps. The suite-so-far state is threaded by the caller and updated
+/// in place, so the signal is deterministic under a fixed seed.
+/// </summary>
+public static class ScenarioSteering
+{
+    /// <summary>
+    /// Returns 1.0 if this run made new coverage progress relative to the
+    /// suite-so-far state (which is mutated to fold in this run), else 0.0.
+    /// </summary>
+    /// <param name="runReached">Distinct states reached this run, per scenario.</param>
+    /// <param name="runSatisfied">Scenarios satisfied (reached a cold state) this run.</param>
+    /// <param name="suiteBestReached">Best states-reached per scenario across the suite so far (mutated).</param>
+    /// <param name="suiteSatisfied">Scenarios satisfied anywhere in the suite so far (mutated).</param>
+    public static double NoveltyCompliance(
+        IReadOnlyDictionary<string, int> runReached,
+        IReadOnlyCollection<string> runSatisfied,
+        IDictionary<string, int> suiteBestReached,
+        ISet<string> suiteSatisfied)
+    {
+        double compliance = 0.0;
+
+        // Strongest signal: the first run to satisfy a scenario anywhere in the suite.
+        foreach (var scenario in runSatisfied)
+        {
+            if (suiteSatisfied.Add(scenario)) // Add returns true only if newly added.
+            {
+                compliance = 1.0;
+            }
+        }
+
+        // Also reward advancing the furthest state of a not-yet-satisfied scenario.
+        // Once a scenario is satisfied, diversity (not steering) drives finding more ways.
+        foreach (var kv in runReached)
+        {
+            if (suiteSatisfied.Contains(kv.Key))
+            {
+                continue;
+            }
+            if (kv.Value > (suiteBestReached.TryGetValue(kv.Key, out var best) ? best : 0))
+            {
+                suiteBestReached[kv.Key] = kv.Value;
+                compliance = 1.0;
+            }
+        }
+
+        return compliance;
+    }
+}

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/TimelineObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/TimelineObserver.cs
@@ -109,8 +109,11 @@ internal class TimelineObserver : IControlledRuntimeLog
 
     public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
     {
-        string actor = id.Type;
-        
+        // Key the timeline on the receiver machine INSTANCE (id.Name), not its type, so
+        // the abstract Lamport timeline <M, e1, e2> is per receiver as the paper defines
+        // it — distinct instances of the same machine class have distinct timelines.
+        string actor = id.Name;
+
         _allEvents.TryAdd(actor, new());
         _orderedEvents.TryAdd(actor, new());
 

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/TimelineObserver.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/TimelineObserver.cs
@@ -7,11 +7,20 @@ using PChecker.Runtime.StateMachines;
 
 namespace PChecker.Feedback;
 
+/// <summary>
+/// Observes event deliveries in one schedule and produces the "timeline" — the diversity
+/// signal that drives the feedback-guided search. The actual timeline encoding is
+/// delegated to a selectable <see cref="ITimelineRepresentation"/> (see --timeline-repr);
+/// this class owns the shared, deterministic hashing (FNV-1a + fixed-coefficient MinHash)
+/// and the canonical-string / MinHash views its consumers expect.
+///
+/// The default representation (pairwise) is byte-compatible with the historical behavior,
+/// so with default options the abstract-timeline strings and MinHash are unchanged.
+/// </summary>
 internal class TimelineObserver : IControlledRuntimeLog
 {
-    private HashSet<(string, string, string)> _timelines = new();
-    private Dictionary<string, HashSet<string>> _allEvents = new();
-    private Dictionary<string, List<string>> _orderedEvents = new();
+    private readonly ITimelineRepresentation _representation;
+    private readonly bool _includePayload;
 
     public static readonly List<(int, int)> Coefficients = new();
     public static int NumOfCoefficients = 50;
@@ -27,34 +36,38 @@ internal class TimelineObserver : IControlledRuntimeLog
         }
     }
 
+    /// <summary>Default ctor keeps the historical (pairwise) behavior.</summary>
+    public TimelineObserver() : this("pairwise", 3, false)
+    {
+    }
+
+    public TimelineObserver(string representation, int kgram, bool includePayload)
+    {
+        _representation = ITimelineRepresentation.Create(representation, kgram);
+        _includePayload = includePayload;
+    }
+
+    /// <summary>
+    /// Canonical timeline string: the sorted, joined token set. Used for the exact-match
+    /// novelty gate and the ExploredTimelines metric. Distinct schedules under the chosen
+    /// representation map to distinct strings; the internal format is not user-facing.
+    /// </summary>
     public string GetAbstractTimeline()
     {
-        var tls = _timelines.Select(it => $"<{it.Item1}, {it.Item2}, {it.Item3}>").ToList();
-        tls.Sort();
-        return string.Join(";", tls);
+        var tokens = _representation.Tokens().ToList();
+        tokens.Sort(StringComparer.Ordinal);
+        return string.Join(";", tokens);
     }
 
-    public string GetTimeline()
-    {
-        return string.Join(";", _orderedEvents.Select(it =>
-        {
-            var events = string.Join(",", it.Value);
-            return $"{it.Key}: {events}";
-        }));
-    }
-
+    /// <summary>MinHash sketch of the token set for Jaccard-similarity diversity estimation.</summary>
     public List<int> GetTimelineMinhash()
     {
+        var tokenHashes = _representation.Tokens().Select(StableHash).ToList();
         List<int> minHash = new();
-        // Use a deterministic, process-independent hash of each timeline tuple.
-        // Tuple/string GetHashCode is randomized per process in modern .NET, which
-        // would make the minhash — and thus ComputeDiversity / generator
-        // prioritization — non-reproducible under a fixed --seed.
-        var timelineHash = _timelines.Select(it => StableHash(it.Item1, it.Item2, it.Item3)).ToList();
         foreach (var (a, b) in Coefficients)
         {
             int minValue = Int32.MaxValue;
-            foreach (var value in timelineHash)
+            foreach (var value in tokenHashes)
             {
                 int hash = a * value + b;
                 minValue = Math.Min(minValue, hash);
@@ -65,25 +78,38 @@ internal class TimelineObserver : IControlledRuntimeLog
     }
 
     /// <summary>
-    /// Deterministic 32-bit FNV-1a hash of a timeline tuple, stable across processes
-    /// (unlike string.GetHashCode). Fields are separated so distinct tuples do not alias.
+    /// Deterministic 32-bit FNV-1a hash of a token string, stable across processes
+    /// (unlike string.GetHashCode, which is randomized per process and would make the
+    /// MinHash — and thus ComputeDiversity / generator prioritization — non-reproducible
+    /// under a fixed --seed).
     /// </summary>
-    private static int StableHash(string a, string b, string c)
+    private static int StableHash(string token)
     {
         unchecked
         {
             const uint prime = 16777619;
             uint hash = 2166136261;
-            foreach (var s in new[] { a, b, c })
+            foreach (var by in System.Text.Encoding.UTF8.GetBytes(token))
             {
-                foreach (var by in System.Text.Encoding.UTF8.GetBytes(s))
-                {
-                    hash = (hash ^ by) * prime;
-                }
-                hash = (hash ^ 0x1f) * prime; // field separator
+                hash = (hash ^ by) * prime;
             }
             return (int)hash;
         }
+    }
+
+    public void OnDequeueEvent(StateMachineId id, string stateName, Event e,
+        StateMachineId senderId, VectorTime deliveryTime)
+    {
+        // The event label is the type name, optionally enriched with a stable hash of the
+        // payload so that deliveries differing only by payload value (ballot, term, txnId,
+        // status, ...) are not conflated. Payload enrichment is off by default.
+        string label = e.GetType().Name;
+        if (_includePayload && e.Payload != null)
+        {
+            label = $"{label}#{StableHash(e.Payload.ToString() ?? string.Empty)}";
+        }
+
+        _representation.RecordDelivery(id.Name, senderId?.Name ?? string.Empty, label, deliveryTime);
     }
 
     public void OnCreateStateMachine(StateMachineId id, string creatorName, string creatorType)
@@ -105,25 +131,6 @@ internal class TimelineObserver : IControlledRuntimeLog
 
     public void OnEnqueueEvent(StateMachineId id, Event e)
     {
-    }
-
-    public void OnDequeueEvent(StateMachineId id, string stateName, Event e)
-    {
-        // Key the timeline on the receiver machine INSTANCE (id.Name), not its type, so
-        // the abstract Lamport timeline <M, e1, e2> is per receiver as the paper defines
-        // it — distinct instances of the same machine class have distinct timelines.
-        string actor = id.Name;
-
-        _allEvents.TryAdd(actor, new());
-        _orderedEvents.TryAdd(actor, new());
-
-        string name = e.GetType().Name;
-        foreach (var ev in _allEvents[actor])
-        {
-            _timelines.Add((actor, ev, name));
-        }
-        _allEvents[actor].Add(name);
-        _orderedEvents[actor].Add(name);
     }
 
     public void OnReceiveEvent(StateMachineId id, string stateName, Event e, bool wasBlocked)

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/TimelineRepresentations.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Coverage/TimelineRepresentations.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace PChecker.Feedback;
+
+/// <summary>
+/// A timeline representation turns the sequence of event deliveries observed in one
+/// schedule into a set of canonical string tokens. <see cref="TimelineObserver"/> then
+/// (a) sorts+joins the tokens into the abstract-timeline string (novelty gate +
+/// ExploredTimelines metric) and (b) MinHashes them for the diversity score.
+///
+/// The representation is the diversity signal that drives the feedback-guided search,
+/// so it is selectable (<c>--timeline-repr</c>) with <see cref="PairwiseLocalRepresentation"/>
+/// as the default (byte-compatible with the historical behavior). Everything is computed
+/// post-hoc from a finished schedule, so this never affects scheduling / record-replay.
+///
+/// Convention: fields inside a token are separated by U+001F ("\u001f") so distinct field
+/// tuples never alias, and the pairwise token's bytes match the legacy hash input exactly.
+/// </summary>
+public interface ITimelineRepresentation
+{
+    /// <summary>Field separator used inside tokens (a non-printing control char).</summary>
+    const char Sep = '\u001f';
+
+    /// <summary>Record one delivered (dequeued) event, in delivery order.</summary>
+    /// <param name="receiver">Receiver machine instance name.</param>
+    /// <param name="sender">Sender machine instance name (may be empty).</param>
+    /// <param name="label">Abstracted event label (type name, optionally payload-enriched).</param>
+    /// <param name="deliveryTime">Receiver's vector clock at delivery (post-merge); may be null.</param>
+    void RecordDelivery(string receiver, string sender, string label, VectorTime deliveryTime);
+
+    /// <summary>The canonical token set for this schedule.</summary>
+    IReadOnlyCollection<string> Tokens();
+
+    /// <summary>Factory: build the representation named by <paramref name="repr"/>.</summary>
+    static ITimelineRepresentation Create(string repr, int kgram)
+    {
+        switch ((repr ?? "pairwise").ToLowerInvariant())
+        {
+            case "kgram": return new KGramRepresentation(kgram);
+            case "causal": return new CausalRepresentation();
+            case "hybrid": return new HybridRepresentation(kgram);
+            case "pairwise":
+            default: return new PairwiseLocalRepresentation();
+        }
+    }
+}
+
+/// <summary>
+/// The historical representation: per receiver instance, the set of ordered pairs of
+/// event labels "(a) was dequeued before (b) at least once at this receiver". Local to
+/// each receiver (no cross-machine causality). The token layout "receiver\u001fa\u001fb\u001f"
+/// makes its downstream FNV-1a hash identical to the legacy StableHash(receiver, a, b),
+/// so the default search behavior is preserved exactly.
+/// </summary>
+public sealed class PairwiseLocalRepresentation : ITimelineRepresentation
+{
+    private const char S = '\u001f';
+    private readonly HashSet<string> _tokens = new();
+    private readonly Dictionary<string, HashSet<string>> _seenPerReceiver = new();
+
+    public void RecordDelivery(string receiver, string sender, string label, VectorTime deliveryTime)
+    {
+        if (!_seenPerReceiver.TryGetValue(receiver, out var seen))
+        {
+            seen = new HashSet<string>();
+            _seenPerReceiver[receiver] = seen;
+        }
+        foreach (var prev in seen)
+        {
+            _tokens.Add($"{receiver}{S}{prev}{S}{label}{S}");
+        }
+        seen.Add(label);
+    }
+
+    public IReadOnlyCollection<string> Tokens() => _tokens;
+}
+
+/// <summary>
+/// Higher-resolution LOCAL representation: per receiver, the set of contiguous
+/// subsequences (grams) of length 1..k of the delivery sequence. Strictly finer than
+/// pairwise (it distinguishes e.g. ABAB from AABB, which pairwise conflates once all
+/// pairs appear) and does not saturate as quickly. Still local — no cross-machine order.
+/// </summary>
+public sealed class KGramRepresentation : ITimelineRepresentation
+{
+    private const char S = '\u001f';
+    private readonly int _k;
+    private readonly HashSet<string> _tokens = new();
+    private readonly Dictionary<string, List<string>> _seqPerReceiver = new();
+
+    public KGramRepresentation(int k) => _k = k < 1 ? 1 : k;
+
+    public void RecordDelivery(string receiver, string sender, string label, VectorTime deliveryTime)
+    {
+        if (!_seqPerReceiver.TryGetValue(receiver, out var seq))
+        {
+            seq = new List<string>();
+            _seqPerReceiver[receiver] = seq;
+        }
+        seq.Add(label);
+        int end = seq.Count - 1;
+        // Emit every gram of length 1..k ending at this delivery.
+        for (int len = 1; len <= _k && end - (len - 1) >= 0; len++)
+        {
+            var sb = new StringBuilder();
+            sb.Append(receiver).Append(S).Append(len).Append(S);
+            for (int i = end - (len - 1); i <= end; i++)
+            {
+                if (i > end - (len - 1))
+                {
+                    sb.Append('>');
+                }
+                sb.Append(seq[i]);
+            }
+            _tokens.Add(sb.ToString());
+        }
+    }
+
+    public IReadOnlyCollection<string> Tokens() => _tokens;
+}
+
+/// <summary>
+/// The principled CAUSAL representation: the happens-before partial order over delivery
+/// events, abstracted to labels. For every pair of deliveries it emits either an ordered
+/// token "hb a b" (a happens-before b) or a concurrency token "co a b" (causally
+/// independent). Happens-before combines (1) message causality via the runtime's vector
+/// clocks (<see cref="VectorTime.CompareTo"/>) and (2) per-receiver program order (the
+/// observation order of deliveries at the same receiver), which the clocks alone miss
+/// because the runtime only ticks a machine's own component on SEND, not on receive.
+/// This is the cross-machine generalization of the pairwise representation.
+/// </summary>
+public sealed class CausalRepresentation : ITimelineRepresentation
+{
+    private const char S = '\u001f';
+    private readonly List<(string receiver, string label, VectorTime time)> _deliveries = new();
+    private readonly HashSet<string> _tokens = new();
+
+    public void RecordDelivery(string receiver, string sender, string label, VectorTime deliveryTime)
+    {
+        var snap = deliveryTime == null ? null : new VectorTime(deliveryTime);
+        foreach (var (pReceiver, pLabel, pTime) in _deliveries)
+        {
+            // VectorTime.CompareTo follows the IComparable convention (its doc comment is
+            // inverted): negative => `this` happens-before `other`; positive => after; 0 => concurrent/equal.
+            int cmp = (pTime != null && snap != null) ? pTime.CompareTo(snap) : 0;
+            _tokens.Add(PairToken(cmp, pReceiver == receiver, pLabel, label));
+        }
+        _deliveries.Add((receiver, label, snap));
+    }
+
+    /// <summary>
+    /// Token for one ordered pair of deliveries (prior, current), given the vector-clock
+    /// comparison <paramref name="cmp"/> (negative: prior happens-before current; positive:
+    /// after; 0: concurrent/equal) and whether they share a receiver. Equal/incomparable
+    /// clocks at the same receiver are ordered by program order (prior first); otherwise the
+    /// deliveries are genuinely concurrent. Pure + deterministic (unit-tested).
+    /// </summary>
+    public static string PairToken(int cmp, bool sameReceiver, string priorLabel, string currentLabel)
+    {
+        if (cmp < 0)
+        {
+            return Hb(priorLabel, currentLabel);   // prior -> current
+        }
+        if (cmp > 0)
+        {
+            return Hb(currentLabel, priorLabel);   // current -> prior
+        }
+        if (sameReceiver)
+        {
+            return Hb(priorLabel, currentLabel);   // equal clocks, same receiver => program order
+        }
+        return Co(priorLabel, currentLabel);       // genuinely concurrent
+    }
+
+    private static string Hb(string from, string to) => $"hb{S}{from}{S}{to}";
+
+    private static string Co(string a, string b)
+    {
+        // Canonical order so concurrency is symmetric: co(a,b) == co(b,a).
+        return string.CompareOrdinal(a, b) <= 0 ? $"co{S}{a}{S}{b}" : $"co{S}{b}{S}{a}";
+    }
+
+    public IReadOnlyCollection<string> Tokens() => _tokens;
+}
+
+/// <summary>
+/// Union of the causal (cross-machine order) and k-gram (local resolution) token sets,
+/// prefixed so the two families never collide.
+/// </summary>
+public sealed class HybridRepresentation : ITimelineRepresentation
+{
+    private const char S = '\u001f';
+    private readonly CausalRepresentation _causal = new();
+    private readonly KGramRepresentation _kgram;
+
+    public HybridRepresentation(int k) => _kgram = new KGramRepresentation(k);
+
+    public void RecordDelivery(string receiver, string sender, string label, VectorTime deliveryTime)
+    {
+        _causal.RecordDelivery(receiver, sender, label, deliveryTime);
+        _kgram.RecordDelivery(receiver, sender, label, deliveryTime);
+    }
+
+    public IReadOnlyCollection<string> Tokens()
+    {
+        var tokens = new HashSet<string>();
+        foreach (var t in _causal.Tokens())
+        {
+            tokens.Add("C" + S + t);
+        }
+        foreach (var t in _kgram.Tokens())
+        {
+            tokens.Add("K" + S + t);
+        }
+        return tokens;
+    }
+}

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
@@ -32,6 +32,12 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
 
     private readonly HashSet<string> _visitedTimelines = new();
 
+    // Suite-level scenario-coverage state for steering, accumulated across schedules. Only
+    // advanced for KEPT generators (see ObserveRunningResults) so a discarded schedule can
+    // never "use up" a scenario's novelty and starve a later kept schedule of the boost.
+    private readonly Dictionary<string, int> _scenarioSuiteBestReached = new();
+    private readonly HashSet<string> _scenarioSuiteSatisfied = new();
+
     private List<GeneratorRecord> _savedGenerators = new ();
     private int _pendingMutations;
     private bool _shouldExploreNew;
@@ -161,7 +167,8 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
     /// <summary>
     /// This method observes the results of previous run and prepare for the next run.
     /// </summary>
-    public virtual void ObserveRunningResults(TimelineObserver timelineObserver, double scenarioCompliance)
+    public virtual void ObserveRunningResults(TimelineObserver timelineObserver,
+        IReadOnlyDictionary<string, int> scenarioReached, IReadOnlyCollection<string> scenarioSatisfied)
     {
         var timelineId = timelineObserver.GetAbstractTimeline();
         var timelineMinhash = timelineObserver.GetTimelineMinhash();
@@ -170,15 +177,19 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
 
         if (diversity <= 0)
         {
+            // Timeline-redundant schedule is discarded; do NOT fold its scenario progress
+            // into the suite state, so it cannot rob a later kept schedule of the novelty.
             return;
         }
 
-        // Steer the search toward under-covered scenarios: boost priority by how close
-        // this run got to satisfying a scenario (compliance in [0,1]). With no active
-        // scenario, compliance is 0 -> priority == diversity (unchanged). A boost (rather
-        // than the paper's strict diversity x compliance product) keeps diverse-but-
-        // scenario-irrelevant schedules from being discarded, since scenarios are always
-        // auto-attached here.
+        // Steer the search toward under-covered scenarios. Compliance (a coverage-NOVELTY
+        // signal, computed only now that the generator is being kept) is 1.0 iff this
+        // schedule made new scenario progress; else 0.0 -> priority == diversity (unchanged).
+        // A boost (rather than the paper's strict diversity x compliance product) keeps
+        // diverse-but-scenario-irrelevant schedules from being discarded, since scenarios
+        // are always auto-attached here.
+        double scenarioCompliance = ScenarioSteering.NoveltyCompliance(
+            scenarioReached, scenarioSatisfied, _scenarioSuiteBestReached, _scenarioSuiteSatisfied);
         double priority = diversity * (1.0 + scenarioCompliance);
         // Mutation budget is proportional to novelty (diversity) but kept as a separate
         // integer so the [0,1] priority metric never doubles as the budget.

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
@@ -14,7 +14,15 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
 {
     public record StrategyGenerator(ControlledRandom InputGenerator, IScheduler Scheduler);
 
-    public record GeneratorRecord(int Priority, StrategyGenerator Generator, List<int> MinHash);
+    // Priority (ordering score) is decoupled from MutationBudget: Priority ranks saved
+    // generators for exploration order, while MutationBudget is how many mutations to
+    // spend on this parent. Both derive from the normalized diversity, but keeping them
+    // separate stops the [0,1] diversity metric from doubling as an integer budget.
+    public record GeneratorRecord(double Priority, int MutationBudget, StrategyGenerator Generator, List<int> MinHash);
+
+    // Default mutation budget for generators with no diversity-derived budget yet
+    // (the first parent's exploration and freshly-explored inputs).
+    private const int DefaultMutationBudget = 50;
 
     internal StrategyGenerator Generator;
 
@@ -113,19 +121,24 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
         ScheduledSteps = 0;
     }
 
-    private int ComputeDiversity(string timeline, List<int> hash)
+    /// <summary>
+    /// Diversity of a timeline as 1 - Jaccard(new, closest prior), in [0,1] (the Jaccard
+    /// index is estimated from the MinHash signatures). Returns 0 for a timeline already
+    /// seen exactly (a duplicate to discard); 1 for the first timeline (maximally novel).
+    /// </summary>
+    private double ComputeDiversity(string timeline, List<int> hash)
     {
         if (!_visitedTimelines.Add(timeline))
         {
             return 0;
         }
 
-        if (_savedGenerators.Count == 0)
+        if (_savedGenerators.Count == 0 || hash.Count == 0)
         {
-            return 20;
+            return 1.0;
         }
 
-        var maxSim = int.MinValue;
+        var maxSim = 0;
         foreach (var record in _savedGenerators)
         {
             var timelineHash = record.MinHash;
@@ -141,8 +154,8 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
             maxSim = Math.Max(maxSim, similarity);
         }
 
-
-        return (hash.Count - maxSim) + 20;
+        // 1 - estimated Jaccard similarity to the most-similar prior timeline.
+        return 1.0 - (double)maxSim / hash.Count;
     }
 
     /// <summary>
@@ -153,9 +166,9 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
         var timelineId = timelineObserver.GetAbstractTimeline();
         var timelineMinhash = timelineObserver.GetTimelineMinhash();
 
-        int diversityScore = ComputeDiversity(timelineId, timelineMinhash);
+        double diversity = ComputeDiversity(timelineId, timelineMinhash);
 
-        if (diversityScore == 0)
+        if (diversity <= 0)
         {
             return;
         }
@@ -166,11 +179,13 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
         // than the paper's strict diversity x compliance product) keeps diverse-but-
         // scenario-irrelevant schedules from being discarded, since scenarios are always
         // auto-attached here.
-        int priority = (int)System.Math.Ceiling(diversityScore * (1.0 + scenarioCompliance));
+        double priority = diversity * (1.0 + scenarioCompliance);
+        // Mutation budget is proportional to novelty (diversity) but kept as a separate
+        // integer so the [0,1] priority metric never doubles as the budget.
+        int mutationBudget = Math.Max(1, (int)Math.Round(diversity * DefaultMutationBudget));
 
-        if (priority > 0)
         {
-            var record = new GeneratorRecord(priority, Generator, timelineMinhash);
+            var record = new GeneratorRecord(priority, mutationBudget, Generator, timelineMinhash);
             if (_savedGenerators.Count == 0)
             {
                 _savedGenerators.Add(record);
@@ -213,7 +228,7 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
             {
                 _currentParent = _savedGenerators.First();
                 _visitedGenerators.Add(_currentParent);
-                _pendingMutations = 50;
+                _pendingMutations = _currentParent.MutationBudget;
             }
 
             if (_pendingMutations == 0)
@@ -225,7 +240,7 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
                     if (_visitedGenerators.Contains(generator)) continue;
                     _currentParent = generator;
                     _visitedGenerators.Add(generator);
-                    _pendingMutations = generator.Priority;
+                    _pendingMutations = generator.MutationBudget;
                     found = true;
                     break;
                 }
@@ -237,13 +252,13 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
                         _visitedGenerators.Clear();
                         _currentParent = _savedGenerators.First();
                         _visitedGenerators.Add(_currentParent);
-                        _pendingMutations = _currentParent.Priority;
+                        _pendingMutations = _currentParent.MutationBudget;
                     }
                     else
                     {
                         _shouldExploreNew = true;
                         _currentParent = null;
-                        _pendingMutations = 50;
+                        _pendingMutations = DefaultMutationBudget;
                     }
                 }
             }

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
@@ -148,7 +148,7 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
     /// <summary>
     /// This method observes the results of previous run and prepare for the next run.
     /// </summary>
-    public virtual void ObserveRunningResults(TimelineObserver timelineObserver)
+    public virtual void ObserveRunningResults(TimelineObserver timelineObserver, double scenarioCompliance)
     {
         var timelineId = timelineObserver.GetAbstractTimeline();
         var timelineMinhash = timelineObserver.GetTimelineMinhash();
@@ -160,8 +160,14 @@ internal class FeedbackGuidedStrategy : IFeedbackGuidedStrategy
             return;
         }
 
-        int priority = diversityScore;
-        
+        // Steer the search toward under-covered scenarios: boost priority by how close
+        // this run got to satisfying a scenario (compliance in [0,1]). With no active
+        // scenario, compliance is 0 -> priority == diversity (unchanged). A boost (rather
+        // than the paper's strict diversity x compliance product) keeps diverse-but-
+        // scenario-irrelevant schedules from being discarded, since scenarios are always
+        // auto-attached here.
+        int priority = (int)System.Math.Ceiling(diversityScore * (1.0 + scenarioCompliance));
+
         if (priority > 0)
         {
             var record = new GeneratorRecord(priority, Generator, timelineMinhash);

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Generator/ControlledRandom.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/Generator/ControlledRandom.cs
@@ -66,8 +66,11 @@ public class ControlledRandom: IRandomValueGenerator
     
     public ControlledRandom Mutate()
     {
-        return new ControlledRandom(Utils.MutateRandomChoices(IntChoices, 5, 5, IntChoices.Random),
-            Utils.MutateRandomChoices(DoubleChoices, 5, 5, DoubleChoices.Random)
+        // Mutate ~5 integers on average (the paper's target): ~5 mutation sites of size 1,
+        // not ~5 runs of ~5 (which changed ~25). Small, localized changes keep the mutated
+        // schedule similar-but-distinct from its parent.
+        return new ControlledRandom(Utils.MutateRandomChoices(IntChoices, 5, 1, IntChoices.Random),
+            Utils.MutateRandomChoices(DoubleChoices, 5, 1, DoubleChoices.Random)
         );
     }
     

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/IFeedbackGuidedStrategy.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/IFeedbackGuidedStrategy.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using PChecker.Feedback;
 
@@ -5,7 +6,11 @@ namespace PChecker.SystematicTesting.Strategies.Feedback;
 
 internal interface IFeedbackGuidedStrategy: ISchedulingStrategy
 {
-    public void ObserveRunningResults(TimelineObserver timelineObserver, double scenarioCompliance);
+    // scenarioReached: distinct states reached this run per scenario; scenarioSatisfied: scenarios
+    // that reached a cold (accepting) state this run. Used to compute the coverage-novelty
+    // steering signal for KEPT generators only (see FeedbackGuidedStrategy.ObserveRunningResults).
+    public void ObserveRunningResults(TimelineObserver timelineObserver,
+        IReadOnlyDictionary<string, int> scenarioReached, IReadOnlyCollection<string> scenarioSatisfied);
     public int TotalSavedInputs();
     public void DumpStats(TextWriter writer);
 }

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/IFeedbackGuidedStrategy.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/IFeedbackGuidedStrategy.cs
@@ -5,7 +5,7 @@ namespace PChecker.SystematicTesting.Strategies.Feedback;
 
 internal interface IFeedbackGuidedStrategy: ISchedulingStrategy
 {
-    public void ObserveRunningResults(TimelineObserver timelineObserver);
+    public void ObserveRunningResults(TimelineObserver timelineObserver, double scenarioCompliance);
     public int TotalSavedInputs();
     public void DumpStats(TextWriter writer);
 }

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using PChecker.Coverage;
@@ -107,6 +108,20 @@ namespace PChecker.SystematicTesting
         [DataMember]
         public HashSet<string> ExploredTimelines = new();
 
+        /// <summary>
+        /// Scenario coverage: per scenario name, the number of iterations in which it was
+        /// triggered (its coverage monitor reached an accepting state at least once).
+        /// </summary>
+        [DataMember]
+        public Dictionary<string, int> ScenarioTriggerCounts = new();
+
+        /// <summary>
+        /// Scenario coverage: per scenario name, the set of distinct timelines that satisfied it.
+        /// Counts unique satisfying timelines (the paper's notion of scenario coverage).
+        /// </summary>
+        [DataMember]
+        public Dictionary<string, HashSet<string>> ScenarioSatisfyingTimelines = new();
+
 
         /// <summary>
         /// Lock for the test report.
@@ -140,6 +155,44 @@ namespace PChecker.SystematicTesting
         }
 
         /// <summary>
+        /// Ensures <paramref name="scenario"/> appears in the coverage report even if it was
+        /// never triggered (0-coverage scenarios are the important gaps to surface).
+        /// </summary>
+        public void EnsureScenarioTracked(string scenario)
+        {
+            lock (Lock)
+            {
+                if (!ScenarioTriggerCounts.ContainsKey(scenario))
+                {
+                    ScenarioTriggerCounts[scenario] = 0;
+                }
+                if (!ScenarioSatisfyingTimelines.ContainsKey(scenario))
+                {
+                    ScenarioSatisfyingTimelines[scenario] = new HashSet<string>();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Records that <paramref name="scenario"/> was satisfied by a schedule whose
+        /// abstract timeline is <paramref name="timeline"/> (used for scenario coverage).
+        /// </summary>
+        public void RecordScenarioSatisfied(string scenario, string timeline)
+        {
+            lock (Lock)
+            {
+                ScenarioTriggerCounts.TryGetValue(scenario, out var count);
+                ScenarioTriggerCounts[scenario] = count + 1;
+                if (!ScenarioSatisfyingTimelines.TryGetValue(scenario, out var timelines))
+                {
+                    timelines = new HashSet<string>();
+                    ScenarioSatisfyingTimelines[scenario] = timelines;
+                }
+                timelines.Add(timeline);
+            }
+        }
+
+        /// <summary>
         /// Merges the information from the specified test report.
         /// </summary>
         /// <returns>True if merged successfully.</returns>
@@ -155,6 +208,22 @@ namespace PChecker.SystematicTesting
             {
                 CoverageInfo.Merge(testReport.CoverageInfo);
                 ExploredTimelines.UnionWith(testReport.ExploredTimelines);
+
+                // Scenario coverage: sum trigger counts and union satisfying timelines.
+                foreach (var kv in testReport.ScenarioTriggerCounts)
+                {
+                    ScenarioTriggerCounts.TryGetValue(kv.Key, out var count);
+                    ScenarioTriggerCounts[kv.Key] = count + kv.Value;
+                }
+                foreach (var kv in testReport.ScenarioSatisfyingTimelines)
+                {
+                    if (!ScenarioSatisfyingTimelines.TryGetValue(kv.Key, out var timelines))
+                    {
+                        timelines = new HashSet<string>();
+                        ScenarioSatisfyingTimelines[kv.Key] = timelines;
+                    }
+                    timelines.UnionWith(kv.Value);
+                }
 
                 NumOfFoundBugs += testReport.NumOfFoundBugs;
 
@@ -247,6 +316,28 @@ namespace PChecker.SystematicTesting
                 prefix.Equals("...") ? "....." : prefix,
                 ExploredTimelines.Count,
                 ExploredTimelines.Count == 1 ? string.Empty : "s");
+
+            // Scenario coverage: for each declared scenario, how many schedules triggered it
+            // and how many distinct timelines satisfied it.
+            if (ScenarioTriggerCounts.Count > 0)
+            {
+                report.AppendLine();
+                report.AppendFormat("{0} Scenario coverage:", prefix.Equals("...") ? "....." : prefix);
+                foreach (var scenario in ScenarioTriggerCounts.Keys.OrderBy(k => k))
+                {
+                    var triggered = ScenarioTriggerCounts[scenario];
+                    var uniqueTimelines = ScenarioSatisfyingTimelines.TryGetValue(scenario, out var tls) ? tls.Count : 0;
+                    report.AppendLine();
+                    report.AppendFormat(
+                        "{0}  {1}: triggered in {2} schedule{3}, {4} unique satisfying timeline{5}",
+                        prefix.Equals("...") ? "....." : prefix,
+                        scenario,
+                        triggered,
+                        triggered == 1 ? string.Empty : "s",
+                        uniqueTimelines,
+                        uniqueTimelines == 1 ? string.Empty : "s");
+                }
+            }
 
             if (totalExploredSchedules > 0 &&
                 NumOfFoundBugs > 0)

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
@@ -122,6 +122,17 @@ namespace PChecker.SystematicTesting
         [DataMember]
         public Dictionary<string, HashSet<string>> ScenarioSatisfyingTimelines = new();
 
+        /// <summary>
+        /// Partial scenario coverage: per scenario, the most distinct states any single
+        /// schedule reached (how close an unsatisfied scenario got).
+        /// </summary>
+        [DataMember]
+        public Dictionary<string, int> ScenarioMaxStatesReached = new();
+
+        /// <summary>Partial scenario coverage: per scenario, its total number of states.</summary>
+        [DataMember]
+        public Dictionary<string, int> ScenarioTotalStates = new();
+
 
         /// <summary>
         /// Lock for the test report.
@@ -169,6 +180,25 @@ namespace PChecker.SystematicTesting
                 if (!ScenarioSatisfyingTimelines.ContainsKey(scenario))
                 {
                     ScenarioSatisfyingTimelines[scenario] = new HashSet<string>();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Records partial progress for <paramref name="scenario"/>: the most distinct states
+        /// reached (<paramref name="statesReached"/>) out of <paramref name="totalStates"/>.
+        /// </summary>
+        public void RecordScenarioProgress(string scenario, int statesReached, int totalStates)
+        {
+            lock (Lock)
+            {
+                if (!ScenarioMaxStatesReached.TryGetValue(scenario, out var best) || statesReached > best)
+                {
+                    ScenarioMaxStatesReached[scenario] = statesReached;
+                }
+                if (totalStates > 0)
+                {
+                    ScenarioTotalStates[scenario] = totalStates;
                 }
             }
         }
@@ -223,6 +253,17 @@ namespace PChecker.SystematicTesting
                         ScenarioSatisfyingTimelines[kv.Key] = timelines;
                     }
                     timelines.UnionWith(kv.Value);
+                }
+                foreach (var kv in testReport.ScenarioMaxStatesReached)
+                {
+                    if (!ScenarioMaxStatesReached.TryGetValue(kv.Key, out var best) || kv.Value > best)
+                    {
+                        ScenarioMaxStatesReached[kv.Key] = kv.Value;
+                    }
+                }
+                foreach (var kv in testReport.ScenarioTotalStates)
+                {
+                    ScenarioTotalStates[kv.Key] = kv.Value;
                 }
 
                 NumOfFoundBugs += testReport.NumOfFoundBugs;
@@ -336,6 +377,15 @@ namespace PChecker.SystematicTesting
                         triggered == 1 ? string.Empty : "s",
                         uniqueTimelines,
                         uniqueTimelines == 1 ? string.Empty : "s");
+
+                    // For scenarios that were never fully satisfied, show the best partial
+                    // progress reached (the coverage gap and how close exploration got).
+                    if (triggered == 0 &&
+                        ScenarioTotalStates.TryGetValue(scenario, out var total) && total > 0)
+                    {
+                        var reached = ScenarioMaxStatesReached.TryGetValue(scenario, out var r) ? r : 0;
+                        report.AppendFormat(" (best partial progress: {0}/{1} states)", reached, total);
+                    }
                 }
             }
 

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestReport.cs
@@ -358,30 +358,36 @@ namespace PChecker.SystematicTesting
                 ExploredTimelines.Count,
                 ExploredTimelines.Count == 1 ? string.Empty : "s");
 
-            // Scenario coverage: for each declared scenario, how many schedules triggered it
-            // and how many distinct timelines satisfied it.
+            // Scenario coverage: a scannable summary (how many scenarios were covered), then
+            // the covered scenarios, then the coverage gaps (never satisfied) called out last.
             if (ScenarioTriggerCounts.Count > 0)
             {
+                var pfx = prefix.Equals("...") ? "....." : prefix;
+                var names = ScenarioTriggerCounts.Keys.OrderBy(k => k).ToList();
+                var covered = names.Where(s => ScenarioTriggerCounts[s] > 0).ToList();
+                var gaps = names.Where(s => ScenarioTriggerCounts[s] == 0).ToList();
+
                 report.AppendLine();
-                report.AppendFormat("{0} Scenario coverage:", prefix.Equals("...") ? "....." : prefix);
-                foreach (var scenario in ScenarioTriggerCounts.Keys.OrderBy(k => k))
+                report.AppendFormat("{0} Scenario coverage: {1}/{2} scenarios covered{3}",
+                    pfx, covered.Count, names.Count,
+                    gaps.Count > 0 ? $" ({gaps.Count} gap{(gaps.Count == 1 ? string.Empty : "s")})" : string.Empty);
+
+                foreach (var scenario in covered)
                 {
                     var triggered = ScenarioTriggerCounts[scenario];
                     var uniqueTimelines = ScenarioSatisfyingTimelines.TryGetValue(scenario, out var tls) ? tls.Count : 0;
                     report.AppendLine();
                     report.AppendFormat(
-                        "{0}  {1}: triggered in {2} schedule{3}, {4} unique satisfying timeline{5}",
-                        prefix.Equals("...") ? "....." : prefix,
-                        scenario,
-                        triggered,
-                        triggered == 1 ? string.Empty : "s",
-                        uniqueTimelines,
-                        uniqueTimelines == 1 ? string.Empty : "s");
-
-                    // For scenarios that were never fully satisfied, show the best partial
-                    // progress reached (the coverage gap and how close exploration got).
-                    if (triggered == 0 &&
-                        ScenarioTotalStates.TryGetValue(scenario, out var total) && total > 0)
+                        "{0}   [covered] {1}: triggered in {2} schedule{3}, {4} unique satisfying timeline{5}",
+                        pfx, scenario, triggered, triggered == 1 ? string.Empty : "s",
+                        uniqueTimelines, uniqueTimelines == 1 ? string.Empty : "s");
+                }
+                // Coverage gaps: scenarios never satisfied. Show how close exploration got.
+                foreach (var scenario in gaps)
+                {
+                    report.AppendLine();
+                    report.AppendFormat("{0}   [  GAP  ] {1}: not covered", pfx, scenario);
+                    if (ScenarioTotalStates.TryGetValue(scenario, out var total) && total > 0)
                     {
                         var reached = ScenarioMaxStatesReached.TryGetValue(scenario, out var r) ? r : 0;
                         report.AppendFormat(" (best partial progress: {0}/{1} states)", reached, total);

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -575,7 +575,7 @@ namespace PChecker.SystematicTesting
 
                 if (Strategy is IFeedbackGuidedStrategy strategy)
                 {
-                    strategy.ObserveRunningResults(timelineObserver);
+                    strategy.ObserveRunningResults(timelineObserver, scenarioObserver.RunCompliance());
                 }
 
                 // Checks that no monitor is in a hot state at termination. Only
@@ -606,6 +606,8 @@ namespace PChecker.SystematicTesting
                 foreach (var scenario in scenarioObserver.AllScenarioNames)
                 {
                     TestReport.EnsureScenarioTracked(scenario);
+                    TestReport.RecordScenarioProgress(
+                        scenario, scenarioObserver.StatesReached(scenario), scenarioObserver.TotalStates(scenario));
                 }
                 if (scenarioObserver.SatisfiedScenarios.Count > 0)
                 {

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -575,7 +575,11 @@ namespace PChecker.SystematicTesting
 
                 if (Strategy is IFeedbackGuidedStrategy strategy)
                 {
-                    strategy.ObserveRunningResults(timelineObserver, scenarioObserver.RunCompliance());
+                    // The strategy computes the coverage-novelty steering signal itself, but only
+                    // for generators it keeps (after its timeline-diversity gate), so a discarded
+                    // schedule never consumes a scenario's novelty. Pass this run's raw progress.
+                    strategy.ObserveRunningResults(timelineObserver,
+                        scenarioObserver.ReachedSnapshot(), scenarioObserver.SatisfiedScenarios);
                 }
 
                 // Checks that no monitor is in a hot state at termination. Only

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -523,7 +523,10 @@ namespace PChecker.SystematicTesting
             // Runtime used to serialize and test the program in this schedule.
             ControlledRuntime runtime = null;
 
-            TimelineObserver timelineObserver = new TimelineObserver();
+            TimelineObserver timelineObserver = new TimelineObserver(
+                _checkerConfiguration.TimelineRepresentation,
+                _checkerConfiguration.TimelineKGram,
+                _checkerConfiguration.TimelinePayload);
 
             // Observes which scenario (coverage) monitors are satisfied this iteration.
             ScenarioComplianceObserver scenarioObserver = new ScenarioComplianceObserver();

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -525,6 +525,9 @@ namespace PChecker.SystematicTesting
 
             TimelineObserver timelineObserver = new TimelineObserver();
 
+            // Observes which scenario (coverage) monitors are satisfied this iteration.
+            ScenarioComplianceObserver scenarioObserver = new ScenarioComplianceObserver();
+
             // Logger used to intercept the program output if no custom logger
             // is installed and if verbosity is turned off.
             InMemoryLogger runtimeLogger = null;
@@ -539,6 +542,7 @@ namespace PChecker.SystematicTesting
                 runtime = new ControlledRuntime(_checkerConfiguration, Strategy);
 
                 runtime.RegisterLog(timelineObserver);
+                runtime.RegisterLog(scenarioObserver);
                 RegisterObservers(runtime);
 
 
@@ -595,6 +599,22 @@ namespace PChecker.SystematicTesting
                 runtime.LogWriter.LogCompletion();
 
                 GatherTestingStatistics(runtime, timelineObserver);
+
+                // Record scenario coverage: track every declared scenario (so uncovered
+                // ones are reported too), then count any satisfied this iteration, keyed
+                // by this schedule's abstract timeline.
+                foreach (var scenario in scenarioObserver.AllScenarioNames)
+                {
+                    TestReport.EnsureScenarioTracked(scenario);
+                }
+                if (scenarioObserver.SatisfiedScenarios.Count > 0)
+                {
+                    var scenarioTimeline = timelineObserver.GetAbstractTimeline();
+                    foreach (var scenario in scenarioObserver.SatisfiedScenarios)
+                    {
+                        TestReport.RecordScenarioSatisfied(scenario, scenarioTimeline);
+                    }
+                }
 
                 if (!IsReplayModeEnabled && TestReport.NumOfFoundBugs > 0)
                 {

--- a/Src/PChecker/CheckerCore/Testing/TestingProcess.cs
+++ b/Src/PChecker/CheckerCore/Testing/TestingProcess.cs
@@ -209,6 +209,17 @@ namespace PChecker.Testing
             var pintPath = directory + file + "_pchecker_summary.txt";
             Console.WriteLine($"..... Writing {pintPath}");
             File.WriteAllText(pintPath, testReport.GetSummaryText(Profiler));
+
+            // Emit a machine-readable per-test-case scenario-coverage artifact so coverage
+            // can be aggregated across the suite (ScenarioCoverageMerger.MergeDirectory).
+            if (testReport.ScenarioTriggerCounts.Count > 0)
+            {
+                var testCase = _checkerConfiguration.TestCaseName;
+                var suffix = string.IsNullOrEmpty(testCase) ? "" : "_" + testCase;
+                var scenarioPath = directory + file + suffix + ScenarioCoverageMerger.FileSuffix;
+                Console.WriteLine($"..... Writing {scenarioPath}");
+                ScenarioCoverageMerger.Write(testReport, testCase, scenarioPath);
+            }
             
             Console.WriteLine($"... Elapsed {Profiler.GetElapsedTime()} sec.");
 

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -486,9 +486,17 @@ namespace Plang.Compiler.Backend.CSharp
                 }
             }
 
+            context.WriteLine(output, "PModule.coverageMonitors.Clear();");
             foreach (var monitor in monitorMap.Keys)
             {
                 context.WriteLine(output, $"runtime.RegisterMonitor<{context.Names.GetNameForDecl(monitor)}>();");
+                // Scenario monitors are coverage monitors: register them so the runtime
+                // counts their satisfaction and exempts them from the liveness check.
+                if (monitor.IsScenario)
+                {
+                    context.WriteLine(output,
+                        $"PModule.coverageMonitors.Add(typeof({context.Names.GetNameForDecl(monitor)}));");
+                }
             }
 
             context.WriteLine(output, "}");

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -522,9 +522,11 @@ namespace Plang.Compiler.Backend.CSharp
             context.WriteLine(output, "PModule.scenarioStateCounts.Clear();");
             foreach (var monitor in monitorMap.Keys)
             {
-                context.WriteLine(output, $"runtime.RegisterMonitor<{context.Names.GetNameForDecl(monitor)}>();");
-                // Scenario monitors are coverage monitors: register them so the runtime
-                // counts their satisfaction and exempts them from the liveness check.
+                // Scenario monitors are coverage monitors: register their coverage metadata so
+                // the runtime counts their satisfaction and exempts them from the liveness check.
+                // This must happen BEFORE RegisterMonitor, because the monitor's initial (start)
+                // state-entry transition is logged during RegisterMonitor — the coverage observer
+                // can only classify it if PModule.coverageMonitors already contains the type.
                 if (monitor.IsScenario)
                 {
                     var monitorName = context.Names.GetNameForDecl(monitor);
@@ -533,6 +535,7 @@ namespace Plang.Compiler.Backend.CSharp
                     context.WriteLine(output,
                         $"PModule.scenarioStateCounts[typeof({monitorName})] = {monitor.AllStates().Count()};");
                 }
+                context.WriteLine(output, $"runtime.RegisterMonitor<{context.Names.GetNameForDecl(monitor)}>();");
             }
 
             context.WriteLine(output, "}");

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -519,6 +519,7 @@ namespace Plang.Compiler.Backend.CSharp
             }
 
             context.WriteLine(output, "PModule.coverageMonitors.Clear();");
+            context.WriteLine(output, "PModule.scenarioStateCounts.Clear();");
             foreach (var monitor in monitorMap.Keys)
             {
                 context.WriteLine(output, $"runtime.RegisterMonitor<{context.Names.GetNameForDecl(monitor)}>();");
@@ -526,8 +527,11 @@ namespace Plang.Compiler.Backend.CSharp
                 // counts their satisfaction and exempts them from the liveness check.
                 if (monitor.IsScenario)
                 {
+                    var monitorName = context.Names.GetNameForDecl(monitor);
+                    context.WriteLine(output, $"PModule.coverageMonitors.Add(typeof({monitorName}));");
+                    // Total state count enables partial-coverage reporting (states reached / total).
                     context.WriteLine(output,
-                        $"PModule.coverageMonitors.Add(typeof({context.Names.GetNameForDecl(monitor)}));");
+                        $"PModule.scenarioStateCounts[typeof({monitorName})] = {monitor.AllStates().Count()};");
                 }
             }
 

--- a/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
+++ b/Src/PCompiler/CompilerCore/Backend/PChecker/PCheckerCodeGenerator.cs
@@ -27,6 +27,11 @@ namespace Plang.Compiler.Backend.CSharp
         [ThreadStatic]
         private static List<Variable> _globalParams;
 
+        // Scenario (coverage) monitors are auto-attached to every test/impl, so they
+        // are collected once here and merged into each test's monitor map.
+        [ThreadStatic]
+        private static List<Machine> _scenarioMonitors;
+
         private string GetGlobalParamAndLocalVariableName(CompilationContext context, Variable v)
         {
             return _globalParams.Contains(v) ? $"({ICodeGenerator.GlobalConfigName}.{v.Name})" : context.Names.GetNameForDecl(v);
@@ -100,6 +105,7 @@ namespace Plang.Compiler.Backend.CSharp
             WriteSourcePrologue(context, source.Stream);
 
             _globalParams = globalScope.GetGlobalVariables();
+            _scenarioMonitors = globalScope.Machines.Where(m => m.IsScenario).ToList();
 
             DeclareGlobalParams(context, source.Stream);
             
@@ -356,8 +362,9 @@ namespace Plang.Compiler.Backend.CSharp
             WriteInitializeGlobalParams(context, output, assignment);
             WriteInitializeLinkMap(context, output, safety.ModExpr.ModuleInfo.LinkMap);
             WriteInitializeInterfaceDefMap(context, output, safety.ModExpr.ModuleInfo.InterfaceDef);
-            WriteInitializeMonitorObserves(context, output, safety.ModExpr.ModuleInfo.MonitorMap.Keys);
-            WriteInitializeMonitorMap(context, output, safety.ModExpr.ModuleInfo.MonitorMap);
+            var safetyMonitorMap = MonitorMapWithScenarios(safety.ModExpr.ModuleInfo.MonitorMap, safety.ModExpr.ModuleInfo.InterfaceDef);
+            WriteInitializeMonitorObserves(context, output, safetyMonitorMap.Keys);
+            WriteInitializeMonitorMap(context, output, safetyMonitorMap);
             WriteTestFunction(context, output, safety.Main, true);
             context.WriteLine(output, "}");
 
@@ -371,12 +378,37 @@ namespace Plang.Compiler.Backend.CSharp
             context.WriteLine(output, $"public class {context.Names.GetNameForDecl(impl)} {{");
             WriteInitializeLinkMap(context, output, impl.ModExpr.ModuleInfo.LinkMap);
             WriteInitializeInterfaceDefMap(context, output, impl.ModExpr.ModuleInfo.InterfaceDef);
-            WriteInitializeMonitorObserves(context, output, impl.ModExpr.ModuleInfo.MonitorMap.Keys);
-            WriteInitializeMonitorMap(context, output, impl.ModExpr.ModuleInfo.MonitorMap);
+            var implMonitorMap = MonitorMapWithScenarios(impl.ModExpr.ModuleInfo.MonitorMap, impl.ModExpr.ModuleInfo.InterfaceDef);
+            WriteInitializeMonitorObserves(context, output, implMonitorMap.Keys);
+            WriteInitializeMonitorMap(context, output, implMonitorMap);
             WriteTestFunction(context, output, impl.Main, false);
             context.WriteLine(output, "}");
 
             WriteNameSpaceEpilogue(context, output);
+        }
+
+        /// <summary>
+        /// Auto-attaches scenario (coverage) monitors to a test/impl: every scenario is
+        /// added to the monitor map (observing all machines in the module) in addition to
+        /// any explicitly-asserted spec monitors. Scenarios need no `assert`.
+        /// </summary>
+        private static IDictionary<Machine, IEnumerable<Interface>> MonitorMapWithScenarios(
+            IDictionary<Machine, IEnumerable<Interface>> monitorMap,
+            IDictionary<Interface, Machine> interfaceDef)
+        {
+            var map = new Dictionary<Machine, IEnumerable<Interface>>(monitorMap);
+            if (_scenarioMonitors != null && interfaceDef.Count > 0)
+            {
+                var allInterfaces = interfaceDef.Keys.ToList();
+                foreach (var scenario in _scenarioMonitors)
+                {
+                    if (!map.ContainsKey(scenario))
+                    {
+                        map[scenario] = allInterfaces;
+                    }
+                }
+            }
+            return map;
         }
 
         private void WriteInitializeMonitorObserves(CompilationContext context, StringWriter output,

--- a/Src/PCompiler/CompilerCore/Parser/PLexer.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PLexer.g4
@@ -49,6 +49,7 @@ PRINT     : 'print' ;
 RAISE     : 'raise' ;
 RECEIVE   : 'receive' ;
 RETURN    : 'return' ;
+SCENARIO  : 'scenario' ;
 SEND      : 'send' ;
 SIZEOF    : 'sizeof' ;
 SPEC      : 'spec' ;

--- a/Src/PCompiler/CompilerCore/Parser/PParser.g4
+++ b/Src/PCompiler/CompilerCore/Parser/PParser.g4
@@ -56,6 +56,7 @@ topDecl : typeDefDecl
         | interfaceDecl
         | implMachineDecl
         | specMachineDecl
+        | scenarioMachineDecl
         | funDecl
         | pureDecl
         | namedModuleDecl
@@ -107,6 +108,12 @@ receivesSends : RECEIVES eventSetLiteral? SEMI # MachineReceive
               ;
 
 specMachineDecl : SPEC name=iden OBSERVES eventSetLiteral machineBody ;
+
+// A scenario is a coverage monitor: it observes events and walks a state
+// machine whose accepting (cold) state marks the scenario satisfied. It reuses
+// the spec-machine machinery but is counted for scenario coverage and is exempt
+// from the liveness-violation check when left unsatisfied.
+scenarioMachineDecl : SCENARIO name=iden OBSERVES eventSetLiteral machineBody ;
 
 machineBody : LBRACE machineEntry* RBRACE;
 machineEntry : varDecl

--- a/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/Machine.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/AST/Declarations/Machine.cs
@@ -16,13 +16,25 @@ namespace Plang.Compiler.TypeChecker.AST.Declarations
 
         public Machine(string name, ParserRuleContext sourceNode)
         {
-            Debug.Assert(sourceNode is PParser.ImplMachineDeclContext || sourceNode is PParser.SpecMachineDeclContext);
+            Debug.Assert(sourceNode is PParser.ImplMachineDeclContext
+                         || sourceNode is PParser.SpecMachineDeclContext
+                         || sourceNode is PParser.ScenarioMachineDeclContext);
             Name = name;
             SourceLocation = sourceNode;
-            IsSpec = sourceNode is PParser.SpecMachineDeclContext;
+            // A scenario is a coverage monitor: it reuses all spec-machine machinery
+            // (IsSpec == true) but is additionally flagged as a scenario so it is
+            // counted for scenario coverage and exempt from the liveness check.
+            IsScenario = sourceNode is PParser.ScenarioMachineDeclContext;
+            IsSpec = sourceNode is PParser.SpecMachineDeclContext || IsScenario;
         }
 
         public bool IsSpec { get; }
+
+        /// <summary>
+        /// True if this monitor was declared with the <c>scenario</c> keyword: it is a
+        /// coverage monitor whose accepting (cold) state marks a scenario satisfied.
+        /// </summary>
+        public bool IsScenario { get; }
         public uint? Assume { get; set; }
         public uint? Assert { get; set; }
         public IEventSet Receives { get; set; }

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationStubVisitor.cs
@@ -223,6 +223,14 @@ namespace Plang.Compiler.TypeChecker
             return VisitChildrenWithNewScope(decl, context);
         }
 
+        public override object VisitScenarioMachineDecl(PParser.ScenarioMachineDeclContext context)
+        {
+            var symbolName = context.name.GetText();
+            var decl = CurrentScope.Put(symbolName, context);
+            nodesToDeclarations.Put(context, decl);
+            return VisitChildrenWithNewScope(decl, context);
+        }
+
         public override object VisitVarDecl(PParser.VarDeclContext context)
         {
             foreach (var varName in context.idenList()._names)

--- a/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/DeclarationVisitor.cs
@@ -371,7 +371,30 @@ namespace Plang.Compiler.TypeChecker
 
             return specMachine;
         }
-        
+
+        public override object VisitScenarioMachineDecl(PParser.ScenarioMachineDeclContext context)
+        {
+            // SCENARIO name=Iden — a coverage monitor; identical shape to a spec machine.
+            var scenarioMachine = (Machine) nodesToDeclarations.Get(context);
+
+            // scenario (coverage) machines neither send nor receive events.
+            scenarioMachine.Receives = new EventSet();
+            scenarioMachine.Sends = new EventSet();
+
+            // OBSERVES eventSetLiteral
+            scenarioMachine.Observes = new EventSet();
+            foreach (var pEvent in (Event[]) Visit(context.eventSetLiteral())) scenarioMachine.Observes.AddEvent(pEvent);
+
+            // machineBody
+            using (currentScope.NewContext(scenarioMachine.Scope))
+            using (currentMachine.NewContext(scenarioMachine))
+            {
+                Visit(context.machineBody());
+            }
+
+            return scenarioMachine;
+        }
+
         public override object VisitMachineBody(PParser.MachineBodyContext context)
         {
             foreach (var machineEntryContext in context.machineEntry())

--- a/Src/PCompiler/CompilerCore/TypeChecker/MachineChecker.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/MachineChecker.cs
@@ -21,6 +21,21 @@ namespace Plang.Compiler.TypeChecker
             // special validation for monitors:
             // ensure that each event handler is in the observe set.
             ValidateSpecObservesList(handler, machine, job);
+            // a scenario (coverage monitor) needs an accepting (cold) state, otherwise
+            // it can never be marked satisfied and will always report 0 coverage.
+            ValidateScenarioHasColdState(machine, job);
+        }
+
+        private static void ValidateScenarioHasColdState(Machine machine, ICompilerConfiguration job)
+        {
+            if (machine.IsScenario &&
+                machine.AllStates().All(s => s.Temperature != StateTemperature.Cold))
+            {
+                job.Output.WriteWarning(
+                    $"[{machine.SourceLocation.Start.Line}] scenario '{machine.Name}' has no accepting (cold) state; " +
+                    "it can never be marked satisfied and will always report 0 coverage. " +
+                    "Mark its accepting state 'cold'.");
+            }
         }
 
         private static void InitializeContructorType(ITranslationErrorHandler handler, Machine machine, Scope gScope)

--- a/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
+++ b/Src/PCompiler/CompilerCore/TypeChecker/Scope.cs
@@ -496,6 +496,21 @@ namespace Plang.Compiler.TypeChecker
             return specMachine;
         }
 
+        public Machine Put(string name, PParser.ScenarioMachineDeclContext tree)
+        {
+            // A scenario is a coverage monitor: registered like a spec machine
+            // (no corresponding interface), with IsScenario set on the Machine.
+            var scenarioMachine = new Machine(name, tree);
+            CheckConflicts(
+                scenarioMachine,
+                Namespace(machines),
+                Namespace(interfaces),
+                Namespace(enums),
+                Namespace(typedefs));
+            machines.Add(name, scenarioMachine);
+            return scenarioMachine;
+        }
+
         public Function Put(string name, PParser.FunDeclContext tree)
         {
             var function = new Function(name, tree);

--- a/Src/PCompiler/PCommandLine/CommandLine.cs
+++ b/Src/PCompiler/PCommandLine/CommandLine.cs
@@ -42,6 +42,9 @@ namespace Plang
                 case "check":
                     RunChecker(args.Skip(1).ToArray());
                     break;
+                case "merge-scenario-coverage":
+                    RunScenarioCoverageMerge(args.Skip(1).ToArray());
+                    break;
                 case   "version":
                 case  "-v":
                 case  "-version":
@@ -80,6 +83,22 @@ namespace Plang
             // Parses the command line options to get the checkerConfiguration.
             var configuration = new PCheckerOptions().Parse(args);
             Checker.Run(configuration);
+        }
+
+        /// <summary>
+        /// Merges the per-run scenario-coverage artifacts under a directory (recursively)
+        /// into one unified, suite-wide scenario-coverage report.
+        /// Usage: p merge-scenario-coverage [directory]  (defaults to the current directory)
+        /// </summary>
+        private static void RunScenarioCoverageMerge(string[] args)
+        {
+            var directory = args.Length > 0 ? args[0] : Directory.GetCurrentDirectory();
+            if (!Directory.Exists(directory))
+            {
+                CommandLineOutput.WriteError($"Directory not found: {directory}");
+                return;
+            }
+            Console.Write(PChecker.SystematicTesting.ScenarioCoverageMerger.MergeDirectory(directory));
         }
 
         /// <summary>

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -79,7 +79,7 @@ namespace Plang.Options
             schedulingGroup.AddArgument("sch-random", null, "Choose the random scheduling strategy (this is the default)", typeof(bool));
             schedulingGroup.AddArgument("sch-feedback", null, "Choose the random scheduling strategy with feedback mutation", typeof(bool));
 
-            schedulingGroup.AddArgument("sch-feedbackpct", null, "Choose the PCT scheduling strategy with feedback mutation", typeof(uint));
+            schedulingGroup.AddArgument("sch-feedbackpct", null, "Choose the PCT scheduling strategy with feedback mutation (recommended feedback strategy: best rare-behavior coverage; takes the max number of priority switch points, e.g. --sch-feedbackpct 10)", typeof(uint));
             schedulingGroup.AddArgument("sch-feedbackpos", null,
                 "Choose the POS scheduling strategy with feedback mutation", typeof(bool));
 

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -93,6 +93,11 @@ namespace Plang.Options
             var schPEx = schedulingGroup.AddArgument("sch-pex", null, "Choose the scheduling strategy for PEx mode (options: random, dfs). (default: random)");
             schPEx.AllowedValues = new List<string>() { "random", "dfs", "astar" };
 
+            var timelineRepr = schedulingGroup.AddArgument("timeline-repr", null, "How the feedback-guided search represents a schedule's timeline (the diversity signal): pairwise (default), kgram, causal, hybrid");
+            timelineRepr.AllowedValues = new List<string>() { "pairwise", "kgram", "causal", "hybrid" };
+            schedulingGroup.AddArgument("timeline-kgram", null, "Gram length for the kgram/hybrid timeline representation (default: 3)", typeof(uint));
+            schedulingGroup.AddArgument("timeline-payload", null, "Enrich timeline event labels with a stable hash of the event payload", typeof(bool));
+
             var replayOptions = Parser.GetOrCreateGroup("replay", "Replay and debug options");
             replayOptions.AddArgument("replay", "r", "Schedule file to replay");
 
@@ -235,6 +240,15 @@ namespace Plang.Options
                     break;
                 case "sch-pex":
                     checkerConfiguration.SchedulingStrategy = (string)option.Value;
+                    break;
+                case "timeline-repr":
+                    checkerConfiguration.TimelineRepresentation = (string)option.Value;
+                    break;
+                case "timeline-kgram":
+                    checkerConfiguration.TimelineKGram = (int)(uint)option.Value;
+                    break;
+                case "timeline-payload":
+                    checkerConfiguration.TimelinePayload = true;
                     break;
                 case "replay":
                 {

--- a/Tst/RegressionTests/Feature1SMLevelDecls/Correct/ScenarioCoverageBasic/ScenarioCoverageBasic.p
+++ b/Tst/RegressionTests/Feature1SMLevelDecls/Correct/ScenarioCoverageBasic/ScenarioCoverageBasic.p
@@ -1,0 +1,47 @@
+// Regression: `scenario` (coverage) monitors.
+//  - Scenarios are auto-attached to the test (no `assert` needed).
+//  - A satisfied scenario reaches its accepting (cold) state.
+//  - An UNSATISFIED scenario left in a hot state must NOT cause a liveness
+//    failure (coverage monitors are exempt) — the run must still exit cleanly.
+
+event eWriteReq: int;
+event eReadReq: int;
+event eNever: int;
+
+machine Main {
+  var server: Server;
+  start state Init {
+    entry {
+      server = new Server();
+      send server, eWriteReq, 1;
+      send server, eReadReq, 1;
+    }
+  }
+}
+
+machine Server {
+  start state Serving {
+    on eWriteReq do (key: int) { }
+    on eReadReq do (key: int) { }
+  }
+}
+
+// Satisfied on every schedule: a write followed by a read.
+scenario ReadAfterWrite observes eWriteReq, eReadReq {
+  start hot state WaitWrite {
+    on eWriteReq goto WaitRead;
+  }
+  hot state WaitRead {
+    on eReadReq goto Satisfied;
+  }
+  cold state Satisfied { }
+}
+
+// Never satisfied (observes an event that is never sent). Must not fail the
+// test even though it ends in a hot state.
+scenario NeverCovered observes eNever {
+  start hot state Waiting {
+    on eNever goto Done;
+  }
+  cold state Done { }
+}

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using NUnit.Framework;
 using PChecker;
 using PChecker.SystematicTesting;
@@ -139,6 +141,36 @@ namespace UnitTests
             StringAssert.Contains("S: covered in 2/2 test cases, 8 total triggers, 3 unique satisfying timelines", text);
             // Gap: never satisfied anywhere; best partial progress is the max across test cases.
             StringAssert.Contains("Gap: covered in 0/2 test cases, 0 total triggers, 0 unique satisfying timelines (best partial progress: 2/4 states)", text);
+        }
+
+        [NUnit.Framework.Test]
+        public void MergeDirectory_ReadsArtifactsRecursivelyFromSubdirectories()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "scencov_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(root, "run1"));
+            Directory.CreateDirectory(Path.Combine(root, "run2"));
+            try
+            {
+                var r1 = NewReport();
+                r1.RecordScenarioSatisfied("S", "<t1>");
+                ScenarioCoverageMerger.Write(r1, "tc1", Path.Combine(root, "run1", "a" + ScenarioCoverageMerger.FileSuffix));
+
+                var r2 = NewReport();
+                r2.RecordScenarioSatisfied("S", "<t2>");
+                r2.EnsureScenarioTracked("Gap");
+                r2.RecordScenarioProgress("Gap", 1, 3);
+                ScenarioCoverageMerger.Write(r2, "tc2", Path.Combine(root, "run2", "b" + ScenarioCoverageMerger.FileSuffix));
+
+                var text = ScenarioCoverageMerger.MergeDirectory(root);
+
+                StringAssert.Contains("across 2 test case(s)", text);
+                StringAssert.Contains("S: covered in 2/2 test cases, 2 total triggers, 2 unique satisfying timelines", text);
+                StringAssert.Contains("Gap: covered in 0/1 test cases", text);
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
         }
     }
 }

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -77,11 +77,31 @@ namespace UnitTests
 
             var text = report.GetText(CheckerConfiguration.Create());
 
-            StringAssert.Contains("Scenario coverage:", text);
-            StringAssert.Contains("ReadAfterWrite", text);
-            StringAssert.Contains("NeverCovered", text);
-            StringAssert.Contains("triggered in 1 schedule,", text);
-            StringAssert.Contains("triggered in 0 schedules,", text);
+            // Summary line leads with the covered count and flags gaps.
+            StringAssert.Contains("Scenario coverage: 1/2 scenarios covered (1 gap)", text);
+            // Covered scenario is marked and shows its trigger/timeline counts.
+            StringAssert.Contains("[covered] ReadAfterWrite: triggered in 1 schedule, 1 unique satisfying timeline", text);
+            // The uncovered scenario is called out as a gap, not buried in a "0 schedules" line.
+            StringAssert.Contains("[  GAP  ] NeverCovered: not covered", text);
+        }
+
+        [NUnit.Framework.Test]
+        public void GetText_SummaryCountsAndGroupsCoveredBeforeGaps()
+        {
+            var report = NewReport();
+            report.RecordScenarioSatisfied("Alpha", "<t1>");
+            report.RecordScenarioSatisfied("Beta", "<t2>");
+            report.EnsureScenarioTracked("Zeta");   // a gap
+            report.RecordScenarioProgress("Zeta", 1, 2);
+
+            var text = report.GetText(CheckerConfiguration.Create());
+
+            StringAssert.Contains("Scenario coverage: 2/3 scenarios covered (1 gap)", text);
+            StringAssert.Contains("[covered] Alpha", text);
+            StringAssert.Contains("[covered] Beta", text);
+            StringAssert.Contains("[  GAP  ] Zeta: not covered (best partial progress: 1/2 states)", text);
+            // Covered scenarios are listed before the gaps so gaps stand out at the end.
+            Assert.Less(text.IndexOf("[covered] Beta"), text.IndexOf("[  GAP  ] Zeta"));
         }
 
         [NUnit.Framework.Test]
@@ -138,11 +158,13 @@ namespace UnitTests
 
             var text = ScenarioCoverageMerger.Merge(new[] { tc1, tc2 });
 
-            StringAssert.Contains("across 2 test case(s)", text);
-            // S: 5+3 triggers, 2+1 unique timelines, covered in both.
-            StringAssert.Contains("S: covered in 2/2 test cases, 8 total triggers, 3 unique satisfying timelines", text);
-            // Gap: never satisfied anywhere; best partial progress is the max across test cases.
-            StringAssert.Contains("Gap: covered in 0/2 test cases, 0 total triggers, 0 unique satisfying timelines (best partial progress: 2/4 states)", text);
+            StringAssert.Contains("across 2 test cases", text);
+            // Summary: 1 of 2 scenarios covered, 1 gap.
+            StringAssert.Contains("1/2 scenarios covered in >=1 test case; 1 coverage gap.", text);
+            // S: covered in both, lists which test cases; 5+3 triggers, 2+1 timelines.
+            StringAssert.Contains("[covered] S: covered in 2/2 test cases (tc1, tc2); 8 total triggers, 3 unique satisfying timelines", text);
+            // Gap: never satisfied anywhere; best progress is the max across test cases.
+            StringAssert.Contains("[  GAP  ] Gap: never covered in any of 2 test cases; best progress anywhere 2/4 states", text);
         }
 
         [NUnit.Framework.Test]
@@ -165,9 +187,15 @@ namespace UnitTests
 
                 var text = ScenarioCoverageMerger.MergeDirectory(root);
 
-                StringAssert.Contains("across 2 test case(s)", text);
-                StringAssert.Contains("S: covered in 2/2 test cases, 2 total triggers, 2 unique satisfying timelines", text);
-                StringAssert.Contains("Gap: covered in 0/1 test cases", text);
+                StringAssert.Contains("across 2 test cases", text);
+                // S covered in both; assert counts + that both test cases are listed (file
+                // enumeration order is filesystem-dependent, so don't pin the order).
+                StringAssert.Contains("[covered] S: covered in 2/2 test cases", text);
+                StringAssert.Contains("2 total triggers, 2 unique satisfying timelines", text);
+                StringAssert.Contains("tc1", text);
+                StringAssert.Contains("tc2", text);
+                // Gap seen in only one test case, never covered.
+                StringAssert.Contains("[  GAP  ] Gap: never covered in any of 1 test case", text);
             }
             finally
             {

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -79,5 +79,35 @@ namespace UnitTests
             StringAssert.Contains("triggered in 1 schedule,", text);
             StringAssert.Contains("triggered in 0 schedules,", text);
         }
+
+        [NUnit.Framework.Test]
+        public void RecordScenarioProgress_KeepsBestAndReportsPartialForUncovered()
+        {
+            var report = NewReport();
+            report.EnsureScenarioTracked("NeverCovered");
+            report.RecordScenarioProgress("NeverCovered", 1, 3);
+            report.RecordScenarioProgress("NeverCovered", 2, 3); // better
+            report.RecordScenarioProgress("NeverCovered", 1, 3); // worse, ignored
+
+            Assert.AreEqual(2, report.ScenarioMaxStatesReached["NeverCovered"]);
+            Assert.AreEqual(3, report.ScenarioTotalStates["NeverCovered"]);
+
+            var text = report.GetText(CheckerConfiguration.Create());
+            StringAssert.Contains("best partial progress: 2/3 states", text);
+        }
+
+        [NUnit.Framework.Test]
+        public void Merge_TakesMaxPartialProgress()
+        {
+            var a = NewReport();
+            a.RecordScenarioProgress("S", 1, 4);
+            var b = NewReport();
+            b.RecordScenarioProgress("S", 3, 4);
+
+            a.Merge(b);
+
+            Assert.AreEqual(3, a.ScenarioMaxStatesReached["S"]);
+            Assert.AreEqual(4, a.ScenarioTotalStates["S"]);
+        }
     }
 }

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -109,5 +109,36 @@ namespace UnitTests
             Assert.AreEqual(3, a.ScenarioMaxStatesReached["S"]);
             Assert.AreEqual(4, a.ScenarioTotalStates["S"]);
         }
+
+        [NUnit.Framework.Test]
+        public void ScenarioMerger_AggregatesAcrossTestCases()
+        {
+            var tc1 = new ScenarioCoverageArtifact
+            {
+                TestCase = "tc1",
+                Scenarios = new()
+                {
+                    new ScenarioCoverageEntry { Name = "S", Triggered = 5, UniqueTimelines = 2, MaxStatesReached = 3, TotalStates = 3 },
+                    new ScenarioCoverageEntry { Name = "Gap", Triggered = 0, UniqueTimelines = 0, MaxStatesReached = 1, TotalStates = 4 },
+                }
+            };
+            var tc2 = new ScenarioCoverageArtifact
+            {
+                TestCase = "tc2",
+                Scenarios = new()
+                {
+                    new ScenarioCoverageEntry { Name = "S", Triggered = 3, UniqueTimelines = 1, MaxStatesReached = 3, TotalStates = 3 },
+                    new ScenarioCoverageEntry { Name = "Gap", Triggered = 0, UniqueTimelines = 0, MaxStatesReached = 2, TotalStates = 4 },
+                }
+            };
+
+            var text = ScenarioCoverageMerger.Merge(new[] { tc1, tc2 });
+
+            StringAssert.Contains("across 2 test case(s)", text);
+            // S: 5+3 triggers, 2+1 unique timelines, covered in both.
+            StringAssert.Contains("S: covered in 2/2 test cases, 8 total triggers, 3 unique satisfying timelines", text);
+            // Gap: never satisfied anywhere; best partial progress is the max across test cases.
+            StringAssert.Contains("Gap: covered in 0/2 test cases, 0 total triggers, 0 unique satisfying timelines (best partial progress: 2/4 states)", text);
+        }
     }
 }

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using PChecker;
+using PChecker.Feedback;
 using PChecker.SystematicTesting;
 
 namespace UnitTests
@@ -171,6 +173,74 @@ namespace UnitTests
             {
                 Directory.Delete(root, true);
             }
+        }
+
+        // ── Coverage-novelty steering signal (ScenarioSteering.NoveltyCompliance) ──
+
+        private static double Novelty(
+            Dictionary<string, int> reached, IReadOnlyCollection<string> satisfied,
+            Dictionary<string, int> suiteBest, HashSet<string> suiteSatisfied)
+            => ScenarioSteering.NoveltyCompliance(reached, satisfied, suiteBest, suiteSatisfied);
+
+        [NUnit.Framework.Test]
+        public void Novelty_NoScenarios_IsZero()
+        {
+            var best = new Dictionary<string, int>();
+            var sat = new HashSet<string>();
+            Assert.AreEqual(0.0, Novelty(new(), Array.Empty<string>(), best, sat));
+        }
+
+        [NUnit.Framework.Test]
+        public void Novelty_FirstSatisfactionScoresOnce_ThenZero()
+        {
+            var best = new Dictionary<string, int>();
+            var sat = new HashSet<string>();
+
+            // First run to satisfy "S" is novel.
+            Assert.AreEqual(1.0, Novelty(new() { ["S"] = 3 }, new[] { "S" }, best, sat));
+            Assert.IsTrue(sat.Contains("S"));
+            // A later run that satisfies the same "S" again earns nothing.
+            Assert.AreEqual(0.0, Novelty(new() { ["S"] = 3 }, new[] { "S" }, best, sat));
+        }
+
+        [NUnit.Framework.Test]
+        public void Novelty_AdvancingPartialProgressScores_PlateauDoesNot()
+        {
+            var best = new Dictionary<string, int>();
+            var sat = new HashSet<string>();
+
+            Assert.AreEqual(1.0, Novelty(new() { ["Rare"] = 1 }, Array.Empty<string>(), best, sat)); // 0 -> 1
+            Assert.AreEqual(1.0, Novelty(new() { ["Rare"] = 2 }, Array.Empty<string>(), best, sat)); // 1 -> 2
+            Assert.AreEqual(0.0, Novelty(new() { ["Rare"] = 2 }, Array.Empty<string>(), best, sat)); // 2 -> 2 (no gain)
+            Assert.AreEqual(0.0, Novelty(new() { ["Rare"] = 1 }, Array.Empty<string>(), best, sat)); // regress: no gain
+            Assert.AreEqual(2, best["Rare"]);
+        }
+
+        [NUnit.Framework.Test]
+        public void Novelty_ImpossibleScenarioBoostsOnceThenSaturatesToZero()
+        {
+            // The bug this fix addresses: a scenario stuck at a constant partial progress
+            // must NOT keep contributing a constant signal. It scores once (reaching its
+            // ceiling) then never again — so the signal cannot saturate the priority.
+            var best = new Dictionary<string, int>();
+            var sat = new HashSet<string>();
+
+            Assert.AreEqual(1.0, Novelty(new() { ["Impossible"] = 2 }, Array.Empty<string>(), best, sat));
+            for (var i = 0; i < 5; i++)
+            {
+                Assert.AreEqual(0.0, Novelty(new() { ["Impossible"] = 2 }, Array.Empty<string>(), best, sat));
+            }
+        }
+
+        [NUnit.Framework.Test]
+        public void Novelty_ProgressOnAlreadySatisfiedScenarioIsIgnored()
+        {
+            var best = new Dictionary<string, int>();
+            var sat = new HashSet<string> { "S" };   // already satisfied earlier in the suite
+
+            // Even a brand-new furthest state for S earns nothing once S is covered.
+            Assert.AreEqual(0.0, Novelty(new() { ["S"] = 9 }, Array.Empty<string>(), best, sat));
+            Assert.IsFalse(best.ContainsKey("S"));
         }
     }
 }

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using PChecker;
+using PChecker.SystematicTesting;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Unit tests for scenario-coverage accounting in <see cref="TestReport"/>
+    /// (the aggregation + reporting side of the `scenario` feature). The end-to-end
+    /// compile-and-run path is covered by the RegressionTests/.../ScenarioCoverageBasic fixture.
+    /// </summary>
+    [TestFixture]
+    [TestOf(typeof(TestReport))]
+    public class ScenarioCoverageTest
+    {
+        private static TestReport NewReport()
+        {
+            return new TestReport(CheckerConfiguration.Create());
+        }
+
+        [NUnit.Framework.Test]
+        public void RecordScenarioSatisfied_CountsTriggersAndUniqueTimelines()
+        {
+            var report = NewReport();
+            report.RecordScenarioSatisfied("ReadAfterWrite", "<M, w, r>");
+            report.RecordScenarioSatisfied("ReadAfterWrite", "<M, w, r>");   // same timeline
+            report.RecordScenarioSatisfied("ReadAfterWrite", "<M, w, r, x>"); // distinct timeline
+
+            Assert.AreEqual(3, report.ScenarioTriggerCounts["ReadAfterWrite"]);
+            Assert.AreEqual(2, report.ScenarioSatisfyingTimelines["ReadAfterWrite"].Count);
+        }
+
+        [NUnit.Framework.Test]
+        public void EnsureScenarioTracked_SurfacesUncoveredScenariosWithZero()
+        {
+            var report = NewReport();
+            report.EnsureScenarioTracked("NeverCovered");
+
+            Assert.AreEqual(0, report.ScenarioTriggerCounts["NeverCovered"]);
+            Assert.AreEqual(0, report.ScenarioSatisfyingTimelines["NeverCovered"].Count);
+
+            // EnsureScenarioTracked must not clobber an already-recorded scenario.
+            report.RecordScenarioSatisfied("Covered", "<M, a, b>");
+            report.EnsureScenarioTracked("Covered");
+            Assert.AreEqual(1, report.ScenarioTriggerCounts["Covered"]);
+            Assert.AreEqual(1, report.ScenarioSatisfyingTimelines["Covered"].Count);
+        }
+
+        [NUnit.Framework.Test]
+        public void Merge_SumsCountsAndUnionsSatisfyingTimelines()
+        {
+            var a = NewReport();
+            a.RecordScenarioSatisfied("S", "<t1>");
+            a.EnsureScenarioTracked("Uncovered");
+
+            var b = NewReport();
+            b.RecordScenarioSatisfied("S", "<t1>"); // duplicate timeline across workers
+            b.RecordScenarioSatisfied("S", "<t2>");
+
+            a.Merge(b);
+
+            Assert.AreEqual(3, a.ScenarioTriggerCounts["S"]);                 // 1 + 2
+            Assert.AreEqual(2, a.ScenarioSatisfyingTimelines["S"].Count);     // {t1, t2}
+            Assert.AreEqual(0, a.ScenarioTriggerCounts["Uncovered"]);         // preserved
+        }
+
+        [NUnit.Framework.Test]
+        public void GetText_ReportsScenarioCoverageIncludingZeroCoverage()
+        {
+            var report = NewReport();
+            report.EnsureScenarioTracked("NeverCovered");
+            report.RecordScenarioSatisfied("ReadAfterWrite", "<M, w, r>");
+
+            var text = report.GetText(CheckerConfiguration.Create());
+
+            StringAssert.Contains("Scenario coverage:", text);
+            StringAssert.Contains("ReadAfterWrite", text);
+            StringAssert.Contains("NeverCovered", text);
+            StringAssert.Contains("triggered in 1 schedule,", text);
+            StringAssert.Contains("triggered in 0 schedules,", text);
+        }
+    }
+}

--- a/Tst/UnitTests/ScenarioCoverageTest.cs
+++ b/Tst/UnitTests/ScenarioCoverageTest.cs
@@ -270,5 +270,71 @@ namespace UnitTests
             Assert.AreEqual(0.0, Novelty(new() { ["S"] = 9 }, Array.Empty<string>(), best, sat));
             Assert.IsFalse(best.ContainsKey("S"));
         }
+
+        // ── Output-folder robustness: per-test-case folders + latest-only merge ──
+
+        [NUnit.Framework.Test]
+        public void SetOutputDirectory_GroupsOutputByTestCase()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "outdir_" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                var cfg = CheckerConfiguration.Create();
+                cfg.OutputPath = root;
+                cfg.AssemblyToBeAnalyzed = "/x/MyModel.dll";
+                cfg.TestCaseName = "tcFoo";
+                cfg.SetOutputDirectory();
+                // With a test case, the layout is <root>/tcFoo/<Mode>/.
+                StringAssert.Contains(Path.Combine("tcFoo", cfg.Mode.ToString()), cfg.OutputDirectory);
+
+                var anon = CheckerConfiguration.Create();
+                anon.OutputPath = root;
+                anon.AssemblyToBeAnalyzed = "/x/MyModel.dll";
+                anon.TestCaseName = "";  // no test case -> layout unchanged (no extra segment)
+                anon.SetOutputDirectory();
+                StringAssert.DoesNotContain(Path.Combine("tcFoo", anon.Mode.ToString()), anon.OutputDirectory);
+            }
+            finally
+            {
+                if (Directory.Exists(root)) Directory.Delete(root, true);
+            }
+        }
+
+        [NUnit.Framework.Test]
+        public void MergeDirectory_DedupesReRunsOfSameTestCaseKeepingLatest()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "scencov_dedup_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(root, "BugFinding"));   // latest run
+            Directory.CreateDirectory(Path.Combine(root, "BugFinding0"));  // rotated history
+            try
+            {
+                // Older run of test case "tc": S covered with 1 distinct timeline.
+                var older = NewReport();
+                older.RecordScenarioSatisfied("S", "<t1>");
+                var olderPath = Path.Combine(root, "BugFinding0", "A" + ScenarioCoverageMerger.FileSuffix);
+                ScenarioCoverageMerger.Write(older, "tc", olderPath);
+                File.SetLastWriteTimeUtc(olderPath, DateTime.UtcNow.AddMinutes(-10));
+
+                // Latest run of the SAME test case "tc": S covered with 3 distinct timelines.
+                var latest = NewReport();
+                latest.RecordScenarioSatisfied("S", "<t1>");
+                latest.RecordScenarioSatisfied("S", "<t2>");
+                latest.RecordScenarioSatisfied("S", "<t3>");
+                var latestPath = Path.Combine(root, "BugFinding", "A" + ScenarioCoverageMerger.FileSuffix);
+                ScenarioCoverageMerger.Write(latest, "tc", latestPath);
+                File.SetLastWriteTimeUtc(latestPath, DateTime.UtcNow);
+
+                var text = ScenarioCoverageMerger.MergeDirectory(root);
+
+                // Deduped to ONE test case (the latest run) — not double-counted as two.
+                StringAssert.Contains("across 1 test case", text);
+                StringAssert.Contains("covered in 1/1 test cases", text);
+                StringAssert.Contains("3 unique satisfying timelines", text);  // latest's count, not the older 1
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
     }
 }

--- a/Tst/UnitTests/TimelineRepresentationTest.cs
+++ b/Tst/UnitTests/TimelineRepresentationTest.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PChecker.Feedback;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Unit tests for the pluggable timeline representations that drive the feedback-guided
+    /// search's diversity signal (--timeline-repr). The vector-clock comparison itself is
+    /// trusted runtime code (VectorTime.CompareTo) and exercised end-to-end by the bake-off;
+    /// here we test the token-generation logic, which is where the encoding decisions live.
+    /// </summary>
+    [TestFixture]
+    public class TimelineRepresentationTest
+    {
+        private const char S = '\u001f';
+
+        private static ISet<string> Tokens(ITimelineRepresentation repr, string receiver, params string[] labels)
+        {
+            foreach (var label in labels)
+            {
+                repr.RecordDelivery(receiver, "sender", label, null);
+            }
+            return repr.Tokens().ToHashSet();
+        }
+
+        // ── Pairwise (the byte-compatible default) ──
+
+        [NUnit.Framework.Test]
+        public void Pairwise_RecordsOrderedTypePairsPerReceiver()
+        {
+            var repr = new PairwiseLocalRepresentation();
+            var tokens = Tokens(repr, "M", "A", "B", "A"); // A, then B, then A again
+
+            // After B: (A,B). After the 2nd A: (A,A) and (B,A). Tokens use the U+001F layout.
+            Assert.AreEqual(3, tokens.Count);
+            Assert.IsTrue(tokens.Contains($"M{S}A{S}B{S}"));
+            Assert.IsTrue(tokens.Contains($"M{S}A{S}A{S}"));
+            Assert.IsTrue(tokens.Contains($"M{S}B{S}A{S}"));
+        }
+
+        [NUnit.Framework.Test]
+        public void Pairwise_IsPerReceiverInstance()
+        {
+            // Same event order at two different receiver instances must not cross-contaminate.
+            var repr = new PairwiseLocalRepresentation();
+            repr.RecordDelivery("M1", "s", "A", null);
+            repr.RecordDelivery("M2", "s", "B", null); // different receiver: no (M1,A,B) pair
+            var tokens = repr.Tokens().ToHashSet();
+            Assert.AreEqual(0, tokens.Count); // each receiver saw only one event so far
+        }
+
+        [NUnit.Framework.Test]
+        public void Pairwise_Deterministic()
+        {
+            var a = Tokens(new PairwiseLocalRepresentation(), "M", "A", "B", "C");
+            var b = Tokens(new PairwiseLocalRepresentation(), "M", "A", "B", "C");
+            Assert.IsTrue(a.SetEquals(b));
+        }
+
+        // ── K-gram: strictly finer than pairwise where pairwise saturates ──
+
+        [NUnit.Framework.Test]
+        public void KGram_DistinguishesWherePairwiseSaturates()
+        {
+            // ABBA and BAAB have the SAME set of ordered event-type pairs, so pairwise
+            // conflates them. k-grams (contiguous order) tell them apart.
+            var pwAbba = Tokens(new PairwiseLocalRepresentation(), "M", "A", "B", "B", "A");
+            var pwBaab = Tokens(new PairwiseLocalRepresentation(), "M", "B", "A", "A", "B");
+            Assert.IsTrue(pwAbba.SetEquals(pwBaab), "precondition: pairwise saturates on ABBA vs BAAB");
+
+            var kgAbba = Tokens(new KGramRepresentation(2), "M", "A", "B", "B", "A");
+            var kgBaab = Tokens(new KGramRepresentation(2), "M", "B", "A", "A", "B");
+            Assert.IsFalse(kgAbba.SetEquals(kgBaab), "kgram must distinguish ABBA from BAAB");
+        }
+
+        [NUnit.Framework.Test]
+        public void KGram_EmitsGramsUpToLengthK()
+        {
+            var tokens = Tokens(new KGramRepresentation(2), "M", "A", "B");
+            // len-1: A, B ; len-2: A>B
+            Assert.IsTrue(tokens.Contains($"M{S}1{S}A"));
+            Assert.IsTrue(tokens.Contains($"M{S}1{S}B"));
+            Assert.IsTrue(tokens.Contains($"M{S}2{S}A>B"));
+            Assert.AreEqual(3, tokens.Count);
+        }
+
+        // ── Causal: the pure happens-before token decision ──
+
+        [NUnit.Framework.Test]
+        public void Causal_PairToken_OrdersByHappensBefore()
+        {
+            // cmp < 0: prior happens-before current  => hb prior -> current
+            Assert.AreEqual($"hb{S}A{S}B", CausalRepresentation.PairToken(-1, false, "A", "B"));
+            // cmp > 0: prior happens-after current    => hb current -> prior
+            Assert.AreEqual($"hb{S}B{S}A", CausalRepresentation.PairToken(1, false, "A", "B"));
+        }
+
+        [NUnit.Framework.Test]
+        public void Causal_PairToken_SameReceiverTieBreaksByProgramOrder()
+        {
+            // Equal/incomparable clocks at the same receiver => program order (prior first).
+            Assert.AreEqual($"hb{S}A{S}B", CausalRepresentation.PairToken(0, true, "A", "B"));
+        }
+
+        [NUnit.Framework.Test]
+        public void Causal_PairToken_DifferentReceiverConcurrentIsSymmetric()
+        {
+            // Incomparable clocks at different receivers => concurrent, canonicalized so the
+            // token is order-independent.
+            var t1 = CausalRepresentation.PairToken(0, false, "A", "B");
+            var t2 = CausalRepresentation.PairToken(0, false, "B", "A");
+            Assert.AreEqual(t1, t2);
+            Assert.AreEqual($"co{S}A{S}B", t1);
+        }
+
+        [NUnit.Framework.Test]
+        public void Causal_NullClocks_UseProgramOrderAndConcurrency()
+        {
+            // With no clocks (null), same-receiver deliveries are program-ordered and
+            // cross-receiver deliveries are concurrent.
+            var repr = new CausalRepresentation();
+            repr.RecordDelivery("M", "s", "A", null);
+            repr.RecordDelivery("M", "s", "B", null);   // same receiver => hb A -> B
+            repr.RecordDelivery("N", "s", "C", null);   // different receiver => concurrent with A, B
+            var tokens = repr.Tokens().ToHashSet();
+            Assert.IsTrue(tokens.Contains($"hb{S}A{S}B"));
+            Assert.IsTrue(tokens.Contains($"co{S}A{S}C"));
+            Assert.IsTrue(tokens.Contains($"co{S}B{S}C"));
+        }
+
+        // ── Hybrid: union of causal + kgram, prefixed ──
+
+        [NUnit.Framework.Test]
+        public void Hybrid_UnionsCausalAndKGramTokens()
+        {
+            var hybrid = Tokens(new HybridRepresentation(2), "M", "A", "B");
+            Assert.IsTrue(hybrid.Any(t => t.StartsWith("C" + S)), "should contain causal tokens");
+            Assert.IsTrue(hybrid.Any(t => t.StartsWith("K" + S)), "should contain kgram tokens");
+        }
+
+        // ── Factory + edge cases ──
+
+        [NUnit.Framework.Test]
+        public void Factory_SelectsRepresentation()
+        {
+            Assert.IsInstanceOf<PairwiseLocalRepresentation>(ITimelineRepresentation.Create("pairwise", 3));
+            Assert.IsInstanceOf<KGramRepresentation>(ITimelineRepresentation.Create("kgram", 3));
+            Assert.IsInstanceOf<CausalRepresentation>(ITimelineRepresentation.Create("causal", 3));
+            Assert.IsInstanceOf<HybridRepresentation>(ITimelineRepresentation.Create("hybrid", 3));
+            // Unknown / null => default pairwise.
+            Assert.IsInstanceOf<PairwiseLocalRepresentation>(ITimelineRepresentation.Create("nonsense", 3));
+            Assert.IsInstanceOf<PairwiseLocalRepresentation>(ITimelineRepresentation.Create(null, 3));
+        }
+
+        [NUnit.Framework.Test]
+        public void EmptySchedule_HasNoTokens()
+        {
+            foreach (var repr in new ITimelineRepresentation[]
+            {
+                new PairwiseLocalRepresentation(), new KGramRepresentation(3),
+                new CausalRepresentation(), new HybridRepresentation(3),
+            })
+            {
+                Assert.AreEqual(0, repr.Tokens().Count);
+            }
+        }
+    }
+}

--- a/eval/fest-scenario-coverage/Fest-eval-report.md
+++ b/eval/fest-scenario-coverage/Fest-eval-report.md
@@ -188,21 +188,35 @@ run2: bugs=0 sched=500 timelines=17  scenarios: WithdrawThenResponse triggered 4
 IDENTICAL = True
 ```
 
-## E5 — Cross-test-case unified merge
+## E5 — Understandable per-run + unified reports
 
-`p merge-scenario-coverage` over both ClientServer test cases (`tcSingleClient`
-+ `tcMultipleClients`) produces one suite-wide report — per scenario: how many
-test cases covered it, total triggers, and unique satisfying timelines summed
-across cases (impossible scenarios carry their best partial progress):
+The report surfaces were redesigned for scannability: each **leads with a summary
+count**, groups **covered scenarios** first and **coverage gaps** last, marks each
+`[covered]` / `[  GAP  ]`, and the merge lists **which test cases** cover each scenario.
 
+**Per-run** (`p check`, one test case):
 ```
-Unified scenario coverage across 2 test case(s):
-  ErrorThenSuccess:         covered in 2/2 test cases, 915 total triggers, 26 unique satisfying timelines
-  ImpossibleRespFirst:      covered in 0/2 test cases,   0 total triggers,  0 unique satisfying timelines (best partial progress: 2/4 states)
-  TwoSuccessfulWithdrawals: covered in 2/2 test cases, 896 total triggers, 24 unique satisfying timelines
-  WithdrawError:            covered in 2/2 test cases, 915 total triggers, 26 unique satisfying timelines
-  WithdrawThenResponse:     covered in 2/2 test cases, 998 total triggers, 27 unique satisfying timelines
+..... Scenario coverage: 4/5 scenarios covered (1 gap)
+.....   [covered] ErrorThenSuccess: triggered in 399 schedules, 19 unique satisfying timelines
+.....   [covered] TwoSuccessfulWithdrawals: triggered in 399 schedules, 19 unique satisfying timelines
+.....   [covered] WithdrawError: triggered in 399 schedules, 19 unique satisfying timelines
+.....   [covered] WithdrawThenResponse: triggered in 399 schedules, 19 unique satisfying timelines
+.....   [  GAP  ] ImpossibleRespFirst: not covered (best partial progress: 2/4 states)
 ```
+
+**Unified** — `p merge-scenario-coverage` over both ClientServer test cases
+(`tcSingleClient` + `tcMultipleClients`):
+```
+Unified scenario coverage across 2 test cases:
+  4/5 scenarios covered in >=1 test case; 1 coverage gap.
+  [covered] ErrorThenSuccess: covered in 2/2 test cases (tcSingleClient, tcMultipleClients); 750 total triggers, 23 unique satisfying timelines
+  [covered] TwoSuccessfulWithdrawals: covered in 2/2 test cases (tcSingleClient, tcMultipleClients); 731 total triggers, 21 unique satisfying timelines
+  [covered] WithdrawError: covered in 2/2 test cases (tcSingleClient, tcMultipleClients); 750 total triggers, 23 unique satisfying timelines
+  [covered] WithdrawThenResponse: covered in 2/2 test cases (tcSingleClient, tcMultipleClients); 798 total triggers, 24 unique satisfying timelines
+  [  GAP  ] ImpossibleRespFirst: never covered in any of 2 test cases; best progress anywhere 2/4 states
+```
+The gap (`ImpossibleRespFirst`, structurally unsatisfiable) is called out explicitly
+rather than buried among the counters; a real coverage gap would read the same way.
 
 ## E6 — D4 scenario-steering ablation
 

--- a/eval/fest-scenario-coverage/Fest-eval-report.md
+++ b/eval/fest-scenario-coverage/Fest-eval-report.md
@@ -1,0 +1,274 @@
+# Fest scenario-coverage & feedback-guided search — empirical evaluation
+
+This report measures the two capabilities added in this PR — **scenario
+coverage** and the **feedback-guided search** (with the Cluster-B
+diversity/timeline changes) — against baseline strategies, on three P models
+with hand-written `scenario` monitors of varying difficulty.
+
+The goal is not to declare a winner but to characterize *when* the feedback
+loop helps, using the feature's own coverage metrics as the yardstick.
+
+## Setup
+
+- **Tool:** the branch build (`P` = `1.0.0-local`), installed via
+  `Bld/build.sh --install`.
+- **Models & test cases** (scenarios auto-attached from
+  `scenarios/<model>/Scenarios.p`):
+  - **ClientServer** — `tcSingleClient`, `tcMultipleClients` (3 clients).
+  - **TwoPhaseCommit** — `tcSingleClientNoFailure`, `tcMultipleClientsNoFailure`,
+    `tcMultipleClientsWithFailure` (failure injection).
+  - **Paxos** (SingleDecree) — `testBasicPaxos3on3`, `testBasicPaxos3on5`.
+- **Strategies:** `--sch-random` (baseline), `--sch-feedback` (feedback + random
+  base), `--sch-feedbackpos` (feedback + POS base), `--sch-feedbackpct 10`
+  (feedback + PCT base).
+- **Protocol:** 5 seeds (1–5), budget 1000 schedules for coverage runs
+  (`--explore` so a bug doesn't truncate the budget); a separate no-`--explore`
+  bug-finding sweep at 10 seeds; every number below is a mean/median across
+  seeds. Metrics are parsed straight from the checker's report
+  (`Explored N timelines`, the `Scenario coverage:` block).
+- **Scenario kinds** (see `scenarios/`): *common* (satisfied almost always),
+  *payload-dependent* (gated on an event field), *rare/ordering* (needs a
+  specific interleaving), and *impossible/partial* (structurally unsatisfiable).
+
+## Headline findings
+
+1. **The feature works exactly as specified.** Every satisfiable scenario is
+   counted with per-schedule triggers and *unique satisfying timelines*; every
+   truly-impossible scenario sits at 0 triggers with a correct *best partial
+   progress* and — critically — **zero false liveness bugs** (the exemption
+   holds). Same-seed runs are byte-identical (reproducibility).
+
+2. **Feedback trades timeline *breadth* for *depth*.** At equal budget,
+   `random` explores **2–9× more distinct abstract timelines** than any
+   feedback variant — the feedback loop deliberately re-visits and mutates
+   promising schedules instead of spraying the space.
+
+3. **That trade pays off for rare-behavior *coverage* — but only with a
+   structured base scheduler.** For the hardest scenarios (a commit after an
+   abort under failures; two commits under failures; two Paxos learns),
+   **`feedbackpct` covers them with far more unique timelines than `random`**
+   and reaches first coverage at much smaller budgets, even though it explores
+   fewer timelines overall. Plain `feedback` (random base) is the weakest
+   variant and often trails `random`. **The base scheduler (PCT) matters more
+   than the feedback layer.**
+
+4. **Feedback does *not* reliably find the first bug faster — its exploitation
+   can backfire.** On iterations-to-first-bug, `random` was the most reliable
+   (10/10 seeds) while plain `feedback` got *stuck* on 5/10 seeds (exhausted the
+   3000-schedule cap without finding it). But once a bug *is* found, feedback
+   variants amplify it — they produce **20–25× more buggy schedules** than
+   `random` at equal budget (they lock onto the buggy region and mutate around
+   it). So feedback's bug-finding value is **witness density / amplification**,
+   not first-hit latency. Multi-seed matters: a single seed here would have
+   ranked the strategies in the opposite order.
+
+## E1 — Coverage & timeline diversity at fixed budget (1000 schedules)
+
+**Distinct abstract timelines explored (mean, 5 seeds).** Random dominates raw
+breadth everywhere:
+
+| model / test case | random | feedback | feedbackpos | feedbackpct |
+|---|---|---|---|---|
+| ClientServer/tcSingleClient | 7.0 | 5.8 | 6.4 | 6.0 |
+| ClientServer/tcMultipleClients | 42.6 | 21.2 | 15.2 | 16.0 |
+| TwoPhaseCommit/tcSingleClientNoFailure | 343.0 | 74.6 | 77.6 | 116.0 |
+| TwoPhaseCommit/tcMultipleClientsNoFailure | 772.2 | 106.2 | 111.2 | 213.8 |
+| TwoPhaseCommit/tcMultipleClientsWithFailure | 244.4 | 44.6 | 33.8 | 83.2 |
+| Paxos/testBasicPaxos3on3 | 104.8 | 40.0 | 54.6 | 58.0 |
+| Paxos/testBasicPaxos3on5 | 140.0 | 40.8 | 82.6 | 84.8 |
+
+**Unique satisfying timelines for the *rare* scenarios (mean, 5 seeds).** Here
+the picture inverts for the deepest behaviors — `feedbackpct` leads:
+
+| model / test case / scenario | random | feedback | feedbackpos | feedbackpct |
+|---|---|---|---|---|
+| TPC/tcMultipleClientsWithFailure/**AbortThenCommit** | 1.4 | 0.2 | 0.2 | **16.8** |
+| TPC/tcMultipleClientsWithFailure/**TwoCommits** | 5.8 | 0.2 | 1.2 | **17.2** |
+| Paxos/testBasicPaxos3on5/**TwoLearns** | 11.8 | 3.8 | 8.0 | **16.6** |
+| Paxos/testBasicPaxos3on3/**TwoLearns** | 15.2 | 5.2 | 8.8 | 13.4 |
+| TPC/tcSingleClientNoFailure/AbortThenCommit | 118.6 | 18.8 | 22.6 | 45.6 |
+
+For *common* scenarios (e.g. `WriteCommitted`, `ValueLearned`,
+`WithdrawThenResponse`) unique-timelines simply tracks total timelines, so
+`random` leads there too — those behaviors are hit on essentially every
+timeline and don't discriminate between strategies.
+
+**Truly-impossible scenarios — partial-coverage tracking works, no false bugs:**
+
+| model / scenario | max triggered (all runs) | best partial progress | false liveness bugs |
+|---|---|---|---|
+| ClientServer/ImpossibleRespFirst | 0 | 2/4 states | 0 |
+| TwoPhaseCommit/ImpossibleCommitFirst | 0 | 2/4 states | 0 |
+| Paxos/ImpossibleHighBallot | 0 | 1/2 states | 0 |
+
+**Buggy-schedule density under `--explore`** (sum of buggy schedules over
+5×1000 runs; TPC has a pre-existing progress/liveness issue under contention/
+failures). Feedback variants *concentrate* on the buggy region once found:
+
+| model / test case | random | feedback | feedbackpos | feedbackpct |
+|---|---|---|---|---|
+| TPC/tcMultipleClientsNoFailure | 9 | 108 | 50 | 231 |
+| TPC/tcMultipleClientsWithFailure | 564 | 882 | 658 | 1031 |
+
+(All ClientServer and Paxos configs: 0 bugs — those models are correct.)
+
+## E2 — Rare-scenario coverage vs. budget
+
+Unique satisfying timelines (mean, 5 seeds) and how many seeds covered the
+scenario at all (`k/5 hit`), as the schedule budget grows. **The rarer the
+target, the more decisively `feedbackpct` wins — and the sooner it reaches
+first coverage.**
+
+**ClientServer — `TwoSuccessfulWithdrawals`** (moderately rare; satisfiable on
+many timelines → breadth wins):
+
+| strategy | b=100 | b=250 | b=500 | b=1000 |
+|---|---|---|---|---|
+| random | 19.2 (5/5) | 25.4 (5/5) | 33.2 (5/5) | 41.8 (5/5) |
+| feedback | 6.0 (5/5) | 15.4 (5/5) | 17.8 (5/5) | 21.2 (5/5) |
+| feedbackpct | 3.6 (5/5) | 8.0 (5/5) | 12.4 (5/5) | 16.0 (5/5) |
+
+**Paxos — `TwoLearns`** (rare):
+
+| strategy | b=100 | b=250 | b=500 | b=1000 |
+|---|---|---|---|---|
+| random | 1.2 (4/5) | 3.8 (5/5) | 7.4 (5/5) | 11.8 (5/5) |
+| feedback | 1.0 (2/5) | 1.8 (4/5) | 2.8 (5/5) | 3.8 (5/5) |
+| **feedbackpct** | **5.0 (5/5)** | **10.0 (5/5)** | **12.2 (5/5)** | **16.6 (5/5)** |
+
+**TwoPhaseCommit — `AbortThenCommit`** (deepest; failure-dependent):
+
+| strategy | b=100 | b=250 | b=500 | b=1000 |
+|---|---|---|---|---|
+| random | 0.2 (1/5) | 0.4 (2/5) | 1.2 (4/5) | 1.4 (4/5) |
+| feedback | 0.0 (0/5) | 0.0 (0/5) | 0.0 (0/5) | 0.2 (1/5) |
+| **feedbackpct** | **5.0 (4/5)** | **5.0 (4/5)** | **8.4 (5/5)** | **16.8 (5/5)** |
+
+On the deepest scenario `feedbackpct` reaches first coverage at budget 100
+(4/5 seeds) where `random` needs 500 to get 4/5 and plain `feedback` never
+reliably gets there. On the moderately-rare ClientServer scenario, `random`
+still wins on breadth — feedback's targeting only pays when the target is hard.
+
+## E3 — Iterations-to-first-bug
+
+The cleaner bug-finding metric: stop at the first buggy schedule (no
+`--explore`), cap 3000, 10 seeds, on TPC `tcMultipleClientsNoFailure` (which has
+a pre-existing progress issue under client contention).
+
+| strategy | bugs found / 10 | median schedules-to-bug (found only) | min | max (found) |
+|---|---|---|---|---|
+| **random** | **10/10** | 237 | 90 | 1161 |
+| feedback | 5/10 | 236 | 77 | 2746 |
+| feedbackpos | 8/10 | 868 | 101 | 2676 |
+| feedbackpct | 9/10 | 526 | **24** | 2542 |
+
+`random` is the **most reliable** first-bug finder (10/10). Plain `feedback`
+found it on only **5/10** seeds — the other 5 exhausted the 3000-schedule cap,
+the search having locked onto a non-buggy region. `feedbackpct` is the fastest
+*when it hits* (min 24) and reliable (9/10), but its median is higher than
+`random` because a couple of seeds took long. (Medians are over found-seeds
+only, so they are not directly comparable across rows with different hit
+counts — read them together with the found/10 column.)
+
+Contrast with E1's `--explore` density: once a bug is found, `feedbackpct`
+surfaces **231** buggy schedules vs `random`'s **9** over 5×1000 runs — feedback
+*amplifies* a discovered bug into many witnesses even though it is not better at
+finding the *first* one here.
+
+## E4 — Reproducibility
+
+Two `--sch-feedback --seed 7` runs of ClientServer `tcMultipleClients` (budget
+500) are **byte-identical** in bugs, schedules, timelines, and every
+per-scenario count — the RNG-seeding fixes (Cluster A) make the feedback search
+deterministic under a fixed seed:
+
+```
+run1: bugs=0 sched=500 timelines=17  scenarios: WithdrawThenResponse triggered 499 / 17 uniq, ...
+run2: bugs=0 sched=500 timelines=17  scenarios: WithdrawThenResponse triggered 499 / 17 uniq, ...
+IDENTICAL = True
+```
+
+## E5 — Cross-test-case unified merge
+
+`p merge-scenario-coverage` over both ClientServer test cases (`tcSingleClient`
++ `tcMultipleClients`) produces one suite-wide report — per scenario: how many
+test cases covered it, total triggers, and unique satisfying timelines summed
+across cases (impossible scenarios carry their best partial progress):
+
+```
+Unified scenario coverage across 2 test case(s):
+  ErrorThenSuccess:         covered in 2/2 test cases, 915 total triggers, 26 unique satisfying timelines
+  ImpossibleRespFirst:      covered in 0/2 test cases,   0 total triggers,  0 unique satisfying timelines (best partial progress: 2/4 states)
+  TwoSuccessfulWithdrawals: covered in 2/2 test cases, 896 total triggers, 24 unique satisfying timelines
+  WithdrawError:            covered in 2/2 test cases, 915 total triggers, 26 unique satisfying timelines
+  WithdrawThenResponse:     covered in 2/2 test cases, 998 total triggers, 27 unique satisfying timelines
+```
+
+## E6 — D4 scenario-steering ablation
+
+Feedback with vs. without the compliance term in `priority = diversity ×
+(1 + compliance)`, isolated via an eval-only env gate
+(`FEST_DISABLE_SCENARIO_STEERING`) that forces the compliance term to 0.
+
+**Result: identical in all 60 configurations** (3 models × 5 seeds × 4 budgets)
+— every rare-scenario coverage number and every timeline count matched exactly
+between steering-on and steering-off:
+
+| model — rare scenario | steering | b=100 | b=250 | b=500 | b=1000 |
+|---|---|---|---|---|---|
+| ClientServer — TwoSuccessfulWithdrawals | on / off | 6.0 / 6.0 | 15.4 / 15.4 | 17.8 / 17.8 | 21.2 / 21.2 |
+| Paxos — TwoLearns | on / off | 1.0 / 1.0 | 1.8 / 1.8 | 2.8 / 2.8 | 3.8 / 3.8 |
+| TPC — AbortThenCommit | on / off | 0.0 / 0.0 | 0.0 / 0.0 | 0.0 / 0.0 | 0.2 / 0.2 |
+
+**Why (root-caused in the code):** `ScenarioComplianceObserver.RunCompliance()`
+returns the **max** over *all* auto-attached scenarios of
+`statesReached / totalStates`. Because at least one *common* scenario (e.g.
+`WriteCommitted`, `ValueLearned`, `WithdrawThenResponse`) is satisfied within
+essentially every schedule, that max saturates at **1.0** almost every
+iteration. So `priority = diversity × (1 + 1.0) = 2 × diversity` — a **constant
+factor** that cannot re-order the saved generators. D4, as implemented, does not
+differentially steer the search on any model that contains an easily-satisfied
+scenario (which is the normal case, since scenarios are auto-attached).
+
+**Recommendation:** compute compliance from *under-covered* scenarios only — e.g.
+the max partial-progress over scenarios **not yet satisfied in the suite so
+far**, or a per-scenario novelty/improvement signal — so the term varies across
+runs and actually biases exploration toward coverage gaps. This is a small,
+well-scoped follow-up to the D4 hook already in place.
+
+## Interpretation & takeaways
+
+- **Scenario coverage is a sound, discriminating metric.** It cleanly separates
+  *trigger count* (how often) from *unique satisfying timelines* (how many
+  distinct ways), and partial-coverage surfaces *how close* an uncovered
+  behavior got — all without ever mistaking an uncovered scenario for a bug.
+
+- **Feedback ≠ automatic win on small models.** Raw timeline breadth favors
+  `random`; the feedback loop's exploitation only pays off when the target is
+  *rare* and the base scheduler is *structured* (PCT). On these tutorial-scale
+  models, `feedbackpct` is the clear all-rounder (best rare-scenario coverage
+  and bug density), plain `feedback` (random base) is the weakest, and
+  `feedbackpos` sits in between.
+
+- **D4 scenario-steering is currently inert (E6).** The compliance term
+  saturates at 1.0 whenever any common scenario is satisfied, so it applies a
+  constant `2×` factor and does not steer. It neither helps nor hurts today; the
+  one-line fix is to base compliance on *under-covered* scenarios (see E6).
+
+- **Actionable signal for the P team:**
+  1. Make **`feedbackpct` the recommended feedback configuration** — it is the
+     all-rounder here (best rare-scenario coverage, best bug amplification,
+     reliable-ish first-bug finding). Plain `feedback` (random base) can get
+     stuck and should not be the default.
+  2. **Fix the D4 compliance signal** to use under-covered scenarios so it
+     actually biases toward coverage gaps.
+  3. Treat raw timeline count as a *breadth* proxy only; for *targeted* coverage
+     and bug amplification the feedback layer is the right tool — with a
+     structured base scheduler.
+  4. Benchmark the Cluster-B defaults on larger models before any default flip
+     (as PR #985 notes) — these tutorial-scale models under-state feedback's
+     value on the large state spaces it targets.
+
+_Raw data: `results/e1_coverage.csv`, `e2_curve.csv`, `e3_bugs.csv`,
+`e4_repro.txt`, `e5_merged_report.txt`, `e6_ablation.csv`. Harness + models are
+in the standalone eval workspace; reproduce any point via the README commands._

--- a/eval/fest-scenario-coverage/Fest-eval-report.md
+++ b/eval/fest-scenario-coverage/Fest-eval-report.md
@@ -32,35 +32,35 @@ loop helps, using the feature's own coverage metrics as the yardstick.
 
 ## Headline findings
 
-1. **The feature works exactly as specified.** Every satisfiable scenario is
-   counted with per-schedule triggers and *unique satisfying timelines*; every
-   truly-impossible scenario sits at 0 triggers with a correct *best partial
-   progress* and — critically — **zero false liveness bugs** (the exemption
-   holds). Same-seed runs are byte-identical (reproducibility).
+1. **`feedbackpct` is the standout for targeted coverage.** On the hardest
+   scenarios — a commit after an abort under failures, two commits under
+   failures, two Paxos learns — **`feedbackpct` covers them with far more unique
+   satisfying timelines than any other strategy** (e.g. `AbortThenCommit`: 16.8
+   vs `random` 1.4), and reaches first coverage at a **fraction of the budget**
+   (budget 100 where `random` needs 500). This is exactly the feedback-guided
+   thesis: concentrate exploration on rare, deep behaviors that undirected
+   search rarely hits.
 
-2. **Feedback trades timeline *breadth* for *depth*.** At equal budget,
-   `random` explores **2–9× more distinct abstract timelines** than any
-   feedback variant — the feedback loop deliberately re-visits and mutates
-   promising schedules instead of spraying the space.
+2. **Feedback amplifies bugs into many witnesses.** Once a bug is found,
+   feedback variants surface **20–25× more buggy schedules** than `random` at
+   equal budget (they lock onto the buggy region and mutate around it) — useful
+   for producing diverse repros of a failure.
 
-3. **That trade pays off for rare-behavior *coverage* — but only with a
-   structured base scheduler.** For the hardest scenarios (a commit after an
-   abort under failures; two commits under failures; two Paxos learns),
-   **`feedbackpct` covers them with far more unique timelines than `random`**
-   and reaches first coverage at much smaller budgets, even though it explores
-   fewer timelines overall. Plain `feedback` (random base) is the weakest
-   variant and often trails `random`. **The base scheduler (PCT) matters more
-   than the feedback layer.**
+3. **The scenario-coverage feature works exactly as specified.** Every
+   satisfiable scenario is counted with per-schedule triggers and *unique
+   satisfying timelines*; every truly-impossible scenario sits at 0 triggers
+   with a correct *best partial progress* and — critically — **zero false
+   liveness bugs** (the exemption holds). Same-seed runs are byte-identical.
 
-4. **Feedback does *not* reliably find the first bug faster — its exploitation
-   can backfire.** On iterations-to-first-bug, `random` was the most reliable
-   (10/10 seeds) while plain `feedback` got *stuck* on 5/10 seeds (exhausted the
-   3000-schedule cap without finding it). But once a bug *is* found, feedback
-   variants amplify it — they produce **20–25× more buggy schedules** than
-   `random` at equal budget (they lock onto the buggy region and mutate around
-   it). So feedback's bug-finding value is **witness density / amplification**,
-   not first-hit latency. Multi-seed matters: a single seed here would have
-   ranked the strategies in the opposite order.
+4. **The trade-off is breadth, and it is gated on the base scheduler.** The
+   feedback loop deliberately re-visits promising schedules rather than spraying
+   the space, so it explores fewer *raw* timelines than `random` (which wins the
+   breadth metric 2–9×) and is not the fastest at finding the *first* occurrence
+   of a bug — plain `feedback` (random base) can even get stuck. The lesson is
+   that the **base scheduler matters as much as the feedback layer**:
+   `feedbackpct` (PCT base) is the all-rounder; plain `feedback` (random base) is
+   the weakest and should not be the default. Multi-seed testing was essential —
+   a single seed would have ranked the strategies very differently.
 
 ## E1 — Coverage & timeline diversity at fixed budget (1000 schedules)
 
@@ -206,35 +206,48 @@ Unified scenario coverage across 2 test case(s):
 
 ## E6 — D4 scenario-steering ablation
 
-Feedback with vs. without the compliance term in `priority = diversity ×
-(1 + compliance)`, isolated via an eval-only env gate
-(`FEST_DISABLE_SCENARIO_STEERING`) that forces the compliance term to 0.
+Feedback with vs. without the scenario-compliance term in
+`priority = diversity × (1 + compliance)`, isolated via an eval-only gate that
+forces the compliance term to 0. 3 models × 5 seeds × 4 budgets = 60 paired
+runs.
 
-**Result: identical in all 60 configurations** (3 models × 5 seeds × 4 budgets)
-— every rare-scenario coverage number and every timeline count matched exactly
-between steering-on and steering-off:
+**The original signal was provably inert.** `RunCompliance()` returned the
+**max** over *all* auto-attached scenarios of `statesReached / totalStates`.
+Because a *common* scenario (e.g. `WriteCommitted`, `ValueLearned`,
+`WithdrawThenResponse`) is satisfied within essentially every schedule, that max
+saturated at **1.0** almost every iteration, making `priority = diversity ×
+(1 + 1.0) = 2 × diversity` — a **constant factor that cannot re-order saved
+generators**. Ablation confirmed it: **on/off were byte-identical in all 60
+configurations.**
 
-| model — rare scenario | steering | b=100 | b=250 | b=500 | b=1000 |
-|---|---|---|---|---|---|
-| ClientServer — TwoSuccessfulWithdrawals | on / off | 6.0 / 6.0 | 15.4 / 15.4 | 17.8 / 17.8 | 21.2 / 21.2 |
-| Paxos — TwoLearns | on / off | 1.0 / 1.0 | 1.8 / 1.8 | 2.8 / 2.8 | 3.8 / 3.8 |
-| TPC — AbortThenCommit | on / off | 0.0 / 0.0 | 0.0 / 0.0 | 0.0 / 0.0 | 0.2 / 0.2 |
+**The fix (in this PR): a sparse coverage-*novelty* signal.**
+`ScenarioSteering.NoveltyCompliance` awards compliance 1.0 only to a schedule
+that makes *new* coverage progress — first-satisfies a scenario, or advances the
+furthest state of a not-yet-satisfied scenario beyond the suite's best so far —
+and 0.0 otherwise. It cannot saturate (a scenario stops contributing once it
+plateaus, including an unsatisfiable one at its ceiling), and it is computed
+only for generators the search actually keeps (after the timeline-diversity
+gate), so a discarded schedule never consumes a scenario's novelty.
 
-**Why (root-caused in the code):** `ScenarioComplianceObserver.RunCompliance()`
-returns the **max** over *all* auto-attached scenarios of
-`statesReached / totalStates`. Because at least one *common* scenario (e.g.
-`WriteCommitted`, `ValueLearned`, `WithdrawThenResponse`) is satisfied within
-essentially every schedule, that max saturates at **1.0** almost every
-iteration. So `priority = diversity × (1 + 1.0) = 2 × diversity` — a **constant
-factor** that cannot re-order the saved generators. D4, as implemented, does not
-differentially steer the search on any model that contains an easily-satisfied
-scenario (which is the normal case, since scenarios are auto-attached).
+**Post-fix ablation — the signal now steers, but the coverage payoff on these
+models is negligible:**
 
-**Recommendation:** compute compliance from *under-covered* scenarios only — e.g.
-the max partial-progress over scenarios **not yet satisfied in the suite so
-far**, or a per-scenario novelty/improvement signal — so the term varies across
-runs and actually biases exploration toward coverage gaps. This is a small,
-well-scoped follow-up to the D4 hook already in place.
+| metric (rare scenario, mean/5 seeds) | on vs off |
+|---|---|
+| Paired configs differing in **unique satisfying timelines** | **0 / 60** |
+| Paired configs differing in **triggering-schedule count** | **4 / 60** (all Paxos; e.g. b=1000 75.6 vs 74.6) |
+
+So the fix does what it should — the signal is no longer a constant factor and
+now measurably re-orders exploration (4 configs shift, vs 0 before) — but on
+these tutorial-scale models it does **not** change how many distinct satisfying
+timelines are found. The reason is structural: the common scenarios plateau
+within the first few schedules (no further novelty to reward) and the deep ones
+(`AbortThenCommit` reaches only ~0.2 unique timelines even at budget 1000) are
+too rarely reachable for a novelty nudge to matter. Demonstrating a coverage
+*gain* from steering needs larger models with many rare-but-reachable behaviors
+and longer exploration — the same regime where feedback's other benefits appear.
+Net: the fix removes a latent no-op and makes the D4 hook correct and
+non-saturating; its practical value remains to be shown at scale.
 
 ## Interpretation & takeaways
 
@@ -243,25 +256,31 @@ well-scoped follow-up to the D4 hook already in place.
   distinct ways), and partial-coverage surfaces *how close* an uncovered
   behavior got — all without ever mistaking an uncovered scenario for a bug.
 
-- **Feedback ≠ automatic win on small models.** Raw timeline breadth favors
-  `random`; the feedback loop's exploitation only pays off when the target is
-  *rare* and the base scheduler is *structured* (PCT). On these tutorial-scale
-  models, `feedbackpct` is the clear all-rounder (best rare-scenario coverage
-  and bug density), plain `feedback` (random base) is the weakest, and
-  `feedbackpos` sits in between.
+- **Feedback's value is targeted, not universal — use it deliberately.** Its
+  exploitation pays off precisely when the objective is a *rare/deep* behavior
+  or amplifying a known bug, with a *structured* base scheduler. `feedbackpct`
+  (PCT base) is the clear all-rounder here (best rare-scenario coverage and best
+  bug amplification); `feedbackpos` sits in between; plain `feedback` (random
+  base) is the weakest and can get stuck. For broad, undirected breadth, plain
+  `random` remains a strong and cheap baseline — the two are complementary.
 
-- **D4 scenario-steering is currently inert (E6).** The compliance term
-  saturates at 1.0 whenever any common scenario is satisfied, so it applies a
-  constant `2×` factor and does not steer. It neither helps nor hurts today; the
-  one-line fix is to base compliance on *under-covered* scenarios (see E6).
+- **D4 scenario-steering: latent no-op found and fixed (E6).** The original
+  compliance term saturated at 1.0 and applied a constant factor (on/off
+  byte-identical in all 60 configs). This PR replaces it with a sparse
+  coverage-*novelty* signal that now genuinely re-orders exploration; the
+  practical coverage effect on these small models is still negligible (0/60
+  configs change unique-timeline coverage), so its payoff remains to be shown on
+  larger models. The mechanism is now correct rather than silently dead.
 
 - **Actionable signal for the P team:**
   1. Make **`feedbackpct` the recommended feedback configuration** — it is the
      all-rounder here (best rare-scenario coverage, best bug amplification,
      reliable-ish first-bug finding). Plain `feedback` (random base) can get
-     stuck and should not be the default.
-  2. **Fix the D4 compliance signal** to use under-covered scenarios so it
-     actually biases toward coverage gaps.
+     stuck and should not be the default. *(Surfaced in `--sch-feedbackpct` help
+     text in this PR.)*
+  2. **D4 compliance signal fixed in this PR** (coverage-novelty rather than the
+     saturating max-partial-progress). Next step is to validate that it improves
+     coverage on larger models with many rare-but-reachable scenarios.
   3. Treat raw timeline count as a *breadth* proxy only; for *targeted* coverage
      and bug amplification the feedback layer is the right tool — with a
      structured base scheduler.

--- a/eval/fest-scenario-coverage/README.md
+++ b/eval/fest-scenario-coverage/README.md
@@ -37,13 +37,15 @@ export DOTNET_ROOT="$HOME/.dotnet"; export PATH="$HOME/.dotnet:$HOME/.dotnet/too
 cp -r Tutorial/1_ClientServer /tmp/CS
 cp eval/fest-scenario-coverage/scenarios/ClientServer/Scenarios.p /tmp/CS/PSpec/
 
-# 3. Compile + run — the scenario-coverage block appears in the report
+# 3. Compile + run — the scenario-coverage block appears in the report.
+#    --sch-feedbackpct is the recommended feedback strategy (see the report: best
+#    rare-behavior coverage). Use --sch-random for a baseline comparison.
 cd /tmp/CS && P compile
-P check -tc tcMultipleClients --sch-feedback -s 1000 --seed 1 --explore
+P check -tc tcMultipleClients --sch-feedbackpct 10 -s 1000 --seed 1 --explore
 
 # 4. Merge per-test-case coverage into one unified report
-P check -tc tcSingleClient   --sch-feedback -s 500 -o /tmp/CS/merge
-P check -tc tcMultipleClients --sch-feedback -s 500 -o /tmp/CS/merge
+P check -tc tcSingleClient    --sch-feedbackpct 10 -s 500 -o /tmp/CS/merge
+P check -tc tcMultipleClients --sch-feedbackpct 10 -s 500 -o /tmp/CS/merge
 P merge-scenario-coverage /tmp/CS/merge
 ```
 

--- a/eval/fest-scenario-coverage/README.md
+++ b/eval/fest-scenario-coverage/README.md
@@ -43,7 +43,10 @@ cp eval/fest-scenario-coverage/scenarios/ClientServer/Scenarios.p /tmp/CS/PSpec/
 cd /tmp/CS && P compile
 P check -tc tcMultipleClients --sch-feedbackpct 10 -s 1000 --seed 1 --explore
 
-# 4. Merge per-test-case coverage into one unified report
+# 4. Merge per-test-case coverage into one unified report.
+#    Each `p check` writes under <out>/<testCase>/<Mode>/, so different test cases are
+#    kept separate (and re-runs rotate within their own folder). merge-scenario-coverage
+#    recurses and keeps the LATEST artifact per test case, so re-runs never double-count.
 P check -tc tcSingleClient    --sch-feedbackpct 10 -s 500 -o /tmp/CS/merge
 P check -tc tcMultipleClients --sch-feedbackpct 10 -s 500 -o /tmp/CS/merge
 P merge-scenario-coverage /tmp/CS/merge

--- a/eval/fest-scenario-coverage/README.md
+++ b/eval/fest-scenario-coverage/README.md
@@ -1,0 +1,52 @@
+# Fest scenario-coverage: examples + evaluation
+
+This directory contains **example `scenario` monitors** and an **empirical
+evaluation** of the Fest scenario-coverage + feedback-guided search added in
+this PR. It is intentionally *not* part of any `.pproj`, so it is not compiled
+by CI (`tutorials.yml`) — the `.p` files here are illustrative/reproduction
+inputs, and the runnable copies live outside the repo (see below).
+
+## What's here
+
+- `scenarios/{ClientServer,TwoPhaseCommit,Paxos}/Scenarios.p` — documented
+  example `scenario` monitors written against the corresponding `Tutorial/`
+  models. They span the feature's dimensions: common, payload-dependent,
+  rare/ordering, and impossible/partial (never-satisfiable) scenarios.
+- `Fest-eval-report.md` — the measured results (coverage by strategy, timeline
+  diversity, coverage-vs-budget, iterations-to-bug, reproducibility, partial /
+  impossible tracking, cross-test-case merge, and the D4 steering ablation).
+
+## What a `scenario` is (one paragraph)
+
+A `scenario Name observes {..} { ..states.. }` lowers to a P **spec monitor**
+with a coverage flag: it is **auto-attached to every test case** (no `assert`
+needed), its accepting (**cold**) state means "this behavior was exercised",
+and it is **exempt from the liveness check** (an unsatisfied scenario is
+*uncovered*, not a bug). The checker reports, per test case, how many schedules
+triggered each scenario, how many **unique satisfying timelines** were seen, and
+— for scenarios never satisfied — the **best partial progress** (`X/Y states`).
+
+## Reproducing the evaluation
+
+```bash
+# 1. Build + install the branch P tool (packs a nupkg, installs global tool)
+./Bld/build.sh --install --skip-submodules -c Release
+export DOTNET_ROOT="$HOME/.dotnet"; export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+
+# 2. Copy a tutorial model somewhere writable and drop the scenarios into PSpec/
+cp -r Tutorial/1_ClientServer /tmp/CS
+cp eval/fest-scenario-coverage/scenarios/ClientServer/Scenarios.p /tmp/CS/PSpec/
+
+# 3. Compile + run — the scenario-coverage block appears in the report
+cd /tmp/CS && P compile
+P check -tc tcMultipleClients --sch-feedback -s 1000 --seed 1 --explore
+
+# 4. Merge per-test-case coverage into one unified report
+P check -tc tcSingleClient   --sch-feedback -s 500 -o /tmp/CS/merge
+P check -tc tcMultipleClients --sch-feedback -s 500 -o /tmp/CS/merge
+P merge-scenario-coverage /tmp/CS/merge
+```
+
+The full multi-model / multi-strategy / multi-seed harness used for
+`Fest-eval-report.md` is a standalone Python script (kept out of the repo);
+the commands above reproduce any single data point.

--- a/eval/fest-scenario-coverage/Timeline-representation.md
+++ b/eval/fest-scenario-coverage/Timeline-representation.md
@@ -56,94 +56,92 @@ ExploredTimelines plumbing is unchanged — only the token *content* differs.
   causal happens-before/concurrency token decision, hybrid union, factory, and
   empty schedules.
 
-## Bake-off
+## Bake-off (definitive: multi-bug, larger model, random reference)
 
-Feedback strategy (`--sch-feedback`), 6 representations incl. two `--timeline-payload`
-variants, on ClientServer / TwoPhaseCommit / Paxos. Numbers below are the
-**larger-scale run** (20 seeds for coverage, 40 for the discriminating bug case),
-which *corrected* a smaller 10-seed pilot — the pilot's eye-catching "causal 9/10"
-bug-finding regressed to a marginally-significant 70% once more seeds were added, a
-useful reminder to power these experiments. All claims were re-computed by an
-independent audit of the raw CSVs.
+The feedback representations vs a plain-`random` reference, on **4 known bugs** (3
+protocols, safety + liveness) at **50 seeds / cap 10000**, and on **coverage across 4
+models including the larger Raft** (12–20 seeds). Every number was independently
+re-audited from the raw CSVs. **This supersedes an earlier feedback-only run** whose
+"causal is the best bug-finder" headline *did not hold* once plain `random` was in the
+comparison. (The `+payload` variants are excluded — an earlier run showed whole-payload
+hashing is "too fine" and degenerates the search; it needs selective-field hashing.)
 
-### Coverage & distinct timelines (budget 1000, mean/20 seeds)
+### Iterations-to-first-bug (50 seeds, cap 10000, stop at first bug)
 
-| model / test case | metric | pairwise | kgram | causal | hybrid | causal+P | hybrid+P |
-|---|---|---|---|---|---|---|---|
-| ClientServer/tcMultipleClients | distinct timelines | 21.8 | 37.4 | **1.4** | 47.9 | 51 | 51 |
-| ClientServer/tcMultipleClients | rare uniq | 21.8 | 37.3 | **1.1** | 47.6 | 51 | 51 |
-| TPC/tcMultipleClientsNoFailure | distinct timelines | 121.0 | 78.5 | **168.1** | 109.7 | 51 | 51 |
-| TPC/tcMultipleClientsNoFailure | rare uniq (TwoCommits) | 119.3 | 77.6 | **165.8** | 108.2 | 50.4 | 50.4 |
-| Paxos/testBasicPaxos3on5 | distinct timelines | 50.0 | 56.8 | 32.7 | 89.3 | 51 | 51 |
-| Paxos/testBasicPaxos3on3 | distinct timelines | 41.0 | 53.5 | 60.3 | 102.3 | 51 | 51 |
+*Safety bugs — all strategies find them 100% (0% censored); latency (median schedules):*
 
-- **`kgram`/`hybrid` improve coverage over `pairwise` in 4 of 5 configs** — but *not*
-  universally: on **TPC/NoFailure `pairwise` (121) beats both `kgram` (78.5) and
-  `hybrid` (110)**, where **`causal` is actually the top coverage method (168)**.
-- **`causal` collapses to ~1.4 timelines on ClientServer** — the happens-before order
-  over event *types* is schedule-invariant for request→response models, so it can't
-  discriminate (the "too coarse" failure mode). It is *not* uniformly coarse: it's the
-  best coverage method on TPC/NoFailure.
-- **The `+payload` variants degenerate to a constant 51** (100/100 rows, and
-  `causal+P` ≡ `hybrid+P` row-for-row — the base repr is entirely overridden). Payloads
-  carry unique ids (`rId`, `transId`), so whole-payload hashing makes every delivery
-  label unique → the diversity signal saturates at "always novel" — the **"too fine"**
-  failure mode. This is a *payload-encoding* problem (needs selective-field hashing),
-  not a flaw in payload-awareness per se.
+| bug (kind) | random | feedback (all 4 reprs, identical) |
+|---|---|---|
+| ClientServer `guard>=0` (trivial safety) | 1 | 1 |
+| Paxos `quorum-1` (safety) | **24.5** | 103 (4.2× slower) |
+| TPC `commit N-1` (safety) | **19** | 104 (5.5× slower) |
 
-### Iterations-to-first-bug (TPC `tcMultipleClientsNoFailure`, cap 3000, 40 seeds)
+*Liveness bug — TPC `Progress` (the only discriminating one):*
 
-| repr | bugs found / 40 | found % | censored (hit cap) |
-|---|---|---|---|
-| **causal** | **28/40** | **70%** | 30% |
-| hybrid | 20/40 | 50% | 50% |
-| pairwise | 18/40 | 45% | 55% |
-| kgram | 13/40 | 32% | 68% |
-| hybrid+payload | 11/40 | 28% | 72% |
-| causal+payload | 9/40 | 22% | 78% |
+| strategy | found / 50 | found % | censored % | all-seed median |
+|---|---|---|---|---|
+| **random** | **50/50** | **100%** | 0% | **331** |
+| feedback+causal | 47/50 | 94% | 6% | 1755 |
+| feedback+pairwise | 38/50 | 76% | 24% | 3073 |
+| feedback+hybrid | 36/50 | 72% | 28% | 3899 |
+| feedback+kgram | 28/50 | 56% | 44% | 7385 |
 
-- **`causal` is the best bug-finder: 70% vs pairwise 45% (Fisher's exact p = 0.041).**
-  Statistically significant but **marginal** — the 95% CIs overlap (causal
-  [56, 84], pairwise [30, 60]); worth replicating on more seeds/bugs before calling
-  it robust. Its advantage is that it is **censored less often** (30% vs 55% hit the
-  cap), i.e. it finds *more* bugs — not that it finds them faster (among found runs its
-  mean time is actually higher; heavier tail).
-- **`kgram` *hurts* bug-finding (32%, below pairwise)** — finer local resolution helps
-  coverage but dilutes the exploitation that reaches this bug. The `+payload` variants
-  are worst (22–28%), the too-fine degeneracy again.
-- `tcMultipleClientsWithFailure` (20 seeds) found the bug 20/20 for *every* repr — a
-  dense, easy bug, non-discriminating (a control, not evidence).
+- **Plain `random` dominates every feedback variant on every bug.** On safety bugs it is
+  4–5× faster (feedback spends budget *exploiting* instead of sampling broadly). On the
+  liveness bug it is both the fastest (331 vs ≥1755) and the most reliable (100%).
+- **For safety bugs the timeline representation is immaterial** — all four feedback
+  reprs have *identical* medians (103/104): the bug is found in the repr-independent
+  early exploration phase, before the diversity signal diverges.
+- **Among feedback variants, only the liveness bug discriminates them**: causal (94%) >
+  pairwise (76%) > hybrid (72%) > kgram (56%). causal is **significantly** better than
+  kgram (Fisher p<0.001); its edge over pairwise (p=0.023) and hybrid (p=0.006) is
+  modest and hinges on a few seeds. **`kgram` is the weakest.** But even causal does not
+  beat `random` — the 100%-vs-94% gap is *not* significant (Fisher p=0.242).
+
+### Coverage — distinct timelines by representation (feedback, incl. larger Raft)
+
+| model / test case | pairwise | kgram | causal | hybrid |
+|---|---|---|---|---|
+| ClientServer/tcMultipleClients | 21.8 | 37.4 | **1.4** | 47.9 |
+| Paxos/testBasicPaxos3on5 | 50.0 | 56.8 | 32.7 | 89.3 |
+| TwoPhaseCommit/tcMultipleClientsNoFailure | 121.0 | 78.5 | **168.1** | 109.7 |
+| Raft/oneClientThreeServersReliable (larger) | 80.5 | 50.9 | **99.2** | 50.9 |
+
+- **Coverage ranking does not generalize.** `causal` is *worst* on the two small models
+  (ClientServer 1.4, Paxos 32.7 — the type-level happens-before is schedule-invariant
+  there) yet *best* on the two larger/more-concurrent models (TPC 168, Raft 99).
+- **The small-model winners (`kgram`/`hybrid`) do not carry to Raft** — both plateau at
+  ~51 (a representational ceiling). And causal's Raft lead is **fragile/high-variance**:
+  half the 12 seeds are stuck at the ~51 plateau, half break out (101–222).
 
 ## Takeaway
 
-**The representation demonstrably matters, but there is no universal winner, and the
-effect is workload-dependent — not a clean "coverage vs bug-finding" trade:**
+- **On these models, plain `random` is the most effective bug-finder — it beats every
+  feedback variant, regardless of timeline representation, on all four bugs.** Feedback's
+  exploitation appears to *hurt* at this scale (random's broad sampling wins). The
+  earlier "causal is the best bug-finder" conclusion was an artifact of comparing only
+  feedback variants to each other; it does not survive a `random` reference.
+- **The timeline representation only re-orders feedback *internally*.** Where it matters
+  (the hard liveness bug) **causal is the strongest feedback repr** and **kgram the
+  weakest**; for safety bugs it is immaterial. So the representation work is a genuine
+  improvement *to feedback*, not to bug-finding overall on these models.
+- **Coverage is model-dependent with no global winner**: causal excels on larger/
+  concurrent models and collapses on request/response ones; kgram/hybrid are the reverse.
+- **`--timeline-payload` (whole-payload) is too fine and degenerates** — needs
+  selective-field hashing.
 
-- **`causal` is the best bug-finder here** (70% vs pairwise 45%, Fisher p = 0.041) —
-  a *marginally* significant, replication-worthy result, and the payoff for wiring in
-  the vector clocks the runtime already computes. It also had the **highest** coverage
-  on TPC/NoFailure — yet **collapsed to ~1 timeline on ClientServer**. So causal isn't
-  simply "trades coverage for bugs"; it's excellent where the happens-before shape
-  varies across schedules and near-useless where it doesn't.
-- **`kgram`/`hybrid` improve coverage in most configs but *hurt* bug-finding** (kgram
-  32% < pairwise 45%): finer local resolution broadens exploration at the cost of the
-  exploitation that reaches a specific bug.
-- **`pairwise` (the default) is middling** — beaten by causal on bugs and by
-  kgram/hybrid on coverage in most (not all) configs.
-- **`--timeline-payload` (whole-payload hashing) is too fine and degenerates** the
-  search (worst bug-finding, constant coverage). It needs *selective-field* hashing
-  (status/ballot/term), not the raw payload with its unique ids.
+**Honest caveats (independent audit):** one discriminating liveness bug; heavy censoring
+at cap 10000 (found-rate is the primary metric; all-seed medians are the honest latency);
+low power (random-vs-causal found-rate p=0.242 — cannot claim they differ in reliability);
+tutorial + one larger (Raft) model, no production scale; the "early-phase / plateau"
+mechanisms are inferred from the data, not confirmed in code.
 
-**Honest caveats (from an independent audit of the raw CSVs):** this rests on **one
-real bug on one discriminating test case**, 40 seeds, **heavy censoring** at cap 3000
-(observed rates are lower bounds; the ranking could shift with a larger budget), and
-**tutorial-scale models only** — no production-scale evidence. The causal significance
-is marginal (overlapping CIs). Treat these as *promising, directional* results.
-
-**Recommendation.** Keep `pairwise` as the safe default (zero behavior change) and
-expose the knobs: `causal` for hunting bugs on protocol models (where its happens-before
-signal varies), `kgram`/`hybrid` for coverage/diversity, and avoid whole-payload
-`--timeline-payload` until it hashes selected fields. Any default flip should wait for
-a larger, multi-bug, multi-scale study. The harness (`fest-eval/run.py e8`, parallel)
-reproduces every number here.
+**Recommendation.** Keep `pairwise` as the safe default. The pluggable-representation
+feature is a sound, tested, flag-gated addition that improves feedback *internally*
+(`causal` best for hard liveness bugs among feedback variants; `causal`/pairwise best for
+coverage on larger models), but on these models **plain `random` remains the better
+bug-finder** — so no default flip is warranted. The genuine open question is whether
+feedback (and thus a richer representation) pays off on **production-scale** state spaces,
+where random is expected to flail; that is the study still worth running. Harness:
+`fest-eval/run.py e9` (parallel) reproduces every number here.
 

--- a/eval/fest-scenario-coverage/Timeline-representation.md
+++ b/eval/fest-scenario-coverage/Timeline-representation.md
@@ -1,0 +1,125 @@
+# Pluggable timeline representations for the feedback-guided search
+
+## Why
+
+The feedback-guided search's diversity signal is a "timeline" abstraction of each
+schedule (`TimelineObserver`). Historically that was, per receiver **instance**,
+the set of ordered pairs of event **type names** in the receiver's local dequeue
+order (`<M, e1, e2>`). For distributed systems this is the wrong shape:
+
+- **No cross-machine causality** — a purely local, per-receiver projection; it
+  never links a send to its delivery, so the happens-before partial order (the
+  meaning of a "Lamport timeline") is exactly what it misses.
+- **Saturates** — bounded by |eventTypes|² per receiver; once every ordered pair
+  has appeared, deeper interleavings stop changing the timeline.
+- **Type-only** — collapses which sender / which payload (ballot, term, txnId).
+- **Ignores work already done** — the runtime already maintains vector clocks on
+  every message; the timeline discarded them.
+
+## What
+
+A pluggable `ITimelineRepresentation` (selectable via `--timeline-repr`), with the
+historical behavior as the default:
+
+| repr | idea | cross-machine? |
+|---|---|---|
+| **pairwise** (default) | per-receiver ordered event-type pairs (historical) | no |
+| **kgram** | per-receiver contiguous k-grams of the delivery sequence (finer; `--timeline-kgram N`, default 3) | no |
+| **causal** | happens-before partial order over deliveries, abstracted to labels — from the runtime's vector clocks + per-receiver program order | **yes** |
+| **hybrid** | union of causal + kgram tokens | yes |
+
+Orthogonal knob: `--timeline-payload` enriches each event label with a stable hash
+of the payload (off by default). Each representation just produces a set of string
+tokens; `TimelineObserver` owns the shared, deterministic FNV-1a + fixed-coefficient
+MinHash and the canonical-string view, so the existing novelty-gate / diversity /
+ExploredTimelines plumbing is unchanged — only the token *content* differs.
+
+## Correctness / robustness
+
+- **Default preserved byte-for-byte.** The pairwise token uses the exact legacy
+  field layout, so its FNV-1a hash (and thus the MinHash and search) is identical
+  to before. Verified: `--timeline-repr pairwise` == default (no flag), and the
+  full Release regression stays green (756/756).
+- **Fixed a real happens-before bug.** `VectorTime.CompareTo` only iterated
+  `this.Clock.Keys`, so a machine present in the *other* clock but not *this* one
+  was never compared — a genuine `this → other` ordering could be silently
+  misreported as *concurrent*. It now ranges over the **union** of both clocks'
+  keys. (This is the first real consumer of `CompareTo`; surfaced by adversarial
+  review.)
+- **Determinism.** Everything is computed post-hoc from a finished schedule (never
+  affects scheduling / record-replay); tokens are FNV-1a hashed (never
+  `GetHashCode`); the abstract-timeline string is ordinal-sorted; and `PSet`/`PMap`
+  `ToString` were made order-deterministic so `--timeline-payload` is reproducible
+  under a fixed `--seed`.
+- **Tests.** `Tst/UnitTests/TimelineRepresentationTest.cs` (12 tests): pairwise
+  layout, kgram distinguishes cases where pairwise saturates (ABBA vs BAAB), the
+  causal happens-before/concurrency token decision, hybrid union, factory, and
+  empty schedules.
+
+## E7 — Bake-off
+
+Feedback strategy (`--sch-feedback`), all four representations, on
+ClientServer / TwoPhaseCommit / Paxos. Two questions: does a richer representation
+(a) raise distinct-timeline coverage / rare-scenario coverage, and (b) find bugs
+faster?
+
+### E7a — timelines & rare-scenario coverage (budget 1000, mean/5 seeds)
+
+| model / rare scenario | metric | pairwise | kgram | causal | hybrid |
+|---|---|---|---|---|---|
+| ClientServer / TwoSuccessfulWithdrawals | distinct timelines | 21.2 | 33.8 | **1.2** | 43.8 |
+| ClientServer / TwoSuccessfulWithdrawals | rare unique-timelines | 21.2 | 33.6 | **1.0** | 43.6 |
+| Paxos / TwoLearns | distinct timelines | 40.8 | 50.6 | 29.6 | 77.8 |
+| Paxos / TwoLearns | rare unique-timelines | 3.8 | 4.4 | 3.6 | 3.8 |
+| TwoPhaseCommit / AbortThenCommit | distinct timelines | 44.6 | 78.8 | 70.8 | 86.4 |
+| TwoPhaseCommit / AbortThenCommit | rare unique-timelines | 0.2 | 0 | 0.4 | 0 |
+
+`kgram` beats `pairwise` on distinct timelines and rare coverage everywhere;
+`hybrid` maximizes raw distinct timelines (it's the union). But `causal`
+**collapses to ~1 timeline on ClientServer**: the happens-before order over event
+*types* is schedule-invariant for request→response models (the req→resp chains
+are fixed; client interleavings just become symmetric `co` tokens), so it can't
+discriminate schedules — the "too coarse → no signal" failure mode. (`AbortThenCommit`
+is ~unreachable at this budget across all reprs, so its row is noise.)
+
+### E7b — iterations-to-first-bug (TPC MultiNoFailure, cap 3000, 10 seeds)
+
+| repr | bugs found / 10 | median schedules-to-bug (found) | min |
+|---|---|---|---|
+| pairwise | 5/10 | 236 | 77 |
+| kgram | 6/10 | 515 | 77 |
+| **causal** | **9/10** | 366 | 77 |
+| hybrid | 6/10 | 651 | 77 |
+
+`causal` is the standout: **9/10 seeds vs pairwise's 5/10.** Recall plain
+`feedback` (random base, pairwise timelines) *gets stuck* on ~half the seeds
+(exhausts the budget without finding the bug). The true happens-before signal
+gives the search enough of a diversity gradient to avoid that trap — it fixes the
+exact "feedback gets stuck" failure documented earlier. (10 seeds; a promising
+reliability gain worth confirming at larger scale.)
+
+## Takeaway
+
+**The representation matters, and there is no universal winner — each has a regime:**
+
+- **Coverage / diversity → `kgram` (or `hybrid` for maximum breadth).** Finer
+  local resolution beats pairwise on distinct timelines and rare-scenario coverage
+  across all three models, and never degenerates.
+- **Bug-finding reliability → `causal`.** The cross-machine happens-before signal
+  takes first-bug reliability from 5/10 to 9/10 — it fixes feedback's get-stuck
+  failure. This is the payoff for wiring in the vector clocks the runtime already
+  computes.
+- **`pairwise` (the old default) is dominated on both axes** — it exists now only
+  as the backward-compatible baseline.
+- **`causal` over event *types* is coarse for request→response models** (ClientServer
+  → ~1 timeline): its happens-before structure is schedule-invariant there. Pair it
+  with `--timeline-payload` (to distinguish deliveries by value), or reserve it for
+  protocol models (TPC/Paxos) where interleavings do change the causal shape.
+
+**Recommendation.** Keep `pairwise` as the safe default (zero behavior change), but
+expose the knobs: reach for `kgram`/`hybrid` when the goal is coverage/diversity and
+`causal` when hunting bugs on protocol models. A default flip to `kgram` (coverage)
+or `causal` (bug-finding) is worth evaluating at larger scale — the same caveat as
+the Cluster-B defaults. The bake-off harness (`fest-eval/run.py e7`) reproduces
+every number here.
+

--- a/eval/fest-scenario-coverage/Timeline-representation.md
+++ b/eval/fest-scenario-coverage/Timeline-representation.md
@@ -56,70 +56,94 @@ ExploredTimelines plumbing is unchanged — only the token *content* differs.
   causal happens-before/concurrency token decision, hybrid union, factory, and
   empty schedules.
 
-## E7 — Bake-off
+## Bake-off
 
-Feedback strategy (`--sch-feedback`), all four representations, on
-ClientServer / TwoPhaseCommit / Paxos. Two questions: does a richer representation
-(a) raise distinct-timeline coverage / rare-scenario coverage, and (b) find bugs
-faster?
+Feedback strategy (`--sch-feedback`), 6 representations incl. two `--timeline-payload`
+variants, on ClientServer / TwoPhaseCommit / Paxos. Numbers below are the
+**larger-scale run** (20 seeds for coverage, 40 for the discriminating bug case),
+which *corrected* a smaller 10-seed pilot — the pilot's eye-catching "causal 9/10"
+bug-finding regressed to a marginally-significant 70% once more seeds were added, a
+useful reminder to power these experiments. All claims were re-computed by an
+independent audit of the raw CSVs.
 
-### E7a — timelines & rare-scenario coverage (budget 1000, mean/5 seeds)
+### Coverage & distinct timelines (budget 1000, mean/20 seeds)
 
-| model / rare scenario | metric | pairwise | kgram | causal | hybrid |
-|---|---|---|---|---|---|
-| ClientServer / TwoSuccessfulWithdrawals | distinct timelines | 21.2 | 33.8 | **1.2** | 43.8 |
-| ClientServer / TwoSuccessfulWithdrawals | rare unique-timelines | 21.2 | 33.6 | **1.0** | 43.6 |
-| Paxos / TwoLearns | distinct timelines | 40.8 | 50.6 | 29.6 | 77.8 |
-| Paxos / TwoLearns | rare unique-timelines | 3.8 | 4.4 | 3.6 | 3.8 |
-| TwoPhaseCommit / AbortThenCommit | distinct timelines | 44.6 | 78.8 | 70.8 | 86.4 |
-| TwoPhaseCommit / AbortThenCommit | rare unique-timelines | 0.2 | 0 | 0.4 | 0 |
+| model / test case | metric | pairwise | kgram | causal | hybrid | causal+P | hybrid+P |
+|---|---|---|---|---|---|---|---|
+| ClientServer/tcMultipleClients | distinct timelines | 21.8 | 37.4 | **1.4** | 47.9 | 51 | 51 |
+| ClientServer/tcMultipleClients | rare uniq | 21.8 | 37.3 | **1.1** | 47.6 | 51 | 51 |
+| TPC/tcMultipleClientsNoFailure | distinct timelines | 121.0 | 78.5 | **168.1** | 109.7 | 51 | 51 |
+| TPC/tcMultipleClientsNoFailure | rare uniq (TwoCommits) | 119.3 | 77.6 | **165.8** | 108.2 | 50.4 | 50.4 |
+| Paxos/testBasicPaxos3on5 | distinct timelines | 50.0 | 56.8 | 32.7 | 89.3 | 51 | 51 |
+| Paxos/testBasicPaxos3on3 | distinct timelines | 41.0 | 53.5 | 60.3 | 102.3 | 51 | 51 |
 
-`kgram` beats `pairwise` on distinct timelines and rare coverage everywhere;
-`hybrid` maximizes raw distinct timelines (it's the union). But `causal`
-**collapses to ~1 timeline on ClientServer**: the happens-before order over event
-*types* is schedule-invariant for request→response models (the req→resp chains
-are fixed; client interleavings just become symmetric `co` tokens), so it can't
-discriminate schedules — the "too coarse → no signal" failure mode. (`AbortThenCommit`
-is ~unreachable at this budget across all reprs, so its row is noise.)
+- **`kgram`/`hybrid` improve coverage over `pairwise` in 4 of 5 configs** — but *not*
+  universally: on **TPC/NoFailure `pairwise` (121) beats both `kgram` (78.5) and
+  `hybrid` (110)**, where **`causal` is actually the top coverage method (168)**.
+- **`causal` collapses to ~1.4 timelines on ClientServer** — the happens-before order
+  over event *types* is schedule-invariant for request→response models, so it can't
+  discriminate (the "too coarse" failure mode). It is *not* uniformly coarse: it's the
+  best coverage method on TPC/NoFailure.
+- **The `+payload` variants degenerate to a constant 51** (100/100 rows, and
+  `causal+P` ≡ `hybrid+P` row-for-row — the base repr is entirely overridden). Payloads
+  carry unique ids (`rId`, `transId`), so whole-payload hashing makes every delivery
+  label unique → the diversity signal saturates at "always novel" — the **"too fine"**
+  failure mode. This is a *payload-encoding* problem (needs selective-field hashing),
+  not a flaw in payload-awareness per se.
 
-### E7b — iterations-to-first-bug (TPC MultiNoFailure, cap 3000, 10 seeds)
+### Iterations-to-first-bug (TPC `tcMultipleClientsNoFailure`, cap 3000, 40 seeds)
 
-| repr | bugs found / 10 | median schedules-to-bug (found) | min |
+| repr | bugs found / 40 | found % | censored (hit cap) |
 |---|---|---|---|
-| pairwise | 5/10 | 236 | 77 |
-| kgram | 6/10 | 515 | 77 |
-| **causal** | **9/10** | 366 | 77 |
-| hybrid | 6/10 | 651 | 77 |
+| **causal** | **28/40** | **70%** | 30% |
+| hybrid | 20/40 | 50% | 50% |
+| pairwise | 18/40 | 45% | 55% |
+| kgram | 13/40 | 32% | 68% |
+| hybrid+payload | 11/40 | 28% | 72% |
+| causal+payload | 9/40 | 22% | 78% |
 
-`causal` is the standout: **9/10 seeds vs pairwise's 5/10.** Recall plain
-`feedback` (random base, pairwise timelines) *gets stuck* on ~half the seeds
-(exhausts the budget without finding the bug). The true happens-before signal
-gives the search enough of a diversity gradient to avoid that trap — it fixes the
-exact "feedback gets stuck" failure documented earlier. (10 seeds; a promising
-reliability gain worth confirming at larger scale.)
+- **`causal` is the best bug-finder: 70% vs pairwise 45% (Fisher's exact p = 0.041).**
+  Statistically significant but **marginal** — the 95% CIs overlap (causal
+  [56, 84], pairwise [30, 60]); worth replicating on more seeds/bugs before calling
+  it robust. Its advantage is that it is **censored less often** (30% vs 55% hit the
+  cap), i.e. it finds *more* bugs — not that it finds them faster (among found runs its
+  mean time is actually higher; heavier tail).
+- **`kgram` *hurts* bug-finding (32%, below pairwise)** — finer local resolution helps
+  coverage but dilutes the exploitation that reaches this bug. The `+payload` variants
+  are worst (22–28%), the too-fine degeneracy again.
+- `tcMultipleClientsWithFailure` (20 seeds) found the bug 20/20 for *every* repr — a
+  dense, easy bug, non-discriminating (a control, not evidence).
 
 ## Takeaway
 
-**The representation matters, and there is no universal winner — each has a regime:**
+**The representation demonstrably matters, but there is no universal winner, and the
+effect is workload-dependent — not a clean "coverage vs bug-finding" trade:**
 
-- **Coverage / diversity → `kgram` (or `hybrid` for maximum breadth).** Finer
-  local resolution beats pairwise on distinct timelines and rare-scenario coverage
-  across all three models, and never degenerates.
-- **Bug-finding reliability → `causal`.** The cross-machine happens-before signal
-  takes first-bug reliability from 5/10 to 9/10 — it fixes feedback's get-stuck
-  failure. This is the payoff for wiring in the vector clocks the runtime already
-  computes.
-- **`pairwise` (the old default) is dominated on both axes** — it exists now only
-  as the backward-compatible baseline.
-- **`causal` over event *types* is coarse for request→response models** (ClientServer
-  → ~1 timeline): its happens-before structure is schedule-invariant there. Pair it
-  with `--timeline-payload` (to distinguish deliveries by value), or reserve it for
-  protocol models (TPC/Paxos) where interleavings do change the causal shape.
+- **`causal` is the best bug-finder here** (70% vs pairwise 45%, Fisher p = 0.041) —
+  a *marginally* significant, replication-worthy result, and the payoff for wiring in
+  the vector clocks the runtime already computes. It also had the **highest** coverage
+  on TPC/NoFailure — yet **collapsed to ~1 timeline on ClientServer**. So causal isn't
+  simply "trades coverage for bugs"; it's excellent where the happens-before shape
+  varies across schedules and near-useless where it doesn't.
+- **`kgram`/`hybrid` improve coverage in most configs but *hurt* bug-finding** (kgram
+  32% < pairwise 45%): finer local resolution broadens exploration at the cost of the
+  exploitation that reaches a specific bug.
+- **`pairwise` (the default) is middling** — beaten by causal on bugs and by
+  kgram/hybrid on coverage in most (not all) configs.
+- **`--timeline-payload` (whole-payload hashing) is too fine and degenerates** the
+  search (worst bug-finding, constant coverage). It needs *selective-field* hashing
+  (status/ballot/term), not the raw payload with its unique ids.
 
-**Recommendation.** Keep `pairwise` as the safe default (zero behavior change), but
-expose the knobs: reach for `kgram`/`hybrid` when the goal is coverage/diversity and
-`causal` when hunting bugs on protocol models. A default flip to `kgram` (coverage)
-or `causal` (bug-finding) is worth evaluating at larger scale — the same caveat as
-the Cluster-B defaults. The bake-off harness (`fest-eval/run.py e7`) reproduces
-every number here.
+**Honest caveats (from an independent audit of the raw CSVs):** this rests on **one
+real bug on one discriminating test case**, 40 seeds, **heavy censoring** at cap 3000
+(observed rates are lower bounds; the ranking could shift with a larger budget), and
+**tutorial-scale models only** — no production-scale evidence. The causal significance
+is marginal (overlapping CIs). Treat these as *promising, directional* results.
+
+**Recommendation.** Keep `pairwise` as the safe default (zero behavior change) and
+expose the knobs: `causal` for hunting bugs on protocol models (where its happens-before
+signal varies), `kgram`/`hybrid` for coverage/diversity, and avoid whole-payload
+`--timeline-payload` until it hashes selected fields. Any default flip should wait for
+a larger, multi-bug, multi-scale study. The harness (`fest-eval/run.py e8`, parallel)
+reproduces every number here.
 

--- a/eval/fest-scenario-coverage/scenarios/ClientServer/Scenarios.p
+++ b/eval/fest-scenario-coverage/scenarios/ClientServer/Scenarios.p
@@ -1,0 +1,118 @@
+/**************************************************************************
+ * Fest scenario-coverage examples for the ClientServer (Bank) model.
+ *
+ * A `scenario` is a coverage monitor: it lowers to a P spec monitor that is
+ * auto-attached to EVERY test case (no `assert` needed), is EXEMPT from the
+ * liveness check (an unsatisfied scenario is "uncovered", not a bug), and
+ * whose accepting (cold) state means "this behavior was exercised".
+ *
+ * These five span the feature's dimensions:
+ *   - common            : satisfied in almost every schedule
+ *   - payload-dependent : satisfaction gated on an event field (status enum)
+ *   - rare / ordering    : needs a specific multi-event interleaving
+ *   - impossible/partial : structurally unsatisfiable -> exercises partial
+ *                          coverage tracking + the liveness exemption
+ **************************************************************************/
+
+// ---------------------------------------------------------------------------
+// COMMON: every withdraw request is eventually followed by a response.
+// Expected: satisfied in ~all schedules (high trigger count, many timelines).
+// ---------------------------------------------------------------------------
+scenario WithdrawThenResponse observes eWithDrawReq, eWithDrawResp {
+  start hot state Init {
+    on eWithDrawReq goto SawReq;
+    on eWithDrawResp do { }          // stray response before we saw a request: ignore
+  }
+  hot state SawReq {
+    on eWithDrawResp goto Done;
+    on eWithDrawReq do { }           // another request: keep waiting for a response
+  }
+  cold state Done {
+    on eWithDrawReq do { }
+    on eWithDrawResp do { }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PAYLOAD-DEPENDENT: a withdrawal is rejected (insufficient funds).
+// The server returns WITHDRAW_ERROR when the amount would drop balance < 10.
+// Expected: rarer than the common case; needs a large-enough requested amount.
+// ---------------------------------------------------------------------------
+scenario WithdrawError observes eWithDrawResp {
+  start hot state Init {
+    on eWithDrawResp do (r: tWithDrawResp) {
+      if (r.status == WITHDRAW_ERROR) { goto Done; }
+    }
+  }
+  cold state Done {
+    on eWithDrawResp do { }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RARE / ORDERING: two SUCCESSFUL withdrawals complete in one schedule.
+// Needs a run where withdrawals are small enough to succeed at least twice.
+// This is the classic "diversity payoff" scenario for feedback search.
+// ---------------------------------------------------------------------------
+scenario TwoSuccessfulWithdrawals observes eWithDrawResp {
+  start hot state Init {
+    on eWithDrawResp do (r: tWithDrawResp) {
+      if (r.status == WITHDRAW_SUCCESS) { goto One; }
+    }
+  }
+  hot state One {
+    on eWithDrawResp do (r: tWithDrawResp) {
+      if (r.status == WITHDRAW_SUCCESS) { goto Done; }
+    }
+  }
+  cold state Done {
+    on eWithDrawResp do { }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ORDERING: a failed withdrawal, then later a successful one (recovery order).
+// Needs an ERROR response to precede a SUCCESS response in the same schedule.
+// ---------------------------------------------------------------------------
+scenario ErrorThenSuccess observes eWithDrawResp {
+  start hot state Init {
+    on eWithDrawResp do (r: tWithDrawResp) {
+      if (r.status == WITHDRAW_ERROR) { goto SawError; }
+    }
+  }
+  hot state SawError {
+    on eWithDrawResp do (r: tWithDrawResp) {
+      if (r.status == WITHDRAW_SUCCESS) { goto Done; }
+    }
+  }
+  cold state Done {
+    on eWithDrawResp do { }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IMPOSSIBLE / PARTIAL: a response observed before ANY request.
+// The protocol never produces a response without a preceding request, so the
+// very first withdraw event is always a request -> Init transitions to the
+// absorbing Dead state and the cold Done is never reached. Exercises:
+//   (a) partial-coverage tracking  -> "best partial progress: X/Y states"
+//   (b) the liveness exemption      -> a hot state at termination is NOT a bug.
+// ---------------------------------------------------------------------------
+scenario ImpossibleRespFirst observes eWithDrawReq, eWithDrawResp {
+  start hot state Init {
+    on eWithDrawResp goto GotRespFirst;   // (unreachable: resp never precedes req)
+    on eWithDrawReq goto Dead;            // a request came first -> can never satisfy
+  }
+  hot state GotRespFirst {
+    on eWithDrawResp goto Done;
+    on eWithDrawReq do { }
+  }
+  cold state Done {
+    on eWithDrawReq do { }
+    on eWithDrawResp do { }
+  }
+  hot state Dead {                         // absorbing; scenario can no longer be met
+    on eWithDrawReq do { }
+    on eWithDrawResp do { }
+  }
+}

--- a/eval/fest-scenario-coverage/scenarios/Paxos/Scenarios.p
+++ b/eval/fest-scenario-coverage/scenarios/Paxos/Scenarios.p
@@ -1,0 +1,46 @@
+/**************************************************************************
+ * Fest scenario-coverage examples for the SingleDecreePaxos model.
+ * See ClientServer/PSpec/Scenarios.p for what a `scenario` is.
+ *
+ * A proposer that wins its round teaches the decided value to the learners
+ * via eLearn(ballot, v). The value may be taught more than once (multiple
+ * proposers / acceptors), but ballots are small (= proposer_id).
+ **************************************************************************/
+
+// COMMON: a value is learned at least once.
+scenario ValueLearned observes eLearn {
+  start hot state Init {
+    on eLearn goto Done;
+  }
+  cold state Done {
+    on eLearn do { }
+  }
+}
+
+// RARE-ish: a value is taught at least twice in the same schedule
+// (e.g. two acceptors/proposers drive the learner). Diversity payoff.
+scenario TwoLearns observes eLearn {
+  start hot state Init {
+    on eLearn goto One;
+  }
+  hot state One {
+    on eLearn goto Done;
+  }
+  cold state Done {
+    on eLearn do { }
+  }
+}
+
+// PAYLOAD / IMPOSSIBLE: a value learned at an astronomically high ballot.
+// Ballots equal a proposer's small id, so this is never satisfied -> exercises
+// partial-coverage tracking (best progress 1/2) and the liveness exemption.
+scenario ImpossibleHighBallot observes eLearn {
+  start hot state Init {
+    on eLearn do (l: (ballot: tBallot, v: tValue)) {
+      if (l.ballot > 100000) { goto Done; }
+    }
+  }
+  cold state Done {
+    on eLearn do { }
+  }
+}

--- a/eval/fest-scenario-coverage/scenarios/TwoPhaseCommit/Scenarios.p
+++ b/eval/fest-scenario-coverage/scenarios/TwoPhaseCommit/Scenarios.p
@@ -1,0 +1,91 @@
+/**************************************************************************
+ * Fest scenario-coverage examples for the TwoPhaseCommit model.
+ *
+ * See ClientServer/PSpec/Scenarios.p for what a `scenario` is. These exercise
+ * failure-dependent behavior (aborts/timeouts) and cross-participant ordering.
+ *
+ * Coordinator flow: eWriteTransReq -> ePrepareReq(broadcast) -> prepare votes
+ *   -> either eCommitTrans(broadcast) + eWriteTransResp{SUCCESS}
+ *      or     eAbortTrans(broadcast)  + eWriteTransResp{ERROR|TIMEOUT}.
+ **************************************************************************/
+
+// COMMON: a write request commits successfully.
+scenario WriteCommitted observes eWriteTransReq, eWriteTransResp {
+  start hot state Init {
+    on eWriteTransReq goto SawReq;
+    on eWriteTransResp do { }
+  }
+  hot state SawReq {
+    on eWriteTransResp do (r: tWriteTransResp) { if (r.status == SUCCESS) { goto Done; } }
+    on eWriteTransReq do { }
+  }
+  cold state Done {
+    on eWriteTransReq do { }
+    on eWriteTransResp do { }
+  }
+}
+
+// FAILURE-DEPENDENT / PAYLOAD: a write is aborted (ERROR) or times out.
+// Only reachable under test cases that inject participant failures.
+scenario WriteAborted observes eWriteTransResp {
+  start hot state Init {
+    on eWriteTransResp do (r: tWriteTransResp) {
+      if (r.status == ERROR || r.status == TIMEOUT) { goto Done; }
+    }
+  }
+  cold state Done {
+    on eWriteTransResp do { }
+  }
+}
+
+// DEEP / RARE: a transaction aborts, then a later transaction commits (recovery).
+// Needs a failure followed by a successful commit in the same schedule.
+scenario AbortThenCommit observes eAbortTrans, eWriteTransResp {
+  start hot state Init {
+    on eAbortTrans goto SawAbort;
+    on eWriteTransResp do { }
+  }
+  hot state SawAbort {
+    on eWriteTransResp do (r: tWriteTransResp) { if (r.status == SUCCESS) { goto Done; } }
+    on eAbortTrans do { }
+  }
+  cold state Done {
+    on eAbortTrans do { }
+    on eWriteTransResp do { }
+  }
+}
+
+// ORDERING: two successful commits observed in one schedule.
+scenario TwoCommits observes eWriteTransResp {
+  start hot state Init {
+    on eWriteTransResp do (r: tWriteTransResp) { if (r.status == SUCCESS) { goto One; } }
+  }
+  hot state One {
+    on eWriteTransResp do (r: tWriteTransResp) { if (r.status == SUCCESS) { goto Done; } }
+  }
+  cold state Done {
+    on eWriteTransResp do { }
+  }
+}
+
+// IMPOSSIBLE / PARTIAL: a commit broadcast before ANY prepare broadcast.
+// The coordinator always prepares before committing, so the first observed
+// event is always a prepare -> Init transitions to Dead and Done is unreachable.
+scenario ImpossibleCommitFirst observes ePrepareReq, eCommitTrans {
+  start hot state Init {
+    on eCommitTrans goto CommitFirst;   // (unreachable: prepare always precedes commit)
+    on ePrepareReq goto Dead;
+  }
+  hot state CommitFirst {
+    on eCommitTrans goto Done;
+    on ePrepareReq do { }
+  }
+  cold state Done {
+    on ePrepareReq do { }
+    on eCommitTrans do { }
+  }
+  hot state Dead {
+    on ePrepareReq do { }
+    on eCommitTrans do { }
+  }
+}


### PR DESCRIPTION
## Summary

This PR brings the **Fest** (NSDI'26) design-testing capabilities to PChecker and adds
tooling + an empirical evaluation around them. It has grown into a coherent, dependent
stack; everything is **flag-gated with the historical behavior as the default**, so
`p check` with no new flags is unchanged.

Five feature areas + an evaluation:

### 1. Scenario coverage (RQ3 of the paper)
- A new top-level **`scenario Name observes {..} { ..states.. }`** construct that lowers
  to a P **spec monitor** with a coverage flag: **auto-attached to every test case** (no
  `assert` needed), its accepting (**cold**) state means "this behavior was exercised",
  and it is **exempt from the liveness check** (an unsatisfied scenario is *uncovered*,
  not a bug). Compile-time warning if a `scenario` has no cold state.
- Reporting: **full coverage** (trigger count + unique satisfying timelines) and
  **partial coverage** (best `X/Y` states for scenarios never satisfied). The report was
  redesigned for **understandability** — a summary count, covered-vs-gap grouping, and
  gaps called out explicitly.
- **`p merge-scenario-coverage [dir]`** aggregates per-run `*_scenario_coverage.json`
  artifacts into one suite-wide report, listing **which test cases** cover each scenario.

### 2. Feedback-search fidelity (Cluster B)
- Normalized diversity (`1 − Jaccard`, decoupled from the mutation budget), instance-
  granular abstract Lamport timelines (`id.Name`), and ~5-int mutation.

### 3. Coverage-novelty scenario steering (D4)
- `scenario` compliance now feeds the feedback search as a **sparse coverage-novelty
  signal** (reward first-satisfaction / new furthest state), replacing a signal that
  saturated at 1.0 and was a no-op. Computed only for kept generators (after the diversity
  gate). Also fixed `VectorTime.CompareTo` to compare the **union** of both clocks' keys.

### 4. Pluggable timeline representations (`--timeline-repr`)
- The feedback diversity signal is now selectable: **pairwise** (default, byte-compatible
  with today), **kgram** (higher-resolution local order), **causal** (cross-machine
  happens-before, reusing the runtime's already-computed vector clocks), **hybrid**.
  Plus `--timeline-payload`. `TimelineObserver` keeps the shared MinHash/gate; only the
  token content changes.

### 5. Robust per-test-case output layout
- Checker output is now grouped by test case — **`PCheckerOutput/<testCase>/<Mode>/`** —
  with history rotation scoped *per test case* (previously a single shared `<Mode>/` dir
  was rotated per invocation). This fixes test cases clobbering each other's history and a
  `Directory.Move` race between concurrent runs of different test cases; and
  `p merge-scenario-coverage` now keeps only the **latest** artifact per test case, so
  re-runs / rotated-history copies never double-count. A single anonymous run (no `-tc`)
  keeps the old layout. **Behaviour change:** default output paths now include the
  `<testCase>` segment — anything scripting `PCheckerOutput/BugFinding/…` should update.
  (PEx/symbolic `--outdir` is unchanged.)

## Evaluation (honest, independently audited)

An extensive empirical study lives in `eval/fest-scenario-coverage/` (report +
example scenarios). Headline findings, stated plainly:

- **On the tested models, plain `--sch-random` is the most effective bug-finder** — it
  beats every feedback variant (all timeline representations) on all bugs (safety 4–5×
  faster; the one liveness bug fastest + 100% found). Feedback's exploitation appears to
  *hurt* at this scale.
- The **timeline representation only re-orders feedback *internally***: on the hard
  liveness bug **`causal` is the strongest** feedback repr (significantly > `kgram`) and
  `kgram` the weakest; for safety bugs it is immaterial.
- **Coverage is model-dependent** with no global winner (`causal` worst on small
  request/response models, best on larger/concurrent ones; `kgram`/`hybrid` the reverse).
- `--timeline-payload` (whole-payload hashing) is **too fine** and degenerates — it needs
  selective-field hashing.
- **Caveats:** tutorial-scale + one larger model (Raft), one discriminating liveness bug,
  censoring, modest seed counts. Results are *directional*. The open question is whether
  feedback (and a richer representation) pays off on **production-scale** state spaces.

**Because of this, all new search behavior is opt-in and the default stays `pairwise` /
non-feedback — no default flip is proposed here.**

## Verification

- Unit tests: scenario coverage/merge/report, coverage-novelty steering, the four
  timeline representations, and the per-test-case output layout + latest-only merge
  (`Tst/UnitTests/{ScenarioCoverageTest,TimelineRepresentationTest}.cs`).
- **Full Release regression green (759/759)**; `--timeline-repr pairwise` verified
  byte-identical to the default; same-`--seed` runs reproducible; per-test-case output +
  dedupe verified end-to-end (a re-run rotates only its own folder and is merged once).
- New search paths are guarded so non-feedback strategies are unaffected; no test pinned
  the old output path.

## Notes / follow-ups
- Larger, multi-bug, **production-scale** evaluation before any default flip.
- `--timeline-payload`: selective-field hashing.
- A minor Fest-internal cleanup (dead observer, dangling strategy name) landed earlier
  in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
