### PR TITLE
Src/PeasyAI: add Gemini backend support.

### DIFF
--- a/Src/PeasyAI/.peasyai-schema.json
+++ b/Src/PeasyAI/.peasyai-schema.json
@@ -14,7 +14,7 @@
         "provider": {
           "type": "string",
           "description": "Active LLM provider",
-          "enum": ["snowflake", "anthropic", "bedrock"],
+          "enum": ["snowflake", "anthropic", "bedrock", "gemini", "google_gemini"],
           "default": "bedrock"
         },
         "model": {
@@ -43,6 +43,13 @@
                 "api_key": { "type": "string", "description": "Anthropic API key" },
                 "model": { "type": "string", "description": "Anthropic model name", "default": "claude-3-5-sonnet-20241022" },
                 "base_url": { "type": "string", "description": "Optional custom base URL" }
+              }
+            },
+            "gemini": {
+              "type": "object",
+              "properties": {
+                "api_key": { "type": "string", "description": "Gemini API key" },
+                "model": { "type": "string", "description": "Gemini model name", "default": "gemini-3.6-flash" }
               }
             },
             "bedrock": {

--- a/Src/PeasyAI/README.md
+++ b/Src/PeasyAI/README.md
@@ -165,7 +165,7 @@ All configuration lives in **`~/.peasyai/settings.json`**.
 
 | Key | Example | Description |
 |-----|---------|-------------|
-| `llm.provider` | `"gemisnowflakeni"` | Active provider: `gemini` (or `google_gemini`), `snowflake`, `anthropic`, or `bedrock` |
+| `llm.provider` | `"snowflake"` | Active provider: `gemini` (or `google_gemini`), `snowflake`, `anthropic`, or `bedrock` |
 | `llm.model` | `"claude-sonnet-4-5"` | Model name (uses provider default if omitted) |
 | `llm.timeout` | `600` | Request timeout in seconds |
 | `llm.providers.gemini.api_key` | | Google Gemini API key |

--- a/Src/PeasyAI/README.md
+++ b/Src/PeasyAI/README.md
@@ -7,7 +7,7 @@ PeasyAI exposes an MCP (Model Context Protocol) server that works with **Cursor*
 ## Features
 
 - **Design Doc → Verified P Code** — Generate types, state machines, safety specs, and test drivers from a plain-text design document
-- **Multi-Provider LLM Support** — Snowflake Cortex, AWS Bedrock, Direct Anthropic
+- **Multi-Provider LLM Support** — Google Gemini, Snowflake Cortex, AWS Bedrock, Direct Anthropic
 - **Ensemble Generation** — Best-of-N candidate selection for higher quality code
 - **Auto-Fix Pipeline** — Automatically fix compilation errors and PChecker failures
 - **Human-in-the-Loop** — Falls back to user guidance when automated fixing fails
@@ -99,6 +99,10 @@ Open it and fill in the credentials for the LLM provider you want to use:
     "model": "claude-sonnet-4-5",
     "timeout": 600,
     "providers": {
+      "gemini": {
+        "api_key": "your-gemini-api-key",
+        "model": "gemini-3.6-flash"
+      },
       "snowflake": {
         "api_key": "your-snowflake-pat-token",
         "base_url": "https://your-account.snowflakecomputing.com/api/v2/cortex/openai"
@@ -120,7 +124,7 @@ Open it and fill in the credentials for the LLM provider you want to use:
 }
 ```
 
-> **Only fill in the provider you use.** Set `"provider"` to `"snowflake"`, `"anthropic"`, or `"bedrock"`.
+> **Only fill in the provider you use.** Set `"provider"` to `"gemini"`, `"snowflake"`, `"anthropic"`, or `"bedrock"`.
 
 Verify everything is set up correctly:
 
@@ -161,9 +165,11 @@ All configuration lives in **`~/.peasyai/settings.json`**.
 
 | Key | Example | Description |
 |-----|---------|-------------|
-| `llm.provider` | `"snowflake"` | Active provider: `snowflake`, `anthropic`, or `bedrock` |
+| `llm.provider` | `"gemisnowflakeni"` | Active provider: `gemini` (or `google_gemini`), `snowflake`, `anthropic`, or `bedrock` |
 | `llm.model` | `"claude-sonnet-4-5"` | Model name (uses provider default if omitted) |
 | `llm.timeout` | `600` | Request timeout in seconds |
+| `llm.providers.gemini.api_key` | | Google Gemini API key |
+| `llm.providers.gemini.model` | `"gemini-3.6-flash"` | Specific model name overrides for Gemini |
 | `llm.providers.snowflake.api_key` | | Snowflake Programmatic Access Token |
 | `llm.providers.snowflake.base_url` | | Snowflake Cortex endpoint URL |
 | `llm.providers.anthropic.api_key` | | Anthropic API key |
@@ -177,6 +183,10 @@ All configuration lives in **`~/.peasyai/settings.json`**.
 ---
 
 ## LLM Providers
+
+### Google Gemini
+
+Set `"provider": "gemini"` and fill in `api_key`. Alternatively, you can use `"provider": "google_gemini"`. You can also configure standard environments with either the `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variables.
 
 ### Snowflake Cortex
 

--- a/Src/PeasyAI/configuration/providers.yaml
+++ b/Src/PeasyAI/configuration/providers.yaml
@@ -15,7 +15,7 @@ providers:
       - claude-3-5-haiku
     timeout: 600
     description: "Snowflake Cortex with Claude models via OpenAI-compatible API"
-    
+
   # AWS Bedrock
   bedrock:
     type: bedrock
@@ -27,7 +27,7 @@ providers:
       - anthropic.claude-3-opus-20240229-v1:0
     timeout: 1000
     description: "AWS Bedrock with Claude models"
-    
+
   # Direct Anthropic API
   anthropic_direct:
     type: anthropic
@@ -40,6 +40,19 @@ providers:
       - claude-3-opus-20240229
     timeout: 600
     description: "Direct Anthropic API"
+
+  # Google Gemini API
+  gemini:
+    type: gemini
+    api_key: "${GEMINI_API_KEY}"
+    default_model: gemini-3.6-flash
+    models:
+      - gemini-3.6-flash
+      - gemini-3.5-flash
+      - gemini-3.1-pro-preview
+      - gemini-2.5-pro
+    timeout: 600
+    description: "Google Gemini API via google-genai SDK"
 
 # Default provider selection
 # The factory will auto-detect based on available environment variables,
@@ -56,5 +69,3 @@ default_provider: auto
 fallback_providers:
   - anthropic_direct
   - bedrock
-
-

--- a/Src/PeasyAI/pyproject.toml
+++ b/Src/PeasyAI/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "mcp[cli]>=1.10.1",
     "openai>=1.0.0",
     "anthropic>=0.30.0",
+    "google-genai",
     "pydantic>=2.0",
     "python-dotenv",
     "whatthepatch",

--- a/Src/PeasyAI/requirements.txt
+++ b/Src/PeasyAI/requirements.txt
@@ -14,3 +14,4 @@ streamlit_scrollable_textbox
 anthropic>=0.30.0
 openai>=1.0.0
 python-dotenv
+google-genai

--- a/Src/PeasyAI/src/core/config.py
+++ b/Src/PeasyAI/src/core/config.py
@@ -91,6 +91,7 @@ class PeasyAISettings:
             "snowflake_cortex": "snowflake",
             "aws_bedrock": "bedrock",
             "anthropic_direct": "anthropic",
+            "google_gemini": "gemini",
         }.get(name, name)
         return self.llm.providers.get(canonical, ProviderConfig())
 
@@ -121,6 +122,13 @@ class PeasyAISettings:
                 env["ANTHROPIC_BASE_URL"] = pc.base_url
             model = self.llm.model or pc.model or "claude-3-5-sonnet-20241022"
             env["ANTHROPIC_MODEL_NAME"] = model
+
+        elif name in ("gemini", "google_gemini"):
+            if pc.api_key:
+                env["GEMINI_API_KEY"] = pc.api_key
+                env["GOOGLE_API_KEY"] = pc.api_key
+            model = self.llm.model or pc.model or "gemini-3.6-flash"
+            env["GEMINI_MODEL_NAME"] = model
 
         elif name in ("bedrock", "aws_bedrock"):
             if pc.region:
@@ -264,6 +272,10 @@ def init_settings() -> Path:
                 "anthropic": {
                     "api_key": "",
                     "model": "claude-3-5-sonnet-20241022",
+                },
+                "gemini": {
+                    "api_key": "",
+                    "model": "gemini-3.6-flash",
                 },
                 "bedrock": {
                     "region": "us-west-2",

--- a/Src/PeasyAI/src/core/llm/factory.py
+++ b/Src/PeasyAI/src/core/llm/factory.py
@@ -13,6 +13,7 @@ from .base import LLMProvider, ProviderError
 from .snowflake import SnowflakeCortexProvider
 from .bedrock import BedrockProvider
 from .anthropic_direct import AnthropicProvider
+from .gemini import GeminiProvider
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,8 @@ class LLMProviderFactory:
         "aws_bedrock": BedrockProvider,
         "anthropic": AnthropicProvider,
         "anthropic_direct": AnthropicProvider,
+        "gemini": GeminiProvider,
+        "google_gemini": GeminiProvider,
     }
     
     @classmethod
@@ -114,6 +117,7 @@ class LLMProviderFactory:
         openai_base_url = os.environ.get("OPENAI_BASE_URL", "")
         openai_api_key = os.environ.get("OPENAI_API_KEY", "")
         anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        gemini_api_key = os.environ.get("GEMINI_API_KEY", "") or os.environ.get("GOOGLE_API_KEY", "")
         
         # 1. Check for Snowflake Cortex
         if openai_base_url and "snowflake" in openai_base_url.lower():
@@ -140,7 +144,16 @@ class LLMProviderFactory:
             
             return cls.create("anthropic", config)
         
-        # 3. Default to AWS Bedrock
+        # 3. Check for Gemini
+        if gemini_api_key:
+            logger.info("Auto-detected: Gemini API")
+            return cls.create("gemini", {
+                "api_key": gemini_api_key,
+                "model": os.environ.get("GEMINI_MODEL_NAME", "gemini-3.6-flash"),
+                "timeout": float(os.environ.get("LLM_TIMEOUT", "600")),
+            })
+        
+        # 4. Default to AWS Bedrock
         logger.info("Auto-detected: AWS Bedrock (default)")
         return cls.create("bedrock", {
             "region": os.environ.get("AWS_REGION", "us-west-2"),
@@ -175,6 +188,13 @@ class LLMProviderFactory:
                 config["base_url"] = anthropic_base_url
             
             return cls.create("anthropic", config)
+        
+        elif provider_name in ("gemini", "google_gemini"):
+            return cls.create("gemini", {
+                "api_key": os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"),
+                "model": os.environ.get("GEMINI_MODEL_NAME", "gemini-3.6-flash"),
+                "timeout": float(os.environ.get("LLM_TIMEOUT", "600")),
+            })
         
         elif provider_name in ("bedrock", "aws_bedrock"):
             return cls.create("bedrock", {

--- a/Src/PeasyAI/src/core/llm/gemini.py
+++ b/Src/PeasyAI/src/core/llm/gemini.py
@@ -1,0 +1,244 @@
+"""
+Google Gemini API Provider
+
+Uses the google-genai SDK to access Gemini models.
+"""
+
+import time
+import logging
+from typing import List, Dict, Any, Optional
+
+from .base import (
+    LLMProvider,
+    LLMConfig,
+    LLMResponse,
+    Message,
+    MessageRole,
+    TokenUsage,
+    ProviderError,
+    AuthenticationError,
+    RateLimitError,
+    ModelNotFoundError,
+    TimeoutError as ProviderTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GeminiProvider(LLMProvider):
+    """
+    Google Gemini API provider using the official google-genai SDK.
+
+    Configuration:
+        api_key: Gemini API key
+        model: Default model name (e.g., 'gemini-3.6-flash')
+        timeout: Request timeout in seconds (default: 600)
+    """
+
+    AVAILABLE_MODELS = [
+        "gemini-3.6-flash",
+        "gemini-3.5-flash",
+        "gemini-3.1-pro-preview",
+        "gemini-2.5-pro",
+    ]
+
+    DEFAULT_MODEL = "gemini-3.6-flash"
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+
+        if not config.get("api_key"):
+            raise ValueError("Gemini provider requires 'api_key' in config")
+
+        self._api_key = config["api_key"]
+        self._timeout = config.get("timeout", 600.0)
+        self._default_model = config.get("model", self.DEFAULT_MODEL)
+
+        # Initialize client lazily
+        self._client = None
+
+    def _get_client(self):
+        """Get or create and configure the Gemini client"""
+        if self._client is None:
+            try:
+                from google import genai
+
+                # Initialize the Client with api_key
+                self._client = genai.Client(api_key=self._api_key)
+            except ImportError:
+                raise ProviderError(
+                    self.name,
+                    "google-genai package not installed. Run: pip install google-genai"
+                )
+        return self._client
+
+    def complete(
+        self,
+        messages: List[Message],
+        config: Optional[LLMConfig] = None,
+        system_prompt: Optional[str] = None
+    ) -> LLMResponse:
+        """Send messages to Gemini API and get completion"""
+
+        cfg = self._get_config(config)
+        model = self._get_model(config)
+        client = self._get_client()
+
+        # Build system prompt and format messages
+        # Gemini expects roles to be 'user' or 'model'.
+        # It doesn't allow 'system' inside contents list, so we map 'SYSTEM' messages to system_instruction or prepend.
+        effective_system_prompt = system_prompt or ""
+        chat_contents = []
+
+        for msg in messages:
+            if msg.role == MessageRole.SYSTEM:
+                if effective_system_prompt:
+                    effective_system_prompt += "\n\n" + msg.get_full_content()
+                else:
+                    effective_system_prompt = msg.get_full_content()
+            else:
+                role = "user" if msg.role == MessageRole.USER else "model"
+                chat_contents.append({
+                    "role": role,
+                    "parts": [msg.get_full_content()]
+                })
+
+        max_tokens = min(cfg.max_tokens, 8192)
+
+        logger.info(f"Gemini request: model={model}, messages={len(chat_contents)}")
+        start_time = time.time()
+
+        try:
+            from google.genai import types
+
+            # Configure generation parameters using GenerateContentConfig
+            generate_config = types.GenerateContentConfig(
+                temperature=cfg.temperature,
+                top_p=cfg.top_p,
+                max_output_tokens=max_tokens,
+            )
+            if effective_system_prompt:
+                generate_config.system_instruction = effective_system_prompt
+
+            # Request content generation
+            response = client.models.generate_content(
+                model=model,
+                contents=chat_contents,
+                config=generate_config
+            )
+
+            latency_ms = self._measure_latency(start_time)
+            logger.info(f"Gemini response: latency={latency_ms}ms")
+
+            # Extract content
+            content = response.text if response.text else ""
+
+            # Extract usage
+            if hasattr(response, "usage_metadata") and response.usage_metadata:
+                usage = TokenUsage(
+                    input_tokens=response.usage_metadata.prompt_token_count,
+                    output_tokens=response.usage_metadata.candidates_token_count,
+                    total_tokens=response.usage_metadata.total_token_count,
+                )
+            else:
+                usage = TokenUsage()
+
+            # Extract finish reason
+            finish_reason = "stop"
+            if response.candidates and len(response.candidates) > 0:
+                candidate = response.candidates[0]
+                if hasattr(candidate, "finish_reason"):
+                    reason = candidate.finish_reason
+                    if hasattr(reason, "name"):
+                        finish_reason = reason.name.lower()
+                    else:
+                        finish_reason = str(reason).lower()
+
+            return LLMResponse(
+                content=content,
+                usage=usage,
+                finish_reason=finish_reason,
+                latency_ms=latency_ms,
+                model=model,
+                provider=self.name,
+                raw_response=response,
+            )
+
+        except Exception as e:
+            latency_ms = self._measure_latency(start_time)
+            error_str = str(e).lower()
+
+            logger.error(f"Gemini error after {latency_ms}ms: {e}")
+
+            try:
+                from google.api_core import exceptions as google_exceptions
+                is_google_exc = True
+            except ImportError:
+                is_google_exc = False
+                google_exceptions = None
+
+            if is_google_exc and google_exceptions:
+                if isinstance(e, (google_exceptions.Unauthenticated, google_exceptions.PermissionDenied)):
+                    raise AuthenticationError(
+                        self.name,
+                        f"Authentication failed. Check your API key. Error: {e}",
+                        original_error=e
+                    )
+                elif isinstance(e, google_exceptions.ResourceExhausted):
+                    raise RateLimitError(
+                        self.name,
+                        f"Rate limit exceeded. Error: {e}",
+                        original_error=e
+                    )
+                elif isinstance(e, google_exceptions.NotFound):
+                    raise ModelNotFoundError(
+                        self.name,
+                        f"Model not found: {model}. Error: {e}",
+                        original_error=e
+                    )
+                elif isinstance(e, google_exceptions.DeadlineExceeded):
+                    raise ProviderTimeoutError(
+                        self.name,
+                        f"Request timed out after {cfg.timeout}s",
+                        original_error=e
+                    )
+
+            # Fallback string-based matching
+            if "api key" in error_str or "unauthenticated" in error_str or "403" in error_str or "permission denied" in error_str:
+                raise AuthenticationError(
+                    self.name,
+                    f"Authentication failed. Check your API key. Error: {e}",
+                    original_error=e
+                )
+            elif "quota" in error_str or "rate limit" in error_str or "429" in error_str:
+                raise RateLimitError(
+                    self.name,
+                    f"Rate limit exceeded. Error: {e}",
+                    original_error=e
+                )
+            elif "not found" in error_str or "404" in error_str:
+                raise ModelNotFoundError(
+                    self.name,
+                    f"Model not found or not accessible. Error: {e}",
+                    original_error=e
+                )
+            elif "timeout" in error_str or "deadline" in error_str:
+                raise ProviderTimeoutError(
+                    self.name,
+                    f"Request timed out after {cfg.timeout}s",
+                    original_error=e
+                )
+            else:
+                raise ProviderError(
+                    self.name,
+                    f"Request failed: {e}",
+                    original_error=e
+                )
+
+    def available_models(self) -> List[str]:
+        """List available models"""
+        return self.AVAILABLE_MODELS.copy()
+
+    @property
+    def name(self) -> str:
+        return "gemini"

--- a/Src/PeasyAI/src/core/llm/gemini.py
+++ b/Src/PeasyAI/src/core/llm/gemini.py
@@ -84,8 +84,10 @@ class GeminiProvider(LLMProvider):
         model = self._get_model(config)
         client = self._get_client()
 
+        from google.genai import types
+
         # Build system prompt and format messages
-        # Gemini expects roles to be 'user' or 'model'.
+        # Gemini expects roles to be 'user' or 'model'. 
         # It doesn't allow 'system' inside contents list, so we map 'SYSTEM' messages to system_instruction or prepend.
         effective_system_prompt = system_prompt or ""
         chat_contents = []
@@ -98,10 +100,13 @@ class GeminiProvider(LLMProvider):
                     effective_system_prompt = msg.get_full_content()
             else:
                 role = "user" if msg.role == MessageRole.USER else "model"
-                chat_contents.append({
-                    "role": role,
-                    "parts": [msg.get_full_content()]
-                })
+                part = types.Part.from_text(text=msg.get_full_content())
+                chat_contents.append(
+                    types.Content(
+                        role=role,
+                        parts=[part]
+                    )
+                )
 
         max_tokens = min(cfg.max_tokens, 8192)
 
@@ -109,7 +114,6 @@ class GeminiProvider(LLMProvider):
         start_time = time.time()
 
         try:
-            from google.genai import types
 
             # Configure generation parameters using GenerateContentConfig
             generate_config = types.GenerateContentConfig(

--- a/Src/PeasyAI/src/ui/mcp/tools/env.py
+++ b/Src/PeasyAI/src/ui/mcp/tools/env.py
@@ -70,6 +70,8 @@ def register_env_tools(mcp, with_metadata):
             provider = "openai"
         elif os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
             provider = "bedrock"
+        elif os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
+            provider = "gemini"
 
         details["llm_provider_detected"] = provider
         if not provider:

--- a/Src/PeasyAI/tests/test_config.py
+++ b/Src/PeasyAI/tests/test_config.py
@@ -132,6 +132,20 @@ class TestToEnvVars(unittest.TestCase):
         self.assertEqual(env["AWS_REGION"], "us-east-1")
         self.assertEqual(env["BEDROCK_MODEL_ID"], "anthropic.claude-3-5-sonnet-20241022-v2:0")
 
+    def test_gemini_env_vars(self):
+        s = PeasyAISettings(
+            llm=LLMConfig(
+                provider="gemini",
+                providers={"gemini": ProviderConfig(api_key="gem-key")},
+            )
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("LLM_PROVIDER", None)
+            env = s.to_env_vars()
+        self.assertEqual(env["GEMINI_API_KEY"], "gem-key")
+        self.assertEqual(env["GOOGLE_API_KEY"], "gem-key")
+        self.assertEqual(env["GEMINI_MODEL_NAME"], "gemini-3.6-flash")
+
     def test_model_precedence_llm_level_over_provider(self):
         """llm.model should take priority over providers.snowflake.model."""
         s = PeasyAISettings(

--- a/Src/PeasyAI/tests/test_gemini_provider.py
+++ b/Src/PeasyAI/tests/test_gemini_provider.py
@@ -1,0 +1,165 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SRC_ROOT = PROJECT_ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
+from core.llm.base import Message, MessageRole, LLMConfig, ProviderError, AuthenticationError
+from core.llm.gemini import GeminiProvider
+
+
+class TestGeminiProvider(unittest.TestCase):
+    def test_default_model_selection(self):
+        provider = GeminiProvider({"api_key": "test-key"})
+        self.assertEqual(provider.default_model, "gemini-3.6-flash")
+        self.assertEqual(provider.name, "gemini")
+        self.assertIn("gemini-3.6-flash", provider.available_models())
+
+    def test_explicit_config_model_overrides_default(self):
+        provider = GeminiProvider({"api_key": "test-key", "model": "gemini-3.1-pro-preview"})
+        self.assertEqual(provider.default_model, "gemini-3.1-pro-preview")
+
+    def test_missing_api_key_raises_error(self):
+        with self.assertRaises(ValueError):
+            GeminiProvider({})
+
+    @patch("google.genai.Client")
+    def test_complete_success(self, mock_client_class):
+        # Setup mock behavior
+        mock_response = MagicMock()
+        mock_response.text = "Generated P code"
+        
+        # Setup mock usage_metadata
+        mock_usage = MagicMock()
+        mock_usage.prompt_token_count = 10
+        mock_usage.candidates_token_count = 20
+        mock_usage.total_token_count = 30
+        mock_response.usage_metadata = mock_usage
+        
+        # Setup mock candidates for finish_reason
+        mock_candidate = MagicMock()
+        mock_candidate.finish_reason = MagicMock()
+        mock_candidate.finish_reason.name = "STOP"
+        mock_response.candidates = [mock_candidate]
+        
+        mock_client_instance = MagicMock()
+        mock_client_instance.models.generate_content.return_value = mock_response
+        mock_client_class.return_value = mock_client_instance
+
+        # Instantiate provider
+        provider = GeminiProvider({"api_key": "test-key"})
+        
+        messages = [
+            Message(role=MessageRole.USER, content="Hello"),
+            Message(role=MessageRole.ASSISTANT, content="Hi"),
+            Message(role=MessageRole.SYSTEM, content="This is context")
+        ]
+        
+        response = provider.complete(messages, system_prompt="System prompt")
+        
+        # Assertions
+        mock_client_class.assert_called_once_with(api_key="test-key")
+        
+        # Verify generate_content called with correct model and arguments
+        mock_client_instance.models.generate_content.assert_called_once()
+        call_kwargs = mock_client_instance.models.generate_content.call_args[1]
+        self.assertEqual(call_kwargs["model"], "gemini-3.6-flash")
+        
+        contents = call_kwargs["contents"]
+        self.assertEqual(len(contents), 2)
+        self.assertEqual(contents[0]["role"], "user")
+        self.assertEqual(contents[0]["parts"][0], "Hello")
+        self.assertEqual(contents[1]["role"], "model")
+        self.assertEqual(contents[1]["parts"][0], "Hi")
+        
+        # Verify GenerateContentConfig configuration
+        config = call_kwargs["config"]
+        self.assertEqual(config.system_instruction, "System prompt\n\nThis is context")
+        
+        # Response checks
+        self.assertEqual(response.content, "Generated P code")
+        self.assertEqual(response.usage.input_tokens, 10)
+        self.assertEqual(response.usage.output_tokens, 20)
+        self.assertEqual(response.usage.total_tokens, 30)
+        self.assertEqual(response.finish_reason, "stop")
+
+    @patch("google.genai.Client")
+    def test_complete_error_handling(self, mock_client_class):
+        from google.api_core import exceptions as google_exceptions
+        from core.llm.base import RateLimitError, ModelNotFoundError, TimeoutError as ProviderTimeoutError
+        
+        mock_client_instance = MagicMock()
+        mock_client_class.return_value = mock_client_instance
+        
+        provider = GeminiProvider({"api_key": "test-key"})
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+        
+        # Test PermissionDenied raises AuthenticationError
+        mock_client_instance.models.generate_content.side_effect = google_exceptions.PermissionDenied("Invalid key")
+        with self.assertRaises(AuthenticationError):
+            provider.complete(messages)
+
+        # Test ResourceExhausted raises RateLimitError
+        mock_client_instance.models.generate_content.side_effect = google_exceptions.ResourceExhausted("Rate limit exceeded")
+        with self.assertRaises(RateLimitError):
+            provider.complete(messages)
+
+        # Test NotFound raises ModelNotFoundError
+        mock_client_instance.models.generate_content.side_effect = google_exceptions.NotFound("Model not found")
+        with self.assertRaises(ModelNotFoundError):
+            provider.complete(messages)
+
+        # Test DeadlineExceeded raises ProviderTimeoutError
+        mock_client_instance.models.generate_content.side_effect = google_exceptions.DeadlineExceeded("Timeout")
+        with self.assertRaises(ProviderTimeoutError):
+            provider.complete(messages)
+
+    @patch("google.genai.Client")
+    def test_complete_error_handling_fallback_matching(self, mock_client_class):
+        from core.llm.base import RateLimitError, ModelNotFoundError, TimeoutError as ProviderTimeoutError, ProviderError
+        
+        mock_client_instance = MagicMock()
+        mock_client_class.return_value = mock_client_instance
+        
+        provider = GeminiProvider({"api_key": "test-key"})
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+
+        # Text: API key
+        mock_client_instance.models.generate_content.side_effect = Exception("error with api key mismatch")
+        with self.assertRaises(AuthenticationError):
+            provider.complete(messages)
+
+        # Text: quota / rate limit
+        mock_client_instance.models.generate_content.side_effect = Exception("exhausted rate limit quota")
+        with self.assertRaises(RateLimitError):
+            provider.complete(messages)
+
+        # Text: not found
+        mock_client_instance.models.generate_content.side_effect = Exception("this requested model was not found")
+        with self.assertRaises(ModelNotFoundError):
+            provider.complete(messages)
+
+        # Text: timeout / deadline
+        mock_client_instance.models.generate_content.side_effect = Exception("request timeout reached")
+        with self.assertRaises(ProviderTimeoutError):
+            provider.complete(messages)
+
+        # Generic exception
+        mock_client_instance.models.generate_content.side_effect = Exception("random failure")
+        with self.assertRaises(ProviderError):
+            provider.complete(messages)
+
+    def test_get_client_import_error(self):
+        from core.llm.base import ProviderError
+        provider = GeminiProvider({"api_key": "test-key"})
+        with patch.dict("sys.modules", {"google": None, "google.genai": None}):
+            with self.assertRaises(ProviderError) as ctx:
+                provider._get_client()
+            self.assertIn("google-genai package not installed", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Src/PeasyAI/tests/test_gemini_provider.py
+++ b/Src/PeasyAI/tests/test_gemini_provider.py
@@ -3,6 +3,64 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+# Mock class definitions that mimic real google.genai classes for reliable tests
+class MockPart:
+    def __init__(self, text=None):
+        self.text = text
+    @classmethod
+    def from_text(cls, text):
+        return cls(text=text)
+
+class MockContent:
+    def __init__(self, role=None, parts=None):
+        self.role = role
+        self.parts = parts or []
+
+class MockGenerateContentConfig:
+    def __init__(self, temperature=None, top_p=None, max_output_tokens=None, system_instruction=None):
+        self.temperature = temperature
+        self.top_p = top_p
+        self.max_output_tokens = max_output_tokens
+        self.system_instruction = system_instruction
+
+# Set up mock module structures
+mock_genai = MagicMock()
+mock_types = MagicMock()
+mock_types.Part = MockPart
+mock_types.Content = MockContent
+mock_types.GenerateContentConfig = MockGenerateContentConfig
+mock_genai.types = mock_types
+
+sys.modules["google.genai"] = mock_genai
+sys.modules["google.genai.types"] = mock_types
+
+try:
+    import google
+    google.genai = mock_genai
+except ImportError:
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+    sys.modules["google"] = mock_google
+
+# Mock google.api_core and exceptions
+class Unauthenticated(Exception): pass
+class PermissionDenied(Exception): pass
+class ResourceExhausted(Exception): pass
+class NotFound(Exception): pass
+class DeadlineExceeded(Exception): pass
+
+mock_exceptions = MagicMock()
+mock_exceptions.Unauthenticated = Unauthenticated
+mock_exceptions.PermissionDenied = PermissionDenied
+mock_exceptions.ResourceExhausted = ResourceExhausted
+mock_exceptions.NotFound = NotFound
+mock_exceptions.DeadlineExceeded = DeadlineExceeded
+
+# Set up mock google.api_core module with correct attributes
+mock_api_core = MagicMock()
+mock_api_core.exceptions = mock_exceptions
+sys.modules["google.api_core"] = mock_api_core
+sys.modules["google.api_core.exceptions"] = mock_exceptions
 PROJECT_ROOT = Path(__file__).parent.parent
 SRC_ROOT = PROJECT_ROOT / "src"
 sys.path.insert(0, str(SRC_ROOT))

--- a/Src/PeasyAI/tests/test_gemini_provider.py
+++ b/Src/PeasyAI/tests/test_gemini_provider.py
@@ -70,10 +70,10 @@ class TestGeminiProvider(unittest.TestCase):
         
         contents = call_kwargs["contents"]
         self.assertEqual(len(contents), 2)
-        self.assertEqual(contents[0]["role"], "user")
-        self.assertEqual(contents[0]["parts"][0], "Hello")
-        self.assertEqual(contents[1]["role"], "model")
-        self.assertEqual(contents[1]["parts"][0], "Hi")
+        self.assertEqual(contents[0].role, "user")
+        self.assertEqual(contents[0].parts[0].text, "Hello")
+        self.assertEqual(contents[1].role, "model")
+        self.assertEqual(contents[1].parts[0].text, "Hi")
         
         # Verify GenerateContentConfig configuration
         config = call_kwargs["config"]


### PR DESCRIPTION
This PR add supports for Gemini backend to PeasyAI MCP.

It uses `google-genai` library to communicate to the model. `gemini` and `google_gemini` objects can be used in the config to specify a model and an API key.

Relevant tests were added and `README.md` was updated.