### PR TITLE
docs: add a code example and checker findings to the landing page

### DIFF
--- a/Docs/docs/index.md
+++ b/Docs/docs/index.md
@@ -22,6 +22,67 @@ P is a state machine based programming language for formally modeling and specif
 
 ![P framework toolchain overview](toolchain.jpg){ align=center }
 
+## :material-code-braces:{ .lg } Model Your Design, Specify What Must Hold, Let the Checker Find the Bugs
+
+<div class="grid" markdown>
+
+```java title="Model the design, then say what must always be true"
+event eWithdraw: int;
+event eBalance: int;
+
+// The model: a bank that serves withdrawals
+// and charges a $1 fee on each one.
+machine Bank {
+  var balance: int;
+
+  start state Serving {
+    entry (initial: int) { balance = initial; }
+
+    on eWithdraw do (amount: int) {
+      if (amount <= balance)
+        balance = balance - amount - 1;
+      announce eBalance, balance;
+    }
+  }
+}
+
+// The specification: whatever the bank does,
+// an account balance must never go negative.
+spec NoOverdraft observes eBalance {
+  start state Checking {
+    on eBalance do (balance: int) {
+      assert balance >= 0,
+        format("overdrawn! balance = {0}", balance);
+    }
+  }
+}
+```
+
+```text title="Check it — P explores the executions you would never test by hand"
+$ p check -tc tcWithdraw -s 1000
+
+... Checker is using 'random' strategy.
+..... Schedule #1
+..... Schedule #100
+..... Schedule #300
+Checker found a bug.
+... Emitting traces:
+..... Writing ptest_0_0.txt
+..... Found 1 bug.
+..... Explored 318 schedules
+..... Found 0.31% buggy schedules.
+
+# The trace replays the exact execution:
+<RandomLog> chose '100'
+<SendLog> sent 'eWithdraw with payload (100)'
+<AnnounceLog> announced 'eBalance' payload -1
+<ErrorLog> Assertion Failed:
+  Bank.p:25:7 overdrawn! balance = -1
+```
+
+</div>
+
+
 ---
 
 ## :material-new-box:{ .lg } What's New


### PR DESCRIPTION
As a developer interested in P, the first thing I looked for was a code sample to see what the language looked like. The next thing I wanted to understand was what sort of issues it flags. The P docs have plenty of prose about both, but I didn't find an easy-to-understand example in the docs.

This PR adds a small example to the homepage so people interested in P can see what the language looks like and what the tooling does.

PR offered as an idea. Totally ok if maintainers decide to simply close it. If you all like the idea but not the example, I'm happy to swap it out for something else.

Testing the example by running it.

<img width="1440" height="1049" alt="Screenshot 2026-08-03 at 9 57 34 AM" src="https://github.com/user-attachments/assets/6ce2551b-6c86-4502-bfab-303ae6f1503a" />
